### PR TITLE
feat: promote RLMS worker to sandboxed REPL engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,16 @@ See `schema/config.schema.json` for all options.
 
 ### RLMS Hybrid Long-Context Mode
 
-When `loops[].rlms.enabled=true`, Superloop can run a bounded recursive context analyzer before each role:
+When `loops[].rlms.enabled=true`, Superloop can run a bounded REPL-style recursive analyzer before each role:
 
 - `mode=auto`: trigger from context size thresholds.
 - `mode=requested`: trigger only when `request_keyword` appears in loop context files.
 - `mode=hybrid`: run when either auto or requested trigger is true.
 - `policy.fail_mode=warn_and_continue|fail_role`: choose whether RLMS failures are non-fatal or role-fatal.
+- Root/subcall CLI wiring: by default RLMS inherits the role's resolved runner command/args/model/thinking settings.
+- Optional env overrides:
+  - `SUPERLOOP_RLMS_ROOT_COMMAND_JSON`, `SUPERLOOP_RLMS_ROOT_ARGS_JSON`, `SUPERLOOP_RLMS_ROOT_PROMPT_MODE`
+  - `SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON`, `SUPERLOOP_RLMS_SUBCALL_ARGS_JSON`, `SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE`
 
 Artifacts are written under `.superloop/loops/<loop-id>/rlms/` and linked into prompts, evidence, events, and run summaries.
 

--- a/feat/rlms-integration/repl-engine/CONTEXT.MD
+++ b/feat/rlms-integration/repl-engine/CONTEXT.MD
@@ -1,0 +1,160 @@
+# RLMS REPL Engine - Deep Context
+
+## 1. Why this phase exists
+
+The hybrid MVP shipped RLMS trigger wiring, artifacts, and evidence integration, but the worker itself was still deterministic heuristics.
+
+This phase upgrades RLMS into the paper-style execution model:
+
+- Prompt/context stays outside model context in an external environment.
+- A root model writes Python code each step.
+- That code is executed in a constrained REPL sandbox.
+- The code can make bounded sub-LLM CLI calls over context slices.
+- Loop stops only when code sets a final value.
+
+This gives Superloop a true long-context inference scaffold instead of a static analyzer.
+
+## 2. What changed
+
+### 2.1 `scripts/rlms_worker.py`
+
+Replaced the heuristic recursive analyzer with a REPL RLMS engine:
+
+1. Loads context files as external state (`CONTEXT` map, `list_files`, `read_file`).
+2. Iteratively prompts a root CLI model to emit Python code.
+3. Parses and validates code with strict AST rules.
+4. Executes code in a restricted sandbox (safe builtins + helper API only).
+5. Supports controlled `sub_rlm(prompt, depth=...)` sub-calls.
+6. Ends when code calls `set_final(...)`.
+7. Emits structured result JSON preserving existing artifact contract (`ok`, `highlights`, `citations`, stats, errors).
+
+### 2.2 `scripts/rlms`
+
+Extended CLI surface to carry root/subcall execution wiring:
+
+- `--root-command-json`
+- `--root-args-json`
+- `--root-prompt-mode`
+- `--subcall-command-json`
+- `--subcall-args-json`
+- `--subcall-prompt-mode`
+
+Also supports env overrides:
+
+- `SUPERLOOP_RLMS_ROOT_COMMAND_JSON`
+- `SUPERLOOP_RLMS_ROOT_ARGS_JSON`
+- `SUPERLOOP_RLMS_ROOT_PROMPT_MODE`
+- `SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON`
+- `SUPERLOOP_RLMS_SUBCALL_ARGS_JSON`
+- `SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE`
+
+### 2.3 `src/60-commands.sh`
+
+When RLMS is triggered for a role, Superloop now:
+
+1. Resolves the role runner config (`command/args/fast_args/prompt_mode`).
+2. Applies role model + thinking mappings.
+3. Converts resolved command vectors to JSON arrays.
+4. Passes them to `scripts/rlms` as root/subcall commands.
+5. Keeps current policy behavior (`warn_and_continue` vs `fail_role`).
+
+Default behavior: subcall runner inherits root runner unless explicitly overridden by env.
+
+## 3. Sandbox model
+
+The sandbox deliberately limits what generated code can do.
+
+Allowed:
+
+- Safe Python expressions, loops, conditionals, simple function defs.
+- Calls to approved helpers and safe builtins.
+
+Blocked:
+
+- `import` / `from ... import ...`
+- Attribute access (`obj.attr`)
+- Class definitions, `try/except`, with-statements, async constructs
+- Dunder names
+- Calls to non-allowlisted functions
+
+This is intentionally strict for safety and predictability.
+
+## 4. Helper API exposed to generated code
+
+The root code can use:
+
+- `list_files()`
+- `read_file(path, start_line=1, end_line=None)`
+- `grep(pattern, path=None, max_matches=80, flags='')`
+- `slice_text(text, start=0, end=None)`
+- `append_highlight(text)`
+- `add_citation(path, start_line, end_line, signal='reference', snippet='')`
+- `sub_rlm(prompt, depth=1)`
+- `set_final(value)`
+
+`set_final(...)` is the completion signal for the worker.
+
+## 5. Control limits
+
+RLMS is bounded by loop config limits:
+
+- `max_steps`: max root iterations
+- `max_depth`: max declared subcall depth
+- `timeout_seconds`: hard wall-clock timeout
+
+Worker also enforces derived max subcall count (`max_steps * 2`) and emits structured limit errors.
+
+## 6. Output contract and observability
+
+Worker still writes `result.json` and `summary.md` under RLMS role output dir.
+
+Result includes:
+
+- `ok`
+- `loop_id`, `role`, `iteration`
+- `highlights`
+- `citations`
+- `stats` (`step_count`, `subcall_count`, file/token metrics)
+- `trace` (recent root/subcall activity)
+- `error`, `error_code` on failure
+
+Existing Superloop RLMS integrations (latest artifacts, evidence, events, prompt references) remain unchanged.
+
+## 7. Failure classes
+
+Common failure classes now:
+
+- `missing_root_command`
+- `invalid_config`
+- `sandbox_violation`
+- `model_invocation_failed`
+- `limit_exceeded`
+- `worker_failure`
+
+Loop behavior after failure is still controlled by `rlms.policy.fail_mode`.
+
+## 8. Test coverage added in this phase
+
+`tests/rlms.bats` now verifies:
+
+1. REPL success path with real worker and mocked root/subcall CLIs.
+2. Sandbox rejection path (root emits forbidden import).
+3. Subcall depth limit enforcement.
+
+Legacy trigger/fallback/evidence tests remain in place and still pass.
+
+## 9. Operational guidance
+
+- Start with default role-derived root/subcall commands.
+- Override root/subcall commands via env only when you need custom routing.
+- Keep `max_steps`, `max_depth`, and timeout conservative until behavior is stable for a loop.
+- Prefer `warn_and_continue` during rollout; use `fail_role` only where RLMS output is critical.
+
+## 10. Non-goals (still out of scope)
+
+- Async / parallel subcalls
+- Deep recursive sub-RLMS trees
+- Containerized sandbox isolation
+- Model fine-tuning for native recursion
+
+Those are future phases once this REPL engine is validated in production loops.

--- a/feat/rlms-integration/repl-engine/PLAN.MD
+++ b/feat/rlms-integration/repl-engine/PLAN.MD
@@ -1,0 +1,47 @@
+# Feature: RLMS REPL Engine (Paper-Style)
+
+## Goal
+Upgrade RLMS from deterministic chunk analyzer to a true REPL scaffold where a root model writes code, executes in a constrained sandbox, and makes bounded recursive sub-LLM CLI calls.
+
+## Scope
+- Replace `scripts/rlms_worker.py` with REPL loop + sandboxed Python code execution.
+- Add root/subcall CLI command plumbing through `scripts/rlms` and `src/60-commands.sh`.
+- Ensure role-derived runner commands can be reused for RLMS root and subcalls.
+- Preserve RLMS artifact/event/evidence contracts introduced in MVP.
+- Add tests for REPL success path, sandbox violation, and subcall invocation.
+
+## Non-Goals (this iteration)
+- No async subcall fan-out.
+- No model fine-tuning.
+- No deep recursion beyond configured depth/call limits.
+- No external container runtime; sandbox remains in-process with strict AST + builtins limits.
+
+## Primary References
+- `feat/rlms-integration/initiation/CONTEXT.MD`
+- `feat/rlms-integration/hybrid-mvp/PLAN.MD`
+- `scripts/rlms`
+- `scripts/rlms_worker.py`
+- `src/60-commands.sh`
+- `tests/rlms.bats`
+
+## Architecture
+1. `src/60-commands.sh` resolves RLMS root/subcall command vectors.
+2. `scripts/rlms` forwards command metadata and limits into worker.
+3. Worker root loop asks root LLM for Python code each step.
+4. Worker executes code in sandbox with helper API (`list_files`, `read_file`, `grep`, `sub_rlm`, `set_final`).
+5. `sub_rlm` invokes sub-LLM CLI calls with depth/call/time caps and structured JSON output.
+6. Worker returns `Final` + trace/citations; existing Superloop RLMS artifact plumbing remains.
+
+## Decisions
+- Keep `scripts/rlms` as stable orchestrator surface.
+- Represent root/subcall commands as JSON arrays to avoid shell injection ambiguity.
+- Enforce AST allowlist and block imports, dunder access, and unsafe builtins.
+- Keep RLMS failure policy behavior unchanged (`warn_and_continue` vs `fail_role`).
+
+## Risks / Constraints
+- CLI model outputs may be non-deterministic and format-noisy.
+- Overly strict sandbox may prevent useful generated code; overly loose sandbox is unsafe.
+- Role runner argument compatibility with REPL prompting must remain robust.
+
+## Phases
+- **Phase 1**: REPL engine implementation + command plumbing + tests.

