### PR TITLE
fix: relax RLMS sandbox for safe method calls

### DIFF
--- a/feat/rlms-integration/repl-engine/CONTEXT.MD
+++ b/feat/rlms-integration/repl-engine/CONTEXT.MD
@@ -72,7 +72,7 @@ Allowed:
 Blocked:
 
 - `import` / `from ... import ...`
-- Attribute access (`obj.attr`)
+- Arbitrary attribute access (`obj.attr`) except a narrow allowlist of safe container/string method calls
 - Class definitions, `try/except`, with-statements, async constructs
 - Dunder names
 - Calls to non-allowlisted functions

--- a/tests/rlms.bats
+++ b/tests/rlms.bats
@@ -95,6 +95,8 @@ cat <<'PY'
 files = list_files()
 if files:
     snippet = read_file(files[0], 1, 80)
+    lines = snippet.split("\\n")
+    append_highlight("line_count:" + str(len(lines)))
     summary = sub_rlm("summarize:\\n" + snippet, depth=1)
     append_highlight("subcall:" + summary)
     matches = grep("class\\s+", files[0], 3, "")


### PR DESCRIPTION
## Summary
- relax RLMS sandbox to allow a narrow allowlist of safe list/dict/string method calls
- keep imports, arbitrary attribute access, and unsafe call targets blocked
- update RLMS REPL test fixture to exercise method-call path
- document sandbox policy update in REPL context notes

## Validation
- python3 -m py_compile scripts/rlms_worker.py
- bats tests/rlms.bats
- dedicated rlms-repl-smoke run verified RLMS status `ok` and artifact emission

Refs #10
