### PR TITLE
docs: add RLMS initiation context scaffold

### DIFF
--- a/feat/rlms-integration/initiation/CONTEXT.MD
+++ b/feat/rlms-integration/initiation/CONTEXT.MD
@@ -1,0 +1,281 @@
+# RLMS Hybrid Integration - Deep Context
+
+## 1. Purpose
+
+This document gives engineers full background on the RLMS integration work for Superloop.
+It is written for readers with zero prior context.
+
+Use this as the primary "what and why" reference.
+Use `PLAN.MD` and `tasks/PHASE_1.MD` for execution tracking.
+
+## 2. Current System Baseline
+
+Superloop today is a deterministic orchestration harness for software delivery:
+
+- Human-authored spec defines requirements.
+- Loop executes `planner -> implementer -> tester -> reviewer`.
+- Completion requires explicit promise + passing gates.
+
+Primary strengths of the current design:
+
+- Clear role boundaries.
+- Auditable artifacts (`events.jsonl`, `run-summary.json`, `evidence.json`).
+- Strong completion controls (tests/checklists/evidence/optional approval).
+- Resume/recovery behavior (timeouts, rate-limit handling, stuck detection).
+
+Primary limitation relevant to this feature:
+
+- Roles can struggle when understanding very large or information-dense inputs.
+- Existing prompting/context mechanisms are not designed for arbitrarily large prompt processing with symbolic recursion.
+
+## 3. Problem Statement
+
+We need a reliable way for roles to process large context without collapsing role boundaries or weakening completion governance.
+
+Constraints:
+
+- Must preserve Superloop’s current control plane and gates.
+- Must avoid introducing a fifth "all-powerful" role.
+- Must remain observable and testable.
+- Must degrade safely when RLMS fails.
+
+## 4. Why RLMS
+
+Recursive Language Models (RLMS) are an inference pattern where:
+
+- Input context is treated as external state in an environment (REPL).
+- The model writes code to inspect/decompose that state.
+- The model recursively invokes sub-calls over slices as needed.
+- Root loop carries compact metadata, not full long text history.
+
+Operational value for Superloop:
+
+- Better long-context processing for planning, implementation analysis, and review support.
+- Maintains model-agnostic orchestration while adding a scalable analysis primitive.
+- Supports structured, persistent artifacts that fit existing evidence/logging model.
+
+## 5. Design Decision: Hybrid Trigger Mode
+
+Default trigger mode is **hybrid**:
+
+- Auto-trigger when objective thresholds are exceeded.
+- Role-requested trigger for hard cases below thresholds.
+- Explicit force-on/force-off policy support.
+
+Why hybrid:
+
+- Auto-only misses tricky low-size but high-complexity tasks.
+- Manual-only depends too much on role behavior consistency.
+- Hybrid balances reliability and operator control.
+
+## 6. Scope of This Phase
+
+In scope:
+
+- `rlms` config contract (schema + static validation + runtime parsing).
+- Deterministic RLMS CLI/executor.
+- Role-time RLMS invocation in loop.
+- Prompt wiring for RLMS output context files.
+- Evidence/logging integration.
+- Tests for trigger behavior and failure fallback.
+
+Out of scope:
+
+- Native recursive model fine-tuning.
+- Async fan-out recursion and distributed execution.
+- Hard security sandboxing (containers/VM isolation) in this first pass.
+- Changing completion gate semantics by default.
+
+## 7. Architecture Overview
+
+### 7.1 Control Plane (unchanged)
+
+Superloop remains authoritative for:
+
+- Role sequencing.
+- Gate evaluation.
+- Completion decision.
+- State persistence and audit logs.
+
+### 7.2 Data Plane (new RLMS tool path)
+
+When RLMS is triggered for a role:
+
+1. Superloop computes trigger eligibility (mode + thresholds + overrides).
+2. Superloop invokes `scripts/rlms` with role/loop/task context.
+3. RLMS worker executes bounded recursive analysis.
+4. RLMS writes structured output under `.superloop/loops/<loop-id>/rlms/`.
+5. Role prompt receives RLMS artifact paths as additional context.
+6. Loop continues regardless of RLMS success/failure (unless explicitly required).
+
+## 8. Config Contract (Planned)
+
+High-level planned shape:
+
+```json
+{
+  "loops": [
+    {
+      "rlms": {
+        "enabled": true,
+        "mode": "hybrid",
+        "request_keyword": "RLMS_REQUEST",
+        "auto": {
+          "max_lines": 2500,
+          "max_estimated_tokens": 120000,
+          "max_files": 40
+        },
+        "roles": {
+          "planner": true,
+          "implementer": true,
+          "tester": true,
+          "reviewer": true
+        },
+        "limits": {
+          "max_steps": 40,
+          "max_depth": 2,
+          "timeout_seconds": 240
+        },
+        "output": {
+          "format": "json",
+          "require_citations": true
+        },
+        "policy": {
+          "force_on": false,
+          "force_off": false,
+          "fail_mode": "warn_and_continue"
+        }
+      }
+    }
+  ]
+}
+```
+
+Note: field names may be adjusted during implementation for consistency with existing schema conventions.
+
+## 9. RLMS Output Contract (Planned)
+
+Each run should produce machine-readable output with diagnostics.
+
+Minimal expected fields:
+
+- `ok` (boolean)
+- `role`, `loop_id`, `iteration`
+- `task_summary`
+- `findings` array
+- `citations` (file + line ranges where applicable)
+- `metrics` (`steps`, `depth`, `duration_ms`, `subcalls`)
+- `errors` (if any)
+
+Output location pattern:
+
+- `.superloop/loops/<loop-id>/rlms/<role>-iter-<n>.json`
+
+## 10. Failure Modes and Guardrails
+
+Expected failure classes:
+
+- Python execution/runtime errors.
+- Schema/contract output mismatch.
+- Timeout/step/depth limit exceeded.
+- Sub-call tool/rate-limit issues.
+
+Guardrails:
+
+- Hard limits on steps/depth/timeout.
+- Explicit non-zero exits for hard contract violations.
+- Standardized error payload for observability.
+- Superloop default behavior: log warning, continue role flow.
+
+## 11. Security and Safety
+
+Phase 1 stance:
+
+- Process-level controls only (timeouts, bounded recursion, restricted interface).
+- No assumption of trusted generated code.
+
+Future hardening:
+
+- Sandboxed execution environment.
+- Explicit filesystem/network restrictions.
+- Policy-based allowed operations.
+
+## 12. Observability and Audit
+
+RLMS actions should appear in existing loop observability:
+
+- Events: `rlms_start`, `rlms_end`, `rlms_failed`, `rlms_skipped`.
+- Artifact metadata in run summary/evidence.
+- Prompt references to RLMS output files for downstream role traceability.
+
+This ensures engineers can answer:
+
+- Why RLMS ran (or did not run).
+- What it produced.
+- Whether it influenced a role’s decision path.
+
+## 13. Testing Strategy
+
+Required tests in this phase:
+
+- Schema validation for `rlms` fields and boundaries.
+- Trigger-mode behavior (auto/manual/hybrid).
+- Role integration path writes artifacts.
+- Failure fallback behavior does not deadlock loop.
+- Evidence manifest includes RLMS artifacts.
+
+Target suites:
+
+- `tests/superloop.bats`
+- `tests/runner.bats`
+- Additional focused BATS file if clearer.
+
+## 14. Rollout and Operational Plan
+
+Rollout order:
+
+1. Land initiation docs + config shape.
+2. Land executor with safe defaults.
+3. Wire invocation + artifacts.
+4. Land tests.
+5. Enable in selected loops via config.
+
+Default deployment posture:
+
+- `enabled: false` unless explicitly configured in loop.
+- Hybrid defaults documented for adopters.
+
+## 15. Tradeoffs and Alternatives
+
+Alternative considered: add RLMS as a new top-level role.
+
+Rejected because:
+
+- Blurs ownership boundaries.
+- Adds completion ambiguity.
+- Duplicates existing reviewer/tester responsibilities.
+
+Chosen approach: RLMS as role-local tool.
+
+Benefits:
+
+- Preserves existing governance model.
+- Easier incremental rollout.
+- Lower integration risk.
+
+## 16. Definition of Done (Phase 1)
+
+Phase 1 is done when:
+
+- `rlms` config is schema-validated and statically checked.
+- RLMS tool executes with bounded recursion and writes structured artifacts.
+- Roles can trigger RLMS via hybrid policy.
+- RLMS artifacts are visible in prompt context and evidence outputs.
+- Tests cover core trigger + fallback behaviors.
+
+## 17. Open Questions for Phase 2+
+
+- Should RLMS output quality become a required completion gate in some loops?
+- Should we support asynchronous sub-calls for latency reduction?
+- What security boundary is acceptable for generated code execution in production?
+- Should we add per-loop cost budgets specifically for RLMS calls?