--- a/feat/rlms-integration/repl-engine/tasks/PHASE_1.MD
+++ b/feat/rlms-integration/repl-engine/tasks/PHASE_1.MD
@@ -1,0 +1,30 @@
+# Phase 1 - RLMS REPL Engine Implementation
+
+## P1.1 Worker Engine Rewrite
+1. [x] Replace `scripts/rlms_worker.py` heuristic segmentation with REPL loop root-code execution.
+2. [x] Implement sandbox guardrails in `scripts/rlms_worker.py` (AST allowlist + blocked imports/attributes/dunder access).
+3. [x] Add bounded helper APIs in `scripts/rlms_worker.py` (`list_files`, `read_file`, `grep`, `sub_rlm`, `set_final`, citation/highlight helpers).
+4. [x] Preserve RLMS output contract fields (`ok`, highlights/citations, stats/errors) for existing pipeline compatibility.
+
+## P1.2 Command Plumbing
+1. [x] Extend `scripts/rlms` to accept root/subcall command vectors and prompt modes.
+2. [x] Support environment overrides for root/subcall command vectors in `scripts/rlms`.
+3. [x] Update `src/60-commands.sh` to resolve role-derived runner commands and pass them into `scripts/rlms`.
+4. [x] Keep RLMS failure policy semantics unchanged (`warn_and_continue` vs `fail_role`).
+
+## P1.3 Regression and New Behavior Tests
+1. [x] Keep existing trigger/fallback/evidence RLMS tests green in `tests/rlms.bats`.
+2. [x] Add REPL success-path test with mocked root/subcall CLI scripts in `tests/rlms.bats`.
+3. [x] Add sandbox violation test (forbidden import) in `tests/rlms.bats`.
+4. [x] Add subcall depth-limit enforcement test in `tests/rlms.bats`.
+
+## P1.4 Documentation and Engineer Context
+1. [x] Add deep implementation context for this phase in `feat/rlms-integration/repl-engine/CONTEXT.MD`.
+2. [x] Update README RLMS section with REPL CLI-command wiring behavior and override knobs.
+
+## P1.V Validation
+1. [x] Run `python3 -m py_compile scripts/rlms_worker.py`.
+2. [x] Run `bats tests/rlms.bats`.
+3. [x] Run `bats tests/superloop.bats`.
+4. [x] Run `./scripts/build.sh` and ensure generated `superloop.sh` is updated.
+5. [x] Run `./superloop.sh validate --repo .`.

--- a/scripts/rlms
+++ b/scripts/rlms
@@ -13,6 +13,12 @@ Usage: scripts/rlms \
   --max-steps <n> \
   --max-depth <n> \
   --timeout-seconds <n> \
+  [--root-command-json <json-array>] \
+  [--root-args-json <json-array>] \
+  [--root-prompt-mode <stdin|file>] \
+  [--subcall-command-json <json-array>] \
+  [--subcall-args-json <json-array>] \
+  [--subcall-prompt-mode <stdin|file>] \
   [--require-citations <true|false>] \
   [--format json] \
   [--metadata-file <path>]
@@ -41,6 +47,12 @@ output_dir=""
 max_steps=""
 max_depth=""
 timeout_seconds=""
+root_command_json=""
+root_args_json=""
+root_prompt_mode=""
+subcall_command_json=""
+subcall_args_json=""
+subcall_prompt_mode=""
 require_citations="true"
 format="json"
 metadata_file=""
@@ -83,6 +95,30 @@ while [[ $# -gt 0 ]]; do
       timeout_seconds="${2:-}"
       shift 2
       ;;
+    --root-command-json)
+      root_command_json="${2:-}"
+      shift 2
+      ;;
+    --root-args-json)
+      root_args_json="${2:-}"
+      shift 2
+      ;;
+    --root-prompt-mode)
+      root_prompt_mode="${2:-}"
+      shift 2
+      ;;
+    --subcall-command-json)
+      subcall_command_json="${2:-}"
+      shift 2
+      ;;
+    --subcall-args-json)
+      subcall_args_json="${2:-}"
+      shift 2
+      ;;
+    --subcall-prompt-mode)
+      subcall_prompt_mode="${2:-}"
+      shift 2
+      ;;
     --require-citations)
       require_citations="${2:-true}"
       shift 2
@@ -116,6 +152,45 @@ need_arg "--output-dir" "$output_dir"
 need_arg "--max-steps" "$max_steps"
 need_arg "--max-depth" "$max_depth"
 need_arg "--timeout-seconds" "$timeout_seconds"
+
+if [[ -z "$root_command_json" ]]; then
+  root_command_json="${SUPERLOOP_RLMS_ROOT_COMMAND_JSON:-}"
+fi
+if [[ -z "$root_args_json" ]]; then
+  root_args_json="${SUPERLOOP_RLMS_ROOT_ARGS_JSON:-}"
+fi
+if [[ -z "$root_prompt_mode" ]]; then
+  root_prompt_mode="${SUPERLOOP_RLMS_ROOT_PROMPT_MODE:-}"
+fi
+
+if [[ -z "$subcall_command_json" ]]; then
+  subcall_command_json="${SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON:-}"
+fi
+if [[ -z "$subcall_args_json" ]]; then
+  subcall_args_json="${SUPERLOOP_RLMS_SUBCALL_ARGS_JSON:-}"
+fi
+if [[ -z "$subcall_prompt_mode" ]]; then
+  subcall_prompt_mode="${SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE:-}"
+fi
+
+if [[ -z "$root_command_json" ]]; then
+  root_command_json='[]'
+fi
+if [[ -z "$root_args_json" ]]; then
+  root_args_json='[]'
+fi
+if [[ -z "$root_prompt_mode" ]]; then
+  root_prompt_mode='stdin'
+fi
+if [[ -z "$subcall_command_json" ]]; then
+  subcall_command_json="$root_command_json"
+fi
+if [[ -z "$subcall_args_json" ]]; then
+  subcall_args_json="$root_args_json"
+fi
+if [[ -z "$subcall_prompt_mode" ]]; then
+  subcall_prompt_mode="$root_prompt_mode"
+fi
 
 mkdir -p "$output_dir"
 result_json="$output_dir/result.json"
@@ -156,6 +231,12 @@ set +e
   --max-steps "$max_steps" \
   --max-depth "$max_depth" \
   --timeout-seconds "$timeout_seconds" \
+  --root-command-json "$root_command_json" \
+  --root-args-json "$root_args_json" \
+  --root-prompt-mode "$root_prompt_mode" \
+  --subcall-command-json "$subcall_command_json" \
+  --subcall-args-json "$subcall_args_json" \
+  --subcall-prompt-mode "$subcall_prompt_mode" \
   --require-citations "$require_citations" \
   --format "$format" \
   --metadata-file "$metadata_file" \

