### PR TITLE
feat: add RLMS max_subcalls budget and deterministic smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ The loop completes when the Reviewer outputs `<promise>COMPLETION_TAG</promise>`
       "limits": {
         "max_steps": 40,
         "max_depth": 2,
-        "timeout_seconds": 240
+        "timeout_seconds": 240,
+        "max_subcalls": 80
       },
       "policy": {
         "force_on": false,
@@ -167,6 +168,7 @@ When `loops[].rlms.enabled=true`, Superloop can run a bounded REPL-style recursi
 - `mode=requested`: trigger only when `request_keyword` appears in loop context files.
 - `mode=hybrid`: run when either auto or requested trigger is true.
 - `policy.fail_mode=warn_and_continue|fail_role`: choose whether RLMS failures are non-fatal or role-fatal.
+- `limits.max_subcalls`: cap recursive sub-LLM call count per role execution.
 - Root/subcall CLI wiring: by default RLMS inherits the role's resolved runner command/args/model/thinking settings.
 - Optional env overrides:
   - `SUPERLOOP_RLMS_ROOT_COMMAND_JSON`, `SUPERLOOP_RLMS_ROOT_ARGS_JSON`, `SUPERLOOP_RLMS_ROOT_PROMPT_MODE`

--- a/feat/rlms-integration/repl-engine/CONTEXT.MD
+++ b/feat/rlms-integration/repl-engine/CONTEXT.MD
@@ -101,8 +101,9 @@ RLMS is bounded by loop config limits:
 - `max_steps`: max root iterations
 - `max_depth`: max declared subcall depth
 - `timeout_seconds`: hard wall-clock timeout
+- `max_subcalls`: max sub-LLM invocations per role execution
 
-Worker also enforces derived max subcall count (`max_steps * 2`) and emits structured limit errors.
+If `max_subcalls` is omitted, worker uses a derived fallback (`max_steps * 2`).
 
 ## 6. Output contract and observability
 

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -390,6 +390,12 @@
                     "type": "integer",
                     "minimum": 1,
                     "default": 240
+                  },
+                  "max_subcalls": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 80,
+                    "description": "Maximum number of sub-LLM calls RLMS can execute before failing"
                   }
                 }
               },

--- a/scripts/rlms
+++ b/scripts/rlms
@@ -13,6 +13,7 @@ Usage: scripts/rlms \
   --max-steps <n> \
   --max-depth <n> \
   --timeout-seconds <n> \
+  [--max-subcalls <n>] \
   [--root-command-json <json-array>] \
   [--root-args-json <json-array>] \
   [--root-prompt-mode <stdin|file>] \
@@ -47,6 +48,7 @@ output_dir=""
 max_steps=""
 max_depth=""
 timeout_seconds=""
+max_subcalls=""
 root_command_json=""
 root_args_json=""
 root_prompt_mode=""
@@ -93,6 +95,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --timeout-seconds)
       timeout_seconds="${2:-}"
+      shift 2
+      ;;
+    --max-subcalls)
+      max_subcalls="${2:-}"
       shift 2
       ;;
     --root-command-json)
@@ -152,6 +158,10 @@ need_arg "--output-dir" "$output_dir"
 need_arg "--max-steps" "$max_steps"
 need_arg "--max-depth" "$max_depth"
 need_arg "--timeout-seconds" "$timeout_seconds"
+
+if [[ -z "$max_subcalls" ]]; then
+  max_subcalls="${SUPERLOOP_RLMS_MAX_SUBCALLS:-0}"
+fi
 
 if [[ -z "$root_command_json" ]]; then
   root_command_json="${SUPERLOOP_RLMS_ROOT_COMMAND_JSON:-}"
@@ -231,6 +241,7 @@ set +e
   --max-steps "$max_steps" \
   --max-depth "$max_depth" \
   --timeout-seconds "$timeout_seconds" \
+  --max-subcalls "$max_subcalls" \
   --root-command-json "$root_command_json" \
   --root-args-json "$root_args_json" \
   --root-prompt-mode "$root_prompt_mode" \