--- a/feat/rlms-integration/initiation/PLAN.MD
+++ b/feat/rlms-integration/initiation/PLAN.MD
@@ -1,0 +1,52 @@
+# Feature: RLMS Hybrid Integration
+
+## Goal
+Add an RLMS (Recursive Language Model Scaffold) execution path that roles can invoke in hybrid mode (auto-threshold + explicit request) while preserving Superloop’s existing role boundaries and completion gates.
+
+## Scope
+- Add `rlms` configuration schema and runtime parsing with per-role policy and trigger thresholds.
+- Implement a deterministic RLMS executor (`scripts/rlms`) backed by a persistent Python REPL worker with bounded recursion, timeouts, and structured outputs.
+- Integrate RLMS invocation into role execution flow and role prompts.
+- Persist RLMS outputs under loop artifacts and include them in evidence manifests.
+- Add targeted tests for trigger behavior, artifact generation, and failure fallback.
+
+## Non-Goals (this iteration)
+- No native recursive model fine-tuning.
+- No asynchronous recursive fan-out.
+- No new top-level Superloop role (RLMS remains role-local tooling).
+- No hardened container sandboxing beyond process-level limits.
+
+## Primary References
+- `schema/config.schema.json` - loop config schema and new `rlms` block.
+- `src/60-commands.sh` - run loop orchestration and role execution path.
+- `src/20-prompts.sh` - role prompt assembly and context file injection.
+- `src/10-evidence.sh` - evidence manifest generation.
+- `src/56-validate-static.sh` - static config validation.
+- `tests/*.bats` - shell-level loop and gate tests.
+- `feat/rlms-integration/initiation/CONTEXT.MD` - deep onboarding and architecture rationale.
+
+## Architecture
+RLMS integration introduces a role-local analysis pipeline:
+1. Evaluate RLMS trigger policy for current role and iteration.
+2. Execute `scripts/rlms` with loop/role/task context and configured limits.
+3. Write structured output JSON and execution metadata to `.superloop/loops/<loop-id>/rlms/`.
+4. Expose artifact paths to the active role prompt and include artifacts in evidence output.
+5. Continue the standard role pipeline even if RLMS fails (with explicit logging/status).
+
+The existing Planner/Implementer/Tester/Reviewer control loop, promise checks, and gates remain unchanged.
+
+## Decisions
+- Use **hybrid** trigger mode by default to combine objective thresholds with optional role-requested invocation.
+- Keep RLMS as a **tool** inside roles rather than a fifth role to preserve accountability boundaries.
+- Require machine-readable RLMS outputs (JSON) with optional citation fields to support evidence and future gate checks.
+- Use a persistent Python REPL per RLMS run for symbolic state + recursive sub-calls with explicit max limits.
+
+## Risks / Constraints
+- Recursive trajectories can increase runtime/cost variance.
+- Executing generated code requires strict step/depth/timeout controls.
+- RLMS failures must not derail normal loop progress unless explicitly configured.
+- Cross-platform shell/Python behavior must remain compatible with current Superloop test matrix.
+
+## Phases
+- **Phase 1**: Ship MVP RLMS hybrid integration (schema, executor, role wiring, evidence, tests).
+- **Phase 2**: Hardening pass (sandbox tightening, richer output validation, cost controls, optional gateing on RLMS quality).