--- a/scripts/rlms_worker.py
+++ b/scripts/rlms_worker.py
@@ -1,25 +1,207 @@
 #!/usr/bin/env python3
 """
-Deterministic RLMS worker for Superloop.
+Superloop RLMS worker with sandboxed REPL execution.
 
-This worker does not call an LLM directly. It builds a recursive, bounded
-analysis tree over context files and emits structured summaries + citations.
+This worker treats the long context as external state and asks a root model
+for Python code in bounded iterations. The generated code runs in a constrained
+sandbox with helper APIs for file access, regex scanning, and controlled
+sub-LLM CLI calls.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
+import io
 import json
 import os
 import re
+import subprocess
 import sys
+import tempfile
 import time
-from dataclasses import dataclass
+from contextlib import redirect_stdout
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
-LINE_SPLIT_THRESHOLD = 400
-MAX_CITATIONS_PER_NODE = 8
+MAX_CITATIONS = 120
+MAX_HIGHLIGHTS = 80
+MAX_SNIPPET_LEN = 220
+MAX_HISTORY_ITEMS = 8
+MAX_PROMPT_FILE_LIST = 160
+MAX_SUBCALL_PROMPT_CHARS = 120_000
+
+
+class RLMSWorkerError(RuntimeError):
+    """Base class for worker failures."""
+
+
+class LimitError(RLMSWorkerError):
+    """Raised when configured limits are exceeded."""
+
+
+class SandboxViolation(RLMSWorkerError):
+    """Raised when generated code violates sandbox policy."""
+
+
+class ModelInvocationError(RLMSWorkerError):
+    """Raised when root/subcall CLI invocation fails."""
+
+
+@dataclass
+class Document:
+    path: str
+    text: str
+    lines: List[str]
+
+    @property
+    def line_count(self) -> int:
+        return len(self.lines)
+
+    @property
+    def char_count(self) -> int:
+        return len(self.text)
+
+
+@dataclass
+class CliConfig:
+    command: List[str]
+    args: List[str]
+    prompt_mode: str
+    label: str
+
+
+@dataclass
+class ExecutionState:
+    started_at_monotonic: float
+    max_steps: int
+    max_depth: int
+    timeout_seconds: int
+    max_subcalls: int
+    step_count: int = 0
+    subcall_count: int = 0
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+    def elapsed_seconds(self) -> float:
+        return time.monotonic() - self.started_at_monotonic
+
+    def check_timeout(self) -> None:
+        if self.timeout_seconds > 0 and self.elapsed_seconds() > self.timeout_seconds:
+            raise LimitError(f"timeout exceeded ({self.timeout_seconds}s)")
+
+    def tick_step(self) -> None:
+        self.step_count += 1
+        if self.max_steps > 0 and self.step_count > self.max_steps:
+            raise LimitError(f"step limit exceeded ({self.max_steps})")
+        self.check_timeout()
+
+    def next_subcall(self, depth: int) -> None:
+        if depth < 1:
+            raise LimitError("subcall depth must be >= 1")
+        if depth > self.max_depth:
+            raise LimitError(f"subcall depth exceeded ({depth} > max_depth={self.max_depth})")
+        self.subcall_count += 1
+        if self.subcall_count > self.max_subcalls:
+            raise LimitError(f"subcall limit exceeded ({self.max_subcalls})")
+        self.check_timeout()
+
+    def remaining_timeout(self) -> Optional[float]:
+        if self.timeout_seconds <= 0:
+            return None
+        remaining = self.timeout_seconds - self.elapsed_seconds()
+        if remaining <= 0:
+            raise LimitError(f"timeout exceeded ({self.timeout_seconds}s)")
+        # Give subprocess at least one second to start.
+        return max(1.0, remaining)
+
+
+SAFE_BUILTINS: Dict[str, Any] = {
+    "len": len,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "sorted": sorted,
+    "range": range,
+    "enumerate": enumerate,
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "set": set,
+    "tuple": tuple,
+    "abs": abs,
+    "any": any,
+    "all": all,
+    "print": print,
+}
+
+
+ALLOWED_AST_NODES: Tuple[type, ...] = (
+    ast.Module,
+    ast.Expr,
+    ast.Assign,
+    ast.AugAssign,
+    ast.Name,
+    ast.Load,
+    ast.Store,
+    ast.Constant,
+    ast.List,
+    ast.Tuple,
+    ast.Set,
+    ast.Dict,
+    ast.Subscript,
+    ast.Slice,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.If,
+    ast.For,
+    ast.While,
+    ast.Break,
+    ast.Continue,
+    ast.Pass,
+    ast.Call,
+    ast.keyword,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+    ast.comprehension,
+    ast.FunctionDef,
+    ast.arguments,
+    ast.arg,
+    ast.Return,
+    ast.IfExp,
+    ast.JoinedStr,
+    ast.FormattedValue,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.UAdd,
+    ast.USub,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
+)
+
 
 PATTERNS: List[Tuple[str, re.Pattern[str]]] = [
     ("class", re.compile(r"^\s*class\s+[A-Za-z_][A-Za-z0-9_]*")),
@@ -40,26 +222,6 @@ PATTERNS: List[Tuple[str, re.Pattern[str]]] = [
 ]
 
 
-class LimitError(RuntimeError):
-    pass
-
-
-@dataclass
-class AnalysisState:
-    started_at_monotonic: float
-    max_steps: int
-    timeout_seconds: int
-    step_count: int = 0
-
-    def tick(self) -> None:
-        self.step_count += 1
-        if self.max_steps > 0 and self.step_count > self.max_steps:
-            raise LimitError(f"step limit exceeded ({self.max_steps})")
-        elapsed = time.monotonic() - self.started_at_monotonic
-        if self.timeout_seconds > 0 and elapsed > self.timeout_seconds:
-            raise LimitError(f"timeout exceeded ({self.timeout_seconds}s)")
-
-
 def utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -74,10 +236,15 @@ def estimate_tokens(char_count: int) -> int:
     return (char_count + 3) // 4
 
 
-def load_metadata(metadata_file: str) -> Dict:
-    if not metadata_file:
-        return {}
-    if not os.path.exists(metadata_file):
+def compact_text(text: str, max_len: int = MAX_SNIPPET_LEN) -> str:
+    line = " ".join(str(text).strip().split())
+    if len(line) <= max_len:
+        return line
+    return line[: max_len - 3] + "..."
+
+
+def load_metadata(metadata_file: str) -> Dict[str, Any]:
+    if not metadata_file or not os.path.exists(metadata_file):
         return {}
     try:
         with open(metadata_file, "r", encoding="utf-8") as f:
@@ -89,175 +256,29 @@ def load_metadata(metadata_file: str) -> Dict:
     return {}
 
 
-def load_context_files(context_file_list: str) -> List[str]:
-    files: List[str] = []
-    seen = set()
+def load_context_files(context_file_list: str, repo: str) -> List[Document]:
+    docs: List[Document] = []
+    seen: set[str] = set()
     if not os.path.exists(context_file_list):
-        return files
+        return docs
+
     with open(context_file_list, "r", encoding="utf-8", errors="ignore") as f:
         for raw in f:
             candidate = raw.strip()
-            if not candidate:
-                continue
-            if candidate in seen:
+            if not candidate or candidate in seen:
                 continue
             seen.add(candidate)
-            if os.path.isfile(candidate):
-                files.append(candidate)
-    return files
+            if not os.path.isfile(candidate):
+                continue
 
-
-def empty_signals() -> Dict[str, int]:
-    return {name: 0 for name, _ in PATTERNS}
-
-
-def add_signals(into: Dict[str, int], extra: Dict[str, int]) -> Dict[str, int]:
-    for k, v in extra.items():
-        into[k] = int(into.get(k, 0)) + int(v)
-    return into
-
-
-def compact_line(text: str, max_len: int = 180) -> str:
-    one_line = " ".join(text.strip().split())
-    if len(one_line) <= max_len:
-        return one_line
-    return one_line[: max_len - 3] + "..."
-
-
-def analyze_leaf(path: str, lines: List[str], start_line: int) -> Dict:
-    signals = empty_signals()
-    citations: List[Dict] = []
-
-    for offset, line in enumerate(lines):
-        line_no = start_line + offset
-        for signal_name, pattern in PATTERNS:
-            if pattern.search(line):
-                signals[signal_name] += 1
-                if len(citations) < MAX_CITATIONS_PER_NODE:
-                    citations.append(
-                        {
-                            "path": path,
-                            "start_line": line_no,
-                            "end_line": line_no,
-                            "signal": signal_name,
-                            "snippet": compact_line(line),
-                        }
-                    )
-
-    char_count = sum(len(l) + 1 for l in lines)
-    highlights: List[str] = []
-    if signals["class"] > 0:
-        highlights.append(f"{signals['class']} class declaration(s)")
-    if signals["python_def"] > 0 or signals["function"] > 0:
-        highlights.append(
-            f"{signals['python_def'] + signals['function']} named function definition(s)"
-        )
-    if signals["todo"] > 0:
-        highlights.append(f"{signals['todo']} TODO/FIXME marker(s)")
-    if signals["error"] > 0:
-        highlights.append(f"{signals['error']} error/failure marker(s)")
-    if not highlights:
-        highlights.append("No high-signal structural markers in this segment")
-
-    return {
-        "path": path,
-        "start_line": start_line,
-        "end_line": start_line + max(len(lines) - 1, 0),
-        "line_count": len(lines),
-        "char_count": char_count,
-        "signals": signals,
-        "highlights": highlights,
-        "citations": citations,
-        "children": [],
-    }
-
-
-def analyze_segment(
-    path: str,
-    lines: List[str],
-    start_line: int,
-    depth: int,
-    max_depth: int,
-    state: AnalysisState,
-) -> Dict:
-    state.tick()
-    if depth >= max_depth or len(lines) <= LINE_SPLIT_THRESHOLD:
-        return analyze_leaf(path, lines, start_line)
-
-    mid = len(lines) // 2
-    left = analyze_segment(path, lines[:mid], start_line, depth + 1, max_depth, state)
-    right = analyze_segment(
-        path, lines[mid:], start_line + mid, depth + 1, max_depth, state
-    )
-
-    signals = empty_signals()
-    add_signals(signals, left.get("signals", {}))
-    add_signals(signals, right.get("signals", {}))
-    citations = (left.get("citations", []) + right.get("citations", []))[
-        : MAX_CITATIONS_PER_NODE * 2
-    ]
-
-    highlights: List[str] = []
-    if signals["class"] > 0:
-        highlights.append(f"{signals['class']} class declaration(s) in subtree")
-    if signals["python_def"] + signals["function"] > 0:
-        highlights.append(
-            f"{signals['python_def'] + signals['function']} named function definition(s) in subtree"
-        )
-    if signals["test"] > 0:
-        highlights.append(f"{signals['test']} test marker(s) in subtree")
-    if not highlights:
-        highlights.append("Subtree split for breadth; no dominant marker")
-
-    return {
-        "path": path,
-        "start_line": start_line,
-        "end_line": start_line + max(len(lines) - 1, 0),
-        "line_count": len(lines),
-        "char_count": left.get("char_count", 0) + right.get("char_count", 0),
-        "signals": signals,
-        "highlights": highlights,
-        "citations": citations,
-        "children": [left, right],
-    }
-
-
-def collect_file_summary(tree: Dict) -> Dict:
-    return {
-        "path": tree.get("path"),
-        "line_count": int(tree.get("line_count", 0)),
-        "char_count": int(tree.get("char_count", 0)),
-        "signals": tree.get("signals", {}),
-        "highlights": tree.get("highlights", []),
-        "citations": tree.get("citations", [])[:12],
-    }
-
-
-def flatten_citations(file_summaries: List[Dict], max_items: int = 60) -> List[Dict]:
-    out: List[Dict] = []
-    for fs in file_summaries:
-        for c in fs.get("citations", []):
-            out.append(c)
-            if len(out) >= max_items:
-                return out
-    return out
-
-
-def build_global_highlights(signals: Dict[str, int], file_count: int) -> List[str]:
-    highlights: List[str] = [f"Processed {file_count} file(s) with recursive segmentation"]
-    if signals.get("class", 0) > 0:
-        highlights.append(f"Detected {signals['class']} class declaration(s)")
-    if signals.get("python_def", 0) + signals.get("function", 0) > 0:
-        highlights.append(
-            f"Detected {signals.get('python_def', 0) + signals.get('function', 0)} named function definition(s)"
-        )
-    if signals.get("test", 0) > 0:
-        highlights.append(f"Detected {signals['test']} test marker(s)")
-    if signals.get("todo", 0) > 0:
-        highlights.append(f"Detected {signals['todo']} TODO/FIXME marker(s)")
-    if signals.get("error", 0) > 0:
-        highlights.append(f"Detected {signals['error']} error/failure marker(s)")
-    return highlights
+            rel = to_rel(candidate, repo)
+            try:
+                with open(candidate, "r", encoding="utf-8", errors="ignore") as cf:
+                    text = cf.read()
+            except Exception:
+                text = ""
+            docs.append(Document(path=rel, text=text, lines=text.splitlines()))
+    return docs
 
 
 def to_rel(path: str, repo: str) -> str:
@@ -270,21 +291,603 @@ def to_rel(path: str, repo: str) -> str:
     return path
 
 
+def parse_json_string_array(name: str, raw: str) -> List[str]:
+    if raw is None or raw == "":
+        return []
+    try:
+        value = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise RLMSWorkerError(f"{name} must be valid JSON array: {exc}")
+    if not isinstance(value, list):
+        raise RLMSWorkerError(f"{name} must be a JSON array")
+    out: List[str] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, str):
+            raise RLMSWorkerError(f"{name}[{idx}] must be a string")
+        out.append(item)
+    return out
+
+
+def parse_prompt_mode(raw: str, default: str = "stdin") -> str:
+    mode = (raw or default or "stdin").strip().lower()
+    if mode not in {"stdin", "file"}:
+        return default
+    return mode
+
+
+def expand_placeholders(arg: str, repo: str, prompt_file: str, last_message_file: str) -> str:
+    out = arg.replace("{repo}", repo)
+    out = out.replace("{prompt_file}", prompt_file)
+    out = out.replace("{last_message_file}", last_message_file)
+    return out
+
+
+def invoke_cli(
+    cli: CliConfig,
+    prompt: str,
+    repo: str,
+    timeout_seconds: Optional[float],
+) -> Dict[str, Any]:
+    if not cli.command:
+        raise ModelInvocationError(f"{cli.label}: command is empty")
+
+    start = time.monotonic()
+    prompt_path = ""
+    last_message_path = ""
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as prompt_file:
+            prompt_file.write(prompt)
+            prompt_path = prompt_file.name
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as msg_file:
+            last_message_path = msg_file.name
+
+        expanded: List[str] = []
+        for part in cli.command:
+            expanded.append(expand_placeholders(part, repo, prompt_path, last_message_path))
+        for part in cli.args:
+            expanded.append(expand_placeholders(part, repo, prompt_path, last_message_path))
+
+        run_kwargs: Dict[str, Any] = {
+            "cwd": repo,
+            "text": True,
+            "capture_output": True,
+            "timeout": timeout_seconds,
+        }
+        if cli.prompt_mode == "stdin":
+            run_kwargs["input"] = prompt
+
+        proc = subprocess.run(expanded, **run_kwargs)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": int(proc.returncode),
+            "stdout": proc.stdout or "",
+            "stderr": proc.stderr or "",
+            "duration_ms": duration_ms,
+            "command": expanded,
+        }
+    except subprocess.TimeoutExpired as exc:
+        raise ModelInvocationError(
+            f"{cli.label}: command timed out after {int(timeout_seconds or 0)}s"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise ModelInvocationError(f"{cli.label}: command not found: {cli.command[0]}") from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ModelInvocationError(f"{cli.label}: command failed: {exc}") from exc
+    finally:
+        try:
+            os.unlink(prompt_path)
+        except Exception:
+            pass
+        try:
+            os.unlink(last_message_path)
+        except Exception:
+            pass
+
+
+def extract_python_code(text: str) -> str:
+    raw = text.strip()
+    if not raw:
+        raise RLMSWorkerError("root model returned empty response")
+
+    fenced = re.findall(r"```(?:python)?\s*(.*?)```", raw, flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        # Favor the longest fenced block.
+        block = sorted(fenced, key=len, reverse=True)[0].strip()
+        if block:
+            return block
+    return raw
+
+
+def normalize_signal(value: Any) -> str:
+    text = compact_text(str(value or "reference"), 48)
+    if not text:
+        return "reference"
+    return text
+
+
+def normalize_citation(raw: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+    path = str(raw.get("path") or "").strip()
+    if not path:
+        return None
+
+    start = raw.get("start_line", raw.get("line", 1))
+    end = raw.get("end_line", start)
+    try:
+        start_i = max(1, int(start))
+        end_i = max(start_i, int(end))
+    except Exception:
+        start_i = 1
+        end_i = 1
+
+    snippet = compact_text(str(raw.get("snippet") or ""), MAX_SNIPPET_LEN)
+    signal = normalize_signal(raw.get("signal"))
+
+    return {
+        "path": path,
+        "start_line": start_i,
+        "end_line": end_i,
+        "signal": signal,
+        "snippet": snippet,
+    }
+
+
+def dedupe_citations(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen: set[Tuple[str, int, int, str, str]] = set()
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        key = (
+            item.get("path", ""),
+            int(item.get("start_line", 1)),
+            int(item.get("end_line", 1)),
+            item.get("signal", "reference"),
+            item.get("snippet", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+        if len(out) >= MAX_CITATIONS:
+            break
+    return out
+
+
+def collect_structural_signals(docs: Sequence[Document]) -> Tuple[Dict[str, int], List[Dict[str, Any]]]:
+    totals = {name: 0 for name, _ in PATTERNS}
+    citations: List[Dict[str, Any]] = []
+
+    for doc in docs:
+        for idx, line in enumerate(doc.lines, start=1):
+            for signal, pattern in PATTERNS:
+                if pattern.search(line):
+                    totals[signal] += 1
+                    if len(citations) < MAX_CITATIONS:
+                        citations.append(
+                            {
+                                "path": doc.path,
+                                "start_line": idx,
+                                "end_line": idx,
+                                "signal": signal,
+                                "snippet": compact_text(line),
+                            }
+                        )
+    return totals, citations
+
+
+def build_file_summaries(docs: Sequence[Document]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for doc in docs:
+        out.append(
+            {
+                "path": doc.path,
+                "line_count": doc.line_count,
+                "char_count": doc.char_count,
+            }
+        )
+    return out
+
+
+def summarize_history(history: Sequence[Dict[str, Any]]) -> str:
+    if not history:
+        return "(none)"
+    rows: List[str] = []
+    for item in history[-MAX_HISTORY_ITEMS:]:
+        rows.append(
+            f"step={item.get('step')} rc={item.get('returncode')} code={compact_text(item.get('code_preview', ''), 120)} stdout={compact_text(item.get('stdout_preview', ''), 120)}"
+        )
+    return "\n".join(rows)
+
+
+def build_root_prompt(
+    *,
+    role: str,
+    loop_id: str,
+    iteration: int,
+    docs: Sequence[Document],
+    metadata: Dict[str, Any],
+    state: ExecutionState,
+) -> str:
+    files = docs[:MAX_PROMPT_FILE_LIST]
+    file_lines = "\n".join(
+        f"- {doc.path} ({doc.line_count} lines, {estimate_tokens(doc.char_count)} est tokens)"
+        for doc in files
+    )
+    if len(docs) > MAX_PROMPT_FILE_LIST:
+        file_lines += f"\n- ... ({len(docs) - MAX_PROMPT_FILE_LIST} more files omitted)"
+
+    metadata_line = json.dumps(metadata or {}, ensure_ascii=True)
+
+    return (
+        "You are the root model in a recursive language model scaffold.\n"
+        "Output only Python code. No prose.\n"
+        "\n"
+        f"Loop: {loop_id}\n"
+        f"Role: {role}\n"
+        f"Iteration: {iteration}\n"
+        f"Step: {state.step_count}/{state.max_steps}\n"
+        f"Elapsed seconds: {state.elapsed_seconds():.2f}\n"
+        f"Subcalls used: {state.subcall_count}/{state.max_subcalls}\n"
+        f"Max subcall depth: {state.max_depth}\n"
+        "\n"
+        "Context is external; use helper functions to inspect it.\n"
+        "Available helpers:\n"
+        "- list_files() -> list[str]\n"
+        "- read_file(path, start_line=1, end_line=None) -> str\n"
+        "- grep(pattern, path=None, max_matches=80, flags='') -> list[{path,start_line,end_line,signal,snippet}]\n"
+        "- slice_text(text, start=0, end=None) -> str\n"
+        "- append_highlight(text)\n"
+        "- add_citation(path, start_line, end_line, signal='reference', snippet='')\n"
+        "- sub_rlm(prompt, depth=1) -> str\n"
+        "- set_final(value)  # call this when done\n"
+        "\n"
+        "Rules:\n"
+        "- Do not use import statements.\n"
+        "- Do not access files or network directly.\n"
+        "- Keep the code compact and deterministic.\n"
+        "- If finished, call set_final({...}) with highlights and citations.\n"
+        "\n"
+        "Current metadata JSON:\n"
+        f"{metadata_line}\n"
+        "\n"
+        "Context file index:\n"
+        f"{file_lines if file_lines else '(no files)'}\n"
+        "\n"
+        "Recent execution history:\n"
+        f"{summarize_history(state.history)}\n"
+    )
+
+
+class SandboxEnvironment:
+    def __init__(
+        self,
+        *,
+        docs: Sequence[Document],
+        state: ExecutionState,
+        subcall_cli: CliConfig,
+        repo: str,
+    ) -> None:
+        self.docs_by_path: Dict[str, Document] = {doc.path: doc for doc in docs}
+        self.state = state
+        self.subcall_cli = subcall_cli
+        self.repo = repo
+
+        self.highlights: List[str] = []
+        self.citations: List[Dict[str, Any]] = []
+        self.final_value: Any = None
+
+        self._bindings: Dict[str, Any] = {
+            "CONTEXT": {doc.path: doc.text for doc in docs},
+            "list_files": self.list_files,
+            "read_file": self.read_file,
+            "grep": self.grep,
+            "slice_text": self.slice_text,
+            "append_highlight": self.append_highlight,
+            "add_citation": self.add_citation,
+            "sub_rlm": self.sub_rlm,
+            "set_final": self.set_final,
+        }
+        self.locals: Dict[str, Any] = dict(self._bindings)
+
+    def _refresh_bindings(self) -> None:
+        for name, value in self._bindings.items():
+            self.locals[name] = value
+
+    def list_files(self) -> List[str]:
+        self.state.check_timeout()
+        return sorted(self.docs_by_path.keys())
+
+    def read_file(self, path: str, start_line: int = 1, end_line: Optional[int] = None) -> str:
+        self.state.check_timeout()
+        key = str(path)
+        doc = self.docs_by_path.get(key)
+        if doc is None:
+            raise SandboxViolation(f"unknown path in read_file: {key}")
+
+        try:
+            start = max(1, int(start_line))
+        except Exception:
+            start = 1
+        if end_line is None:
+            end = doc.line_count
+        else:
+            try:
+                end = max(start, int(end_line))
+            except Exception:
+                end = doc.line_count
+        if start > doc.line_count:
+            return ""
+        return "\n".join(doc.lines[start - 1 : end])
+
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        max_matches: int = 80,
+        flags: str = "",
+    ) -> List[Dict[str, Any]]:
+        self.state.check_timeout()
+
+        try:
+            limit = max(1, int(max_matches))
+        except Exception:
+            limit = 80
+        limit = min(limit, 500)
+
+        flag_value = 0
+        if "i" in str(flags):
+            flag_value |= re.IGNORECASE
+        if "m" in str(flags):
+            flag_value |= re.MULTILINE
+
+        try:
+            regex = re.compile(str(pattern), flag_value)
+        except re.error as exc:
+            raise SandboxViolation(f"invalid regex: {exc}") from exc
+
+        if path is None:
+            targets = sorted(self.docs_by_path.items(), key=lambda kv: kv[0])
+        else:
+            doc = self.docs_by_path.get(str(path))
+            if doc is None:
+                raise SandboxViolation(f"unknown path in grep: {path}")
+            targets = [(doc.path, doc)]
+
+        out: List[Dict[str, Any]] = []
+        for rel_path, doc in targets:
+            for line_no, line in enumerate(doc.lines, start=1):
+                if regex.search(line):
+                    out.append(
+                        {
+                            "path": rel_path,
+                            "start_line": line_no,
+                            "end_line": line_no,
+                            "signal": "regex_match",
+                            "snippet": compact_text(line),
+                        }
+                    )
+                    if len(out) >= limit:
+                        return out
+        return out
+
+    def slice_text(self, text: Any, start: int = 0, end: Optional[int] = None) -> str:
+        self.state.check_timeout()
+        src = str(text)
+        try:
+            s = int(start)
+        except Exception:
+            s = 0
+        if end is None:
+            return src[s:]
+        try:
+            e = int(end)
+        except Exception:
+            return src[s:]
+        return src[s:e]
+
+    def append_highlight(self, text: Any) -> None:
+        value = compact_text(str(text), 240)
+        if not value:
+            return
+        if value not in self.highlights:
+            self.highlights.append(value)
+        if len(self.highlights) > MAX_HIGHLIGHTS:
+            self.highlights = self.highlights[:MAX_HIGHLIGHTS]
+
+    def add_citation(
+        self,
+        path: Any,
+        start_line: Any,
+        end_line: Any,
+        signal: Any = "reference",
+        snippet: Any = "",
+    ) -> None:
+        citation = normalize_citation(
+            {
+                "path": str(path),
+                "start_line": start_line,
+                "end_line": end_line,
+                "signal": signal,
+                "snippet": snippet,
+            }
+        )
+        if citation is None:
+            return
+
+        if citation["path"] not in self.docs_by_path:
+            raise SandboxViolation(f"citation path not in context: {citation['path']}")
+
+        self.citations.append(citation)
+        if len(self.citations) > MAX_CITATIONS:
+            self.citations = self.citations[:MAX_CITATIONS]
+
+    def set_final(self, value: Any) -> None:
+        self.final_value = value
+
+    def sub_rlm(self, prompt: Any, depth: int = 1) -> str:
+        prompt_text = str(prompt)
+        if len(prompt_text) > MAX_SUBCALL_PROMPT_CHARS:
+            prompt_text = prompt_text[:MAX_SUBCALL_PROMPT_CHARS]
+
+        self.state.next_subcall(depth)
+        timeout = self.state.remaining_timeout()
+        response = invoke_cli(self.subcall_cli, prompt_text, self.repo, timeout)
+
+        preview = compact_text(response.get("stdout", ""), 180)
+        self.state.history.append(
+            {
+                "step": self.state.step_count,
+                "type": "subcall",
+                "returncode": response.get("returncode", -1),
+                "duration_ms": response.get("duration_ms", 0),
+                "stdout_preview": preview,
+            }
+        )
+        if len(self.state.history) > 200:
+            self.state.history = self.state.history[-200:]
+
+        if not response.get("ok"):
+            stderr = compact_text(response.get("stderr", ""), 220)
+            raise ModelInvocationError(
+                f"subcall command failed (rc={response.get('returncode')}): {stderr or 'no stderr'}"
+            )
+        return response.get("stdout", "").strip()
+
+    def _validate_ast(self, code: str) -> ast.Module:
+        try:
+            tree = ast.parse(code, mode="exec")
+        except SyntaxError as exc:
+            raise SandboxViolation(f"syntax error: {exc}") from exc
+
+        defined_functions = {
+            node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+        }
+        allowed_callables = set(SAFE_BUILTINS.keys()) | set(self._bindings.keys()) | defined_functions
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                raise SandboxViolation("attribute access is not allowed")
+            if isinstance(node, (ast.Import, ast.ImportFrom, ast.With, ast.AsyncWith, ast.ClassDef, ast.Lambda, ast.Global, ast.Nonlocal, ast.Delete, ast.Try, ast.Raise, ast.Assert, ast.AsyncFunctionDef, ast.Await, ast.Yield, ast.YieldFrom, ast.Match)):
+                raise SandboxViolation(f"node type not allowed: {type(node).__name__}")
+            if not isinstance(node, ALLOWED_AST_NODES):
+                raise SandboxViolation(f"node type not allowed: {type(node).__name__}")
+            if isinstance(node, ast.Name) and node.id.startswith("__"):
+                raise SandboxViolation("dunder names are not allowed")
+            if isinstance(node, ast.Call):
+                if not isinstance(node.func, ast.Name):
+                    raise SandboxViolation("only direct function calls are allowed")
+                if node.func.id not in allowed_callables:
+                    raise SandboxViolation(f"call target not allowed: {node.func.id}")
+            if isinstance(node, ast.keyword) and node.arg and node.arg.startswith("__"):
+                raise SandboxViolation("dunder keyword args are not allowed")
+
+        return tree
+
+    def execute(self, code: str) -> Dict[str, Any]:
+        tree = self._validate_ast(code)
+        self._refresh_bindings()
+
+        stdout_buffer = io.StringIO()
+        with redirect_stdout(stdout_buffer):
+            exec(compile(tree, "<rlms-root>", "exec"), {"__builtins__": SAFE_BUILTINS}, self.locals)
+
+        stdout_text = stdout_buffer.getvalue()
+        return {
+            "stdout": stdout_text,
+            "stdout_preview": compact_text(stdout_text, 220),
+            "code_preview": compact_text(code, 220),
+        }
+
+
+def merge_highlights(final_value: Any, sandbox_highlights: Sequence[str], fallback_signals: Dict[str, int], file_count: int) -> List[str]:
+    out: List[str] = []
+
+    if isinstance(final_value, dict):
+        raw = final_value.get("highlights", [])
+        if isinstance(raw, list):
+            for item in raw:
+                value = compact_text(str(item), 240)
+                if value and value not in out:
+                    out.append(value)
+
+    for item in sandbox_highlights:
+        if item and item not in out:
+            out.append(item)
+
+    if not out:
+        out.append(f"Processed {file_count} file(s) via REPL RLMS")
+        if fallback_signals.get("class", 0) > 0:
+            out.append(f"Detected {fallback_signals['class']} class declaration(s)")
+        if fallback_signals.get("python_def", 0) + fallback_signals.get("function", 0) > 0:
+            out.append(
+                f"Detected {fallback_signals.get('python_def', 0) + fallback_signals.get('function', 0)} named function definition(s)"
+            )
+
+    return out[:MAX_HIGHLIGHTS]
+
+
+def merge_citations(final_value: Any, sandbox_citations: Sequence[Dict[str, Any]], fallback_citations: Sequence[Dict[str, Any]], require_citations: bool, docs: Sequence[Document]) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+
+    if isinstance(final_value, dict):
+        raw = final_value.get("citations", [])
+        if isinstance(raw, list):
+            for item in raw:
+                citation = normalize_citation(item)
+                if citation is not None:
+                    items.append(citation)
+
+    for item in sandbox_citations:
+        citation = normalize_citation(item)
+        if citation is not None:
+            items.append(citation)
+
+    if not items:
+        for item in fallback_citations[:MAX_CITATIONS]:
+            citation = normalize_citation(item)
+            if citation is not None:
+                items.append(citation)
+
+    if require_citations and not items:
+        for doc in docs[:8]:
+            items.append(
+                {
+                    "path": doc.path,
+                    "start_line": 1,
+                    "end_line": 1,
+                    "signal": "file_reference",
+                    "snippet": "Fallback citation generated because no explicit citation was produced",
+                }
+            )
+
+    return dedupe_citations(items)
+
+
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Superloop RLMS worker")
-    p.add_argument("--repo", required=True)
-    p.add_argument("--loop-id", required=True)
-    p.add_argument("--role", required=True)
-    p.add_argument("--iteration", required=True, type=int)
-    p.add_argument("--context-file-list", required=True)
-    p.add_argument("--output-dir", required=True)
-    p.add_argument("--max-steps", required=True, type=int)
-    p.add_argument("--max-depth", required=True, type=int)
-    p.add_argument("--timeout-seconds", required=True, type=int)
-    p.add_argument("--require-citations", required=False, default="true")
-    p.add_argument("--format", required=False, default="json")
-    p.add_argument("--metadata-file", required=False, default="")
-    return p.parse_args()
+    parser = argparse.ArgumentParser(description="Superloop RLMS worker")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--loop-id", required=True)
+    parser.add_argument("--role", required=True)
+    parser.add_argument("--iteration", required=True, type=int)
+    parser.add_argument("--context-file-list", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--max-steps", required=True, type=int)
+    parser.add_argument("--max-depth", required=True, type=int)
+    parser.add_argument("--timeout-seconds", required=True, type=int)
+
+    parser.add_argument("--root-command-json", required=False, default="[]")
+    parser.add_argument("--root-args-json", required=False, default="[]")
+    parser.add_argument("--root-prompt-mode", required=False, default="stdin")
+    parser.add_argument("--subcall-command-json", required=False, default="[]")
+    parser.add_argument("--subcall-args-json", required=False, default="[]")
+    parser.add_argument("--subcall-prompt-mode", required=False, default="stdin")
+
+    parser.add_argument("--require-citations", required=False, default="true")
+    parser.add_argument("--format", required=False, default="json")
+    parser.add_argument("--metadata-file", required=False, default="")
+    return parser.parse_args()
 
 
 def main() -> int:
@@ -292,49 +895,120 @@ def main() -> int:
     os.makedirs(args.output_dir, exist_ok=True)
 
     metadata = load_metadata(args.metadata_file)
-    files = load_context_files(args.context_file_list)
-    rel_files = [to_rel(path, args.repo) for path in files]
-
-    state = AnalysisState(
-        started_at_monotonic=time.monotonic(),
-        max_steps=max(1, args.max_steps),
-        timeout_seconds=max(1, args.timeout_seconds),
-    )
+    docs = load_context_files(args.context_file_list, args.repo)
 
     try:
-        trees: List[Dict] = []
-        total_signals = empty_signals()
-        total_lines = 0
-        total_chars = 0
-
-        for abs_path, rel_path in zip(files, rel_files):
-            with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
-                text = f.read()
-            lines = text.splitlines()
-            total_lines += len(lines)
-            total_chars += len(text)
-            tree = analyze_segment(
-                rel_path, lines, start_line=1, depth=0, max_depth=max(0, args.max_depth), state=state
+        root_command = parse_json_string_array("root_command_json", args.root_command_json)
+        root_args = parse_json_string_array("root_args_json", args.root_args_json)
+        sub_command = parse_json_string_array("subcall_command_json", args.subcall_command_json)
+        sub_args = parse_json_string_array("subcall_args_json", args.subcall_args_json)
+    except RLMSWorkerError as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "generated_at": utc_now(),
+                    "loop_id": args.loop_id,
+                    "role": args.role,
+                    "iteration": args.iteration,
+                    "error": str(exc),
+                    "error_code": "invalid_config",
+                    "metadata": metadata or None,
+                },
+                separators=(",", ":"),
+                ensure_ascii=True,
             )
-            trees.append(tree)
-            add_signals(total_signals, tree.get("signals", {}))
+        )
+        return 2
 
-        file_summaries = [collect_file_summary(t) for t in trees]
-        citations = flatten_citations(file_summaries)
-        require_citations = parse_bool(args.require_citations)
-        if require_citations and not citations:
-            for rel in rel_files[:8]:
-                citations.append(
-                    {
-                        "path": rel,
-                        "start_line": 1,
-                        "end_line": 1,
-                        "signal": "file_reference",
-                        "snippet": "Fallback citation generated because no pattern match was found",
-                    }
+    root_prompt_mode = parse_prompt_mode(args.root_prompt_mode, "stdin")
+    sub_prompt_mode = parse_prompt_mode(args.subcall_prompt_mode, "stdin")
+
+    if not root_command:
+        result = {
+            "ok": False,
+            "generated_at": utc_now(),
+            "loop_id": args.loop_id,
+            "role": args.role,
+            "iteration": args.iteration,
+            "error": "root command is empty",
+            "error_code": "missing_root_command",
+            "metadata": metadata or None,
+        }
+        print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))
+        return 2
+
+    if not sub_command:
+        sub_command = list(root_command)
+    if not sub_args:
+        sub_args = list(root_args)
+
+    root_cli = CliConfig(command=root_command, args=root_args, prompt_mode=root_prompt_mode, label="root")
+    sub_cli = CliConfig(command=sub_command, args=sub_args, prompt_mode=sub_prompt_mode, label="subcall")
+
+    state = ExecutionState(
+        started_at_monotonic=time.monotonic(),
+        max_steps=max(1, int(args.max_steps)),
+        max_depth=max(1, int(args.max_depth)),
+        timeout_seconds=max(1, int(args.timeout_seconds)),
+        max_subcalls=max(1, int(args.max_steps) * 2),
+    )
+
+    require_citations = parse_bool(args.require_citations)
+    total_chars = sum(doc.char_count for doc in docs)
+    total_lines = sum(doc.line_count for doc in docs)
+    structural_signals, structural_citations = collect_structural_signals(docs)
+
+    sandbox = SandboxEnvironment(docs=docs, state=state, subcall_cli=sub_cli, repo=args.repo)
+
+    try:
+        while sandbox.final_value is None:
+            state.tick_step()
+            prompt = build_root_prompt(
+                role=args.role,
+                loop_id=args.loop_id,
+                iteration=args.iteration,
+                docs=docs,
+                metadata=metadata,
+                state=state,
+            )
+
+            response = invoke_cli(root_cli, prompt, args.repo, state.remaining_timeout())
+            if not response.get("ok"):
+                stderr = compact_text(response.get("stderr", ""), 260)
+                raise ModelInvocationError(
+                    f"root command failed (rc={response.get('returncode')}): {stderr or 'no stderr'}"
                 )
 
-        result = {
+            code = extract_python_code(str(response.get("stdout", "")))
+            execution = sandbox.execute(code)
+
+            state.history.append(
+                {
+                    "step": state.step_count,
+                    "type": "root",
+                    "returncode": int(response.get("returncode", 0)),
+                    "duration_ms": int(response.get("duration_ms", 0)),
+                    "code_preview": execution.get("code_preview", ""),
+                    "stdout_preview": execution.get("stdout_preview", ""),
+                }
+            )
+            if len(state.history) > 200:
+                state.history = state.history[-200:]
+
+            if sandbox.final_value is None and state.step_count >= state.max_steps:
+                raise LimitError("final value was not set before max_steps")
+
+        highlights = merge_highlights(sandbox.final_value, sandbox.highlights, structural_signals, len(docs))
+        citations = merge_citations(
+            sandbox.final_value,
+            sandbox.citations,
+            structural_citations,
+            require_citations,
+            docs,
+        )
+
+        result: Dict[str, Any] = {
             "ok": True,
             "generated_at": utc_now(),
             "loop_id": args.loop_id,
@@ -342,23 +1016,29 @@ def main() -> int:
             "iteration": args.iteration,
             "format": args.format,
             "limits": {
-                "max_steps": args.max_steps,
-                "max_depth": args.max_depth,
-                "timeout_seconds": args.timeout_seconds,
+                "max_steps": int(args.max_steps),
+                "max_depth": int(args.max_depth),
+                "timeout_seconds": int(args.timeout_seconds),
+                "max_subcalls": state.max_subcalls,
             },
             "stats": {
-                "file_count": len(files),
+                "file_count": len(docs),
                 "line_count": total_lines,
                 "char_count": total_chars,
                 "estimated_tokens": estimate_tokens(total_chars),
                 "step_count": state.step_count,
+                "subcall_count": state.subcall_count,
+                "elapsed_seconds": round(state.elapsed_seconds(), 3),
             },
-            "signals": total_signals,
-            "highlights": build_global_highlights(total_signals, len(files)),
+            "signals": structural_signals,
+            "highlights": highlights,
             "citations": citations,
-            "files": file_summaries,
+            "files": build_file_summaries(docs),
+            "trace": state.history[-MAX_HISTORY_ITEMS:],
+            "final": sandbox.final_value,
             "metadata": metadata or None,
         }
+
         print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))
         return 0
     except LimitError as exc:
@@ -370,11 +1050,54 @@ def main() -> int:
             "iteration": args.iteration,
             "error": str(exc),
             "error_code": "limit_exceeded",
-            "stats": {"step_count": state.step_count},
+            "stats": {
+                "step_count": state.step_count,
+                "subcall_count": state.subcall_count,
+                "elapsed_seconds": round(state.elapsed_seconds(), 3),
+            },
+            "trace": state.history[-MAX_HISTORY_ITEMS:],
             "metadata": metadata or None,
         }
         print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))
         return 2
+    except SandboxViolation as exc:
+        result = {
+            "ok": False,
+            "generated_at": utc_now(),
+            "loop_id": args.loop_id,
+            "role": args.role,
+            "iteration": args.iteration,
+            "error": str(exc),
+            "error_code": "sandbox_violation",
+            "stats": {
+                "step_count": state.step_count,
+                "subcall_count": state.subcall_count,
+                "elapsed_seconds": round(state.elapsed_seconds(), 3),
+            },
+            "trace": state.history[-MAX_HISTORY_ITEMS:],
+            "metadata": metadata or None,
+        }
+        print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))
+        return 1
+    except ModelInvocationError as exc:
+        result = {
+            "ok": False,
+            "generated_at": utc_now(),
+            "loop_id": args.loop_id,
+            "role": args.role,
+            "iteration": args.iteration,
+            "error": str(exc),
+            "error_code": "model_invocation_failed",
+            "stats": {
+                "step_count": state.step_count,
+                "subcall_count": state.subcall_count,
+                "elapsed_seconds": round(state.elapsed_seconds(), 3),
+            },
+            "trace": state.history[-MAX_HISTORY_ITEMS:],
+            "metadata": metadata or None,
+        }
+        print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))
+        return 1
     except Exception as exc:  # pragma: no cover - defensive path
         result = {
             "ok": False,
@@ -384,7 +1107,12 @@ def main() -> int:
             "iteration": args.iteration,
             "error": str(exc),
             "error_code": "worker_failure",
-            "stats": {"step_count": state.step_count},
+            "stats": {
+                "step_count": state.step_count,
+                "subcall_count": state.subcall_count,
+                "elapsed_seconds": round(state.elapsed_seconds(), 3),
+            },
+            "trace": state.history[-MAX_HISTORY_ITEMS:],
             "metadata": metadata or None,
         }
         print(json.dumps(result, separators=(",", ":"), ensure_ascii=True))

--- a/src/60-commands.sh
+++ b/src/60-commands.sh
@@ -1639,6 +1639,105 @@ run_cmd() {
             '{generated_at: $generated_at, loop_id: $loop_id, run_id: $run_id, role: $role, mode: $mode, trigger_reason: $trigger_reason, should_run: $should_run, metrics: $metrics, limits: $limits}' \
             > "$role_rlms_metadata_file"
 
+          local rlms_root_command_json='[]'
+          local rlms_root_args_json='[]'
+          local rlms_root_prompt_mode='stdin'
+          local rlms_subcall_command_json='[]'
+          local rlms_subcall_args_json='[]'
+          local rlms_subcall_prompt_mode='stdin'
+
+          local rlms_runner_name
+          rlms_runner_name=$(get_role_runner_name "$role")
+          local rlms_runner_config
+          rlms_runner_config=$(get_runner_for_role "$role" "$rlms_runner_name")
+
+          local -a rlms_runner_command=()
+          local -a rlms_runner_args=()
+          local -a rlms_runner_fast_args=()
+          local rlms_runner_prompt_mode='stdin'
+
+          if [[ -n "$rlms_runner_config" ]]; then
+            while IFS= read -r line; do
+              [[ -n "$line" ]] && rlms_runner_command+=("$line")
+            done < <(jq -r '.command[]?' <<<"$rlms_runner_config")
+
+            while IFS= read -r line; do
+              [[ -n "$line" ]] && rlms_runner_args+=("$line")
+            done < <(jq -r '.args[]?' <<<"$rlms_runner_config")
+
+            while IFS= read -r line; do
+              [[ -n "$line" ]] && rlms_runner_fast_args+=("$line")
+            done < <(jq -r '.fast_args[]?' <<<"$rlms_runner_config")
+
+            rlms_runner_prompt_mode=$(jq -r '.prompt_mode // "stdin"' <<<"$rlms_runner_config")
+          fi
+
+          if [[ ${#rlms_runner_command[@]} -eq 0 ]]; then
+            rlms_runner_command=("${runner_command[@]}")
+            rlms_runner_args=("${runner_args[@]}")
+            rlms_runner_fast_args=("${runner_fast_args[@]}")
+            rlms_runner_prompt_mode="$runner_prompt_mode"
+          fi
+
+          local -a rlms_runner_active_args=("${rlms_runner_args[@]}")
+          if [[ "${fast_mode:-0}" -eq 1 && ${#rlms_runner_fast_args[@]} -gt 0 ]]; then
+            rlms_runner_active_args=("${rlms_runner_fast_args[@]}")
+          fi
+
+          local rlms_role_model rlms_role_thinking rlms_runner_type
+          rlms_role_model=$(get_role_model "$role")
+          rlms_role_thinking=$(get_role_thinking "$role")
+          rlms_runner_type=$(detect_runner_type_from_cmd "${rlms_runner_command[0]:-}")
+
+          if [[ -n "$rlms_role_model" && "$rlms_role_model" != "null" ]]; then
+            rlms_runner_active_args=("--model" "$rlms_role_model" "${rlms_runner_active_args[@]}")
+          fi
+
+          if [[ -n "$rlms_role_thinking" && "$rlms_role_thinking" != "null" ]]; then
+            local -a rlms_thinking_flags=()
+            while IFS= read -r flag; do
+              [[ -n "$flag" ]] && rlms_thinking_flags+=("$flag")
+            done < <(get_thinking_flags "$rlms_runner_type" "$rlms_role_thinking")
+            if [[ ${#rlms_thinking_flags[@]} -gt 0 ]]; then
+              rlms_runner_active_args=("${rlms_thinking_flags[@]}" "${rlms_runner_active_args[@]}")
+            fi
+          fi
+
+          rlms_root_command_json=$(printf '%s\n' "${rlms_runner_command[@]}" | jq -R . | jq -s .)
+          rlms_root_args_json=$(printf '%s\n' "${rlms_runner_active_args[@]}" | jq -R . | jq -s .)
+          rlms_root_prompt_mode="$rlms_runner_prompt_mode"
+
+          if [[ -n "${SUPERLOOP_RLMS_ROOT_COMMAND_JSON:-}" ]]; then
+            rlms_root_command_json="$SUPERLOOP_RLMS_ROOT_COMMAND_JSON"
+          fi
+          if [[ -n "${SUPERLOOP_RLMS_ROOT_ARGS_JSON:-}" ]]; then
+            rlms_root_args_json="$SUPERLOOP_RLMS_ROOT_ARGS_JSON"
+          fi
+          if [[ -n "${SUPERLOOP_RLMS_ROOT_PROMPT_MODE:-}" ]]; then
+            rlms_root_prompt_mode="$SUPERLOOP_RLMS_ROOT_PROMPT_MODE"
+          fi
+
+          rlms_subcall_command_json="$rlms_root_command_json"
+          rlms_subcall_args_json="$rlms_root_args_json"
+          rlms_subcall_prompt_mode="$rlms_root_prompt_mode"
+
+          if [[ -n "${SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON:-}" ]]; then
+            rlms_subcall_command_json="$SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON"
+          fi
+          if [[ -n "${SUPERLOOP_RLMS_SUBCALL_ARGS_JSON:-}" ]]; then
+            rlms_subcall_args_json="$SUPERLOOP_RLMS_SUBCALL_ARGS_JSON"
+          fi
+          if [[ -n "${SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE:-}" ]]; then
+            rlms_subcall_prompt_mode="$SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE"
+          fi
+
+          if [[ "$rlms_root_prompt_mode" != "stdin" && "$rlms_root_prompt_mode" != "file" ]]; then
+            rlms_root_prompt_mode="stdin"
+          fi
+          if [[ "$rlms_subcall_prompt_mode" != "stdin" && "$rlms_subcall_prompt_mode" != "file" ]]; then
+            rlms_subcall_prompt_mode="stdin"
+          fi
+
           local rlms_status_text="skipped"
           local rlms_error_message=""
           local rlms_started_at=""
@@ -1666,6 +1765,12 @@ run_cmd() {
               --max-steps "$rlms_limit_max_steps" \
               --max-depth "$rlms_limit_max_depth" \
               --timeout-seconds "$rlms_limit_timeout_seconds" \
+              --root-command-json "$rlms_root_command_json" \
+              --root-args-json "$rlms_root_args_json" \
+              --root-prompt-mode "$rlms_root_prompt_mode" \
+              --subcall-command-json "$rlms_subcall_command_json" \
+              --subcall-args-json "$rlms_subcall_args_json" \
+              --subcall-prompt-mode "$rlms_subcall_prompt_mode" \
               --require-citations "$rlms_output_require_citations" \
               --format "$rlms_output_format" \
               --metadata-file "$role_rlms_metadata_file"


### PR DESCRIPTION
## Summary
- replace heuristic  with a sandboxed REPL RLMS loop (root model emits code, bounded execution, controlled subcalls)
- pass root/subcall CLI command vectors through 
- derive RLMS root/subcall command defaults from each role's resolved runner config in 
- add RLMS REPL tests for success path, sandbox violation, and subcall depth limits
- add deep engineer context docs for this phase under 

## Validation
- 
- 1..8
ok 1 rlms requested mode does not run when keyword is absent
ok 2 rlms hybrid mode auto-triggers on large context
ok 3 rlms warn_and_continue allows role execution when rlms fails
ok 4 rlms fail_role stops execution when rlms fails
ok 5 rlms artifacts are included in evidence manifest when evidence is enabled
ok 6 rlms REPL worker executes sandboxed root code with subcall CLI
ok 7 rlms REPL worker rejects sandbox violations from root code
ok 8 rlms REPL worker enforces subcall depth limits
- 1..15
ok 1 superloop --version shows version
ok 2 superloop --help shows usage
ok 3 superloop with no args shows usage
ok 4 validate succeeds with valid config
ok 5 validate fails with invalid config
ok 6 validate fails with missing config
ok 7 validate --static accepts valid rlms configuration
ok 8 validate --static fails when rlms policy force_on and force_off are both true
ok 9 list shows no loops when empty
ok 10 list shows configured loops
ok 11 status works with no state
ok 12 init creates .superloop directory structure
ok 13 run --dry-run works without runners
ok 14 config with role_defaults validates
ok 15 config with per-role model and thinking validates
- 
- ok: config matches schema

Refs #10