--- a/scripts/rlms_worker.py
+++ b/scripts/rlms_worker.py
@@ -943,6 +943,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-steps", required=True, type=int)
     parser.add_argument("--max-depth", required=True, type=int)
     parser.add_argument("--timeout-seconds", required=True, type=int)
+    parser.add_argument("--max-subcalls", required=False, default=0, type=int)
 
     parser.add_argument("--root-command-json", required=False, default="[]")
     parser.add_argument("--root-args-json", required=False, default="[]")
@@ -1013,12 +1014,16 @@ def main() -> int:
     root_cli = CliConfig(command=root_command, args=root_args, prompt_mode=root_prompt_mode, label="root")
     sub_cli = CliConfig(command=sub_command, args=sub_args, prompt_mode=sub_prompt_mode, label="subcall")
 
+    configured_max_subcalls = int(args.max_subcalls or 0)
+    if configured_max_subcalls <= 0:
+        configured_max_subcalls = max(1, int(args.max_steps) * 2)
+
     state = ExecutionState(
         started_at_monotonic=time.monotonic(),
         max_steps=max(1, int(args.max_steps)),
         max_depth=max(1, int(args.max_depth)),
         timeout_seconds=max(1, int(args.timeout_seconds)),
-        max_subcalls=max(1, int(args.max_steps) * 2),
+        max_subcalls=max(1, configured_max_subcalls),
     )
 
     require_citations = parse_bool(args.require_citations)

--- a/src/56-validate-static.sh
+++ b/src/56-validate-static.sh
@@ -308,9 +308,10 @@ check_rlms_config() {
     check_timeout "rlms.timeout_seconds" "$timeout_seconds" "$location_prefix.rlms.limits.timeout_seconds"
   fi
 
-  local max_steps max_depth
+  local max_steps max_depth max_subcalls
   max_steps=$(echo "$loop_json" | jq -r '.rlms.limits.max_steps // 0' 2>/dev/null || echo "0")
   max_depth=$(echo "$loop_json" | jq -r '.rlms.limits.max_depth // 0' 2>/dev/null || echo "0")
+  max_subcalls=$(echo "$loop_json" | jq -r '.rlms.limits.max_subcalls // 0' 2>/dev/null || echo "0")
 
   if [[ "$max_steps" =~ ^[0-9]+$ && "$max_steps" -gt 0 && "$max_steps" -gt 500 ]]; then
     static_add_warning "$STATIC_ERR_TIMEOUT_SUSPICIOUS" \
@@ -322,6 +323,12 @@ check_rlms_config() {
     static_add_warning "$STATIC_ERR_TIMEOUT_SUSPICIOUS" \
       "rlms.limits.max_depth is $max_depth which may cause deep recursion and high cost" \
       "$location_prefix.rlms.limits.max_depth"
+  fi
+
+  if [[ "$max_subcalls" =~ ^[0-9]+$ && "$max_subcalls" -gt 0 && "$max_subcalls" -gt 2000 ]]; then
+    static_add_warning "$STATIC_ERR_TIMEOUT_SUSPICIOUS" \
+      "rlms.limits.max_subcalls is $max_subcalls which may be expensive; consider lower defaults" \
+      "$location_prefix.rlms.limits.max_subcalls"
   fi
 }
 


### PR DESCRIPTION
## Summary
- add `rlms.limits.max_subcalls` to schema and static validation
- wire max-subcalls through loop runtime (`src/60-commands.sh`) into `scripts/rlms` and `scripts/rlms_worker.py`
- keep backward compatibility by deriving default subcall cap from `max_steps * 2` when omitted
- extend RLMS tests with:
  - direct worker max_subcalls limit enforcement
  - deterministic superloop-level RLMS smoke test using root/subcall env overrides
- update RLMS docs for the new control limit

## Validation
- python3 -m py_compile scripts/rlms_worker.py
- bats tests/rlms.bats
- bats tests/superloop.bats
- ./scripts/build.sh
- ./superloop.sh validate --repo .

Refs #10