--- a/feat/rlms-integration/initiation/tasks/PHASE_1.MD
+++ b/feat/rlms-integration/initiation/tasks/PHASE_1.MD
@@ -1,0 +1,41 @@
+# Phase 1 - RLMS Hybrid MVP
+
+## P1.0 Deep Context Onboarding
+1. [x] Create `feat/rlms-integration/initiation/CONTEXT.MD` with full problem statement, rationale, architecture, constraints, and rollout plan for zero-context engineers.
+2. [x] Link `CONTEXT.MD` from `feat/rlms-integration/initiation/PLAN.MD` primary references.
+
+## P1.1 Config + Validation Surface
+1. [ ] Add `rlms` configuration block to `schema/config.schema.json` with mode, thresholds, per-role toggles, limits, and output settings.
+2. [ ] Extend static validation in `src/56-validate-static.sh` for RLMS field shape/ranges and sensible defaults.
+3. [ ] Parse RLMS loop config in `src/60-commands.sh` into runtime variables.
+
+## P1.2 RLMS Executor
+1. [ ] Create `scripts/rlms` CLI entrypoint for deterministic invocation from Superloop roles.
+2. [ ] Add Python worker module in `scripts/rlms_worker.py` implementing:
+   1. [ ] Persistent REPL state with prompt/context variables.
+   2. [ ] Bounded recursive sub-call interface with `max_depth`, `max_steps`, and timeout controls.
+   3. [ ] Structured JSON output + execution metadata contract.
+3. [ ] Ensure executor exits non-zero on hard contract violations and writes diagnostic output for loop logs.
+
+## P1.3 Role Integration
+1. [ ] Add RLMS trigger evaluation helper(s) in `src/60-commands.sh` for hybrid mode:
+   1. [ ] Auto-threshold checks (line/token/file-count heuristics).
+   2. [ ] Role-requested override checks.
+2. [ ] Invoke RLMS before role execution when triggered and store artifacts under `.superloop/loops/<loop-id>/rlms/`.
+3. [ ] Append RLMS context file paths into role prompts via `src/20-prompts.sh`.
+4. [ ] Log RLMS lifecycle events into `events.jsonl` via `src/50-events.sh` helpers.
+
+## P1.4 Evidence + Reporting Integration
+1. [ ] Include RLMS artifacts in evidence manifest generation in `src/10-evidence.sh`.
+2. [ ] Add RLMS artifact metadata to run summary/timeline paths in `src/50-events.sh` as needed.
+3. [ ] Keep completion gating behavior unchanged unless RLMS is explicitly configured as required evidence.
+
+## P1.5 Tests
+1. [ ] Add BATS tests for RLMS config validation and defaulting behavior in `tests/superloop.bats` and/or `tests/runner.bats`.
+2. [ ] Add BATS tests for hybrid trigger logic (auto on threshold, manual request, force off).
+3. [ ] Add BATS tests verifying RLMS artifact emission and non-fatal fallback when RLMS fails.
+
+## P1.V Validation
+1. [ ] Run targeted BATS tests for changed areas and confirm they pass.
+2. [ ] Run `./scripts/build.sh` and verify generated `superloop.sh` matches sources.
+3. [ ] Run `./superloop.sh validate --repo .` against updated schema/config samples.


### PR DESCRIPTION
## Summary
- add deep onboarding doc at `feat/rlms-integration/initiation/CONTEXT.MD`
- add initiation `feat/rlms-integration/initiation/PLAN.MD` and `feat/rlms-integration/initiation/tasks/PHASE_1.MD` for RLMS hybrid integration
- link context doc from plan and include onboarding tasks in Phase 1

## Why
Engineers with no prior context need a complete problem/rationale/architecture handoff before implementation begins.

## Notes
This PR intentionally contains initiation/scaffolding docs only.

Refs #10
