### PR TITLE
feat(rlms): add canary CI status+quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,66 @@ jobs:
       - name: List loops
         run: ./superloop.sh list --repo .
 
+  rlms-canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wrapper
+        run: ./scripts/build.sh
+      - name: Verify generated script is up to date
+        run: git diff --exit-code superloop.sh
+      - name: Configure deterministic canary role runner
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          jq '
+            .runners["ci-shell"] = {
+              command: ["bash"],
+              args: ["-lc", "echo \"<promise>SUPERLOOP_COMPLETE</promise>\" > \"{last_message_file}\""],
+              prompt_mode: "stdin"
+            }
+            | (.loops[] | select(.id == "rlms-canary") | .roles.reviewer.runner) = "ci-shell"
+            | del(
+                (.loops[] | select(.id == "rlms-canary") | .roles.reviewer.model),
+                (.loops[] | select(.id == "rlms-canary") | .roles.reviewer.thinking)
+              )
+          ' .superloop/config.json > "$tmp"
+          mv "$tmp" .superloop/config.json
+      - name: Validate config schema
+        run: ./superloop.sh validate --repo .
+      - name: Run rlms-canary loop
+        run: |
+          set -euo pipefail
+          root_command_json="$(jq -cn --arg cmd "$PWD/scripts/rlms-mock-root.sh" '[$cmd]')"
+          subcall_command_json="$(jq -cn --arg cmd "$PWD/scripts/rlms-mock-subcall.sh" '[$cmd]')"
+          SUPERLOOP_RLMS_ROOT_COMMAND_JSON="$root_command_json" \
+          SUPERLOOP_RLMS_ROOT_ARGS_JSON='[]' \
+          SUPERLOOP_RLMS_ROOT_PROMPT_MODE='stdin' \
+          SUPERLOOP_RLMS_SUBCALL_COMMAND_JSON="$subcall_command_json" \
+          SUPERLOOP_RLMS_SUBCALL_ARGS_JSON='[]' \
+          SUPERLOOP_RLMS_SUBCALL_PROMPT_MODE='stdin' \
+          ./superloop.sh run --repo . --loop rlms-canary
+      - name: Assert rlms-canary status and quality
+        run: |
+          set -euo pipefail
+          scripts/assert-rlms-canary.sh \
+            --status-file .superloop/loops/rlms-canary/rlms/latest/reviewer.status.json \
+            --result-file .superloop/loops/rlms-canary/rlms/latest/reviewer.json \
+            --require-should-run true \
+            --min-citations "${RLMS_CANARY_MIN_CITATIONS:-1}" \
+            --min-non-fallback-citations "${RLMS_CANARY_MIN_NON_FALLBACK_CITATIONS:-1}" \
+            --fallback-signals "${RLMS_CANARY_FALLBACK_SIGNALS:-file_reference}" \
+            --require-highlight-pattern "${RLMS_CANARY_REQUIRE_HIGHLIGHT_PATTERN:-mock_root_complete}"
+      - name: Dump rlms-canary artifacts on failure
+        if: failure()
+        run: |
+          set +e
+          find .superloop/loops/rlms-canary -maxdepth 4 -type f | sort
+          echo "--- reviewer.status.json ---"
+          cat .superloop/loops/rlms-canary/rlms/latest/reviewer.status.json
+          echo "--- reviewer.json ---"
+          cat .superloop/loops/rlms-canary/rlms/latest/reviewer.json
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,24 @@ When `loops[].rlms.enabled=true`, Superloop can run a bounded REPL-style recursi
 
 Artifacts are written under `.superloop/loops/<loop-id>/rlms/` and linked into prompts, evidence, events, and run summaries.
 
+### RLMS Canary Gate
+
+CI runs a deterministic canary loop (`rlms-canary`) and enforces both status and quality checks using:
+
+- `scripts/assert-rlms-canary.sh`
+
+The script validates:
+
+- `reviewer.status.json`: `status == "ok"` and (optionally) `should_run == true`
+- `reviewer.json`: `ok == true`, citation thresholds, non-fallback citation thresholds, and optional highlight regex
+
+Threshold knobs (CLI flags or env vars):
+
+- `RLMS_CANARY_MIN_CITATIONS` (default: `1`)
+- `RLMS_CANARY_MIN_NON_FALLBACK_CITATIONS` (default: `1`)
+- `RLMS_CANARY_FALLBACK_SIGNALS` (default: `file_reference`)
+- `RLMS_CANARY_REQUIRE_HIGHLIGHT_PATTERN` (default in CI: `mock_root_complete`)
+
 ## Dashboard
 
 Superloop includes a **liquid dashboard** - a contextual UI that adapts to loop state:

--- a/feat/rlms-integration/phase2-hardening/PLAN.MD
+++ b/feat/rlms-integration/phase2-hardening/PLAN.MD
@@ -1,0 +1,38 @@
+# Feature: RLMS Phase 2 Hardening (Canary + Quality Gates)
+
+## Goal
+Add deterministic CI enforcement for RLMS canary behavior so regressions are blocked before merge.
+
+## Scope
+- Add a deterministic RLMS canary assertion script for status + quality checks.
+- Add CI job wiring to run `rlms-canary` and enforce assertions.
+- Add mock RLMS root/subcall command scripts for CI-safe execution.
+- Add regression tests for canary assertion behavior.
+
+## Non-Goals (this iteration)
+- No fallback runner/model strategy changes.
+- No RLMS telemetry/report surface expansion.
+- No production rollout changes for additional real loops.
+
+## Primary References
+- `feat/rlms-integration/repl-engine/PLAN.MD`: existing REPL RLMS architecture.
+- `.superloop/config.json`: canary loop definition (`rlms-canary`).
+- `scripts/rlms_worker.py`: sandboxed RLMS REPL runtime.
+- `.github/workflows/ci.yml`: CI enforcement pipeline.
+
+## Architecture
+CI runs the `rlms-canary` loop with deterministic mock role execution and deterministic RLMS root/subcall scripts. The run emits standard RLMS artifacts. A dedicated assertion script validates both activation/status (`should_run`, `status`) and output quality (`ok`, citations, highlights). CI fails with actionable messages on any threshold violation.
+
+## Decisions
+- Keep canary validation as a standalone shell script in `scripts/` for local + CI reuse.
+- Use explicit threshold flags/env vars instead of hardcoding values in workflow steps.
+- Keep canary deterministic by using local mock scripts instead of external model APIs.
+
+## Risks / Constraints
+- Overly strict thresholds can create noisy CI failures.
+- Too lenient thresholds can allow low-signal RLMS output to pass.
+- CI runtime must remain bounded and not depend on external credentials.
+
+## Phases
+- **Phase 1**: CI canary status/quality gate + tests + deterministic mocks.
+- **Phase 2**: Fallback strategy + telemetry + rollout policy hardening.

--- a/feat/rlms-integration/phase2-hardening/tasks/PHASE_1.MD
+++ b/feat/rlms-integration/phase2-hardening/tasks/PHASE_1.MD
@@ -1,0 +1,42 @@
+# Phase 1 - RLMS Canary CI Gate
+
+## P1.1 Canary Assertion Script
+1. [x] Create `scripts/assert-rlms-canary.sh` to validate RLMS canary status artifacts.
+2. [x] Enforce required status checks:
+   1. [x] `reviewer.status.json` has `status == "ok"`.
+   2. [x] `reviewer.status.json` has `should_run == true` (configurable).
+3. [x] Enforce quality checks against `reviewer.json`:
+   1. [x] `.ok == true`.
+   2. [x] Citation count threshold (`>= min_citations`).
+   3. [x] Non-fallback citation threshold (`>= min_non_fallback_citations`).
+   4. [x] Optional highlight pattern check.
+4. [x] Return actionable non-zero failures with clear threshold-specific messages.
+
+## P1.2 Deterministic RLMS Mock Commands
+1. [x] Create deterministic mock root code script in `scripts/rlms-mock-root.sh`.
+2. [x] Create deterministic mock subcall script in `scripts/rlms-mock-subcall.sh`.
+3. [x] Ensure root mock emits high-signal citation/highlight output that satisfies canary thresholds.
+
+## P1.3 CI Wiring
+1. [x] Extend `.github/workflows/ci.yml` with `rlms-canary` job.
+2. [x] In canary job, execute:
+   1. [x] `./superloop.sh validate --repo .`
+   2. [x] `./superloop.sh run --repo . --loop rlms-canary`
+3. [x] Make run deterministic in CI by patching canary role runner to a local shell runner and using RLMS root/subcall env overrides.
+4. [x] Invoke `scripts/assert-rlms-canary.sh` and fail CI on assertion violations.
+
+## P1.4 Regression Coverage
+1. [x] Add BATS tests for canary assertion script pass/fail paths.
+2. [x] Cover failure cases for:
+   1. [x] `should_run=false`
+   2. [x] low/empty citations
+   3. [x] fallback-only citations
+   4. [x] missing required highlight pattern
+
+## P1.5 Documentation
+1. [x] Update `README.md` RLMS section with canary assertion usage and threshold knobs.
+
+## P1.V Validation
+1. [x] Run `bats tests/rlms.bats tests/superloop.bats tests/rlms-canary-gate.bats`.
+2. [x] Run `./scripts/build.sh` and ensure generated `superloop.sh` is in sync.
+3. [x] Run `./superloop.sh validate --repo .`.

--- a/scripts/assert-rlms-canary.sh
+++ b/scripts/assert-rlms-canary.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/assert-rlms-canary.sh \
+  --status-file <path> \
+  [--result-file <path>] \
+  [--require-should-run <true|false>] \
+  [--min-citations <n>] \
+  [--min-non-fallback-citations <n>] \
+  [--fallback-signals <comma-separated>] \
+  [--require-highlight-pattern <regex>]
+
+Environment variable defaults:
+  RLMS_CANARY_REQUIRE_SHOULD_RUN=true
+  RLMS_CANARY_MIN_CITATIONS=1
+  RLMS_CANARY_MIN_NON_FALLBACK_CITATIONS=1
+  RLMS_CANARY_FALLBACK_SIGNALS=file_reference
+  RLMS_CANARY_REQUIRE_HIGHLIGHT_PATTERN=
+USAGE
+}
+
+fail() {
+  local message="$1"
+  echo "RLMS canary assertion failed: $message" >&2
+  echo "::error::$message" >&2
+  exit 1
+}
+
+need_file() {
+  local path="$1"
+  local label="$2"
+  if [[ -z "$path" ]]; then
+    fail "missing required $label"
+  fi
+  if [[ ! -f "$path" ]]; then
+    fail "$label not found: $path"
+  fi
+}
+
+need_int() {
+  local value="$1"
+  local label="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "$label must be a non-negative integer (got: $value)"
+  fi
+}
+
+status_file=""
+result_file=""
+require_should_run="${RLMS_CANARY_REQUIRE_SHOULD_RUN:-true}"
+min_citations="${RLMS_CANARY_MIN_CITATIONS:-1}"
+min_non_fallback_citations="${RLMS_CANARY_MIN_NON_FALLBACK_CITATIONS:-1}"
+fallback_signals="${RLMS_CANARY_FALLBACK_SIGNALS:-file_reference}"
+require_highlight_pattern="${RLMS_CANARY_REQUIRE_HIGHLIGHT_PATTERN:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --status-file)
+      status_file="${2:-}"
+      shift 2
+      ;;
+    --result-file)
+      result_file="${2:-}"
+      shift 2
+      ;;
+    --require-should-run)
+      require_should_run="${2:-}"
+      shift 2
+      ;;
+    --min-citations)
+      min_citations="${2:-}"
+      shift 2
+      ;;
+    --min-non-fallback-citations)
+      min_non_fallback_citations="${2:-}"
+      shift 2
+      ;;
+    --fallback-signals)
+      fallback_signals="${2:-}"
+      shift 2
+      ;;
+    --require-highlight-pattern)
+      require_highlight_pattern="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_file "$status_file" "status file"
+if [[ -z "$result_file" ]]; then
+  result_file="${status_file%.status.json}.json"
+fi
+need_file "$result_file" "result file"
+
+if [[ "$require_should_run" != "true" && "$require_should_run" != "false" ]]; then
+  fail "--require-should-run must be true or false (got: $require_should_run)"
+fi
+
+need_int "$min_citations" "--min-citations"
+need_int "$min_non_fallback_citations" "--min-non-fallback-citations"
+
+local_status=$(jq -r '.status // ""' "$status_file")
+if [[ "$local_status" != "ok" ]]; then
+  fail "expected status=ok, got '$local_status' in $status_file"
+fi
+
+local_should_run=$(jq -r '.should_run // false' "$status_file")
+if [[ "$require_should_run" == "true" && "$local_should_run" != "true" ]]; then
+  fail "expected should_run=true in $status_file"
+fi
+
+local_ok=$(jq -r '.ok // false' "$result_file")
+if [[ "$local_ok" != "true" ]]; then
+  fail "expected ok=true in $result_file"
+fi
+
+citation_count=$(jq -r '(.citations // []) | length' "$result_file")
+if (( citation_count < min_citations )); then
+  fail "citation threshold failed: expected >= $min_citations, got $citation_count"
+fi
+
+fallback_signals_json=$(jq -Rn --arg csv "$fallback_signals" '
+  ($csv | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)))
+')
+
+non_fallback_count=$(jq -r --argjson fallback "$fallback_signals_json" '
+  (.citations // [])
+  | map((.signal // "") as $signal | select(($fallback | index($signal)) == null))
+  | length
+' "$result_file")
+
+if (( non_fallback_count < min_non_fallback_citations )); then
+  fail "non-fallback citation threshold failed: expected >= $min_non_fallback_citations, got $non_fallback_count (fallback signals: $fallback_signals)"
+fi
+
+if [[ -n "$require_highlight_pattern" ]]; then
+  highlight_matches=$(jq -r --arg pattern "$require_highlight_pattern" '
+    (.highlights // [])
+    | map(tostring)
+    | map(select(test($pattern)))
+    | length
+  ' "$result_file")
+  if (( highlight_matches < 1 )); then
+    fail "required highlight pattern not found: $require_highlight_pattern"
+  fi
+fi
+
+echo "RLMS canary assertions passed: status=ok, should_run=$local_should_run, citations=$citation_count, non_fallback_citations=$non_fallback_count"

--- a/scripts/rlms-mock-root.sh
+++ b/scripts/rlms-mock-root.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consume prompt payload and emit deterministic root Python code for rlms_worker.
+cat >/dev/null
+
+cat <<'PY'
+files = list_files()
+target = files[0] if files else ""
+snippet = read_file(target, 1, 120) if target else ""
+
+if snippet:
+    child = sub_rlm("summarize:\n" + snippet, depth=1)
+    append_highlight("subcall:" + str(child))
+
+append_highlight("mock_root_complete")
+
+if target:
+    lines = snippet.split("\n") if snippet else [""]
+    end_line = min(3, len(lines)) if len(lines) > 0 else 1
+    add_citation(target, 1, end_line, "semantic_match", snippet)
+
+set_final({"highlights": ["mock_root_complete"], "citations": []})
+PY

--- a/scripts/rlms-mock-subcall.sh
+++ b/scripts/rlms-mock-subcall.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic subcall response used by canary CI and tests.
+cat >/dev/null
+echo "mock-subcall-ok"

--- a/tests/rlms-canary-gate.bats
+++ b/tests/rlms-canary-gate.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  STATUS_FILE="$TEMP_DIR/reviewer.status.json"
+  RESULT_FILE="$TEMP_DIR/reviewer.json"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+write_status() {
+  local status_value="$1"
+  local should_run_value="$2"
+  cat > "$STATUS_FILE" <<JSON
+{"status":"$status_value","should_run":$should_run_value}
+JSON
+}
+
+write_result() {
+  local body="$1"
+  cat > "$RESULT_FILE" <<JSON
+$body
+JSON
+}
+
+@test "assert-rlms-canary passes for healthy canary artifacts" {
+  write_status "ok" "true"
+  write_result '{"ok":true,"highlights":["mock_root_complete"],"citations":[{"signal":"semantic_match"}]}'
+
+  run "$PROJECT_ROOT/scripts/assert-rlms-canary.sh" \
+    --status-file "$STATUS_FILE" \
+    --result-file "$RESULT_FILE" \
+    --require-highlight-pattern "mock_root_complete"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "assertions passed" ]]
+}
+
+@test "assert-rlms-canary fails when should_run is false and required" {
+  write_status "ok" "false"
+  write_result '{"ok":true,"highlights":["mock_root_complete"],"citations":[{"signal":"semantic_match"}]}'
+
+  run "$PROJECT_ROOT/scripts/assert-rlms-canary.sh" \
+    --status-file "$STATUS_FILE" \
+    --result-file "$RESULT_FILE" \
+    --require-should-run true
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "expected should_run=true" ]]
+}
+
+@test "assert-rlms-canary fails when citation threshold is not met" {
+  write_status "ok" "true"
+  write_result '{"ok":true,"highlights":["mock_root_complete"],"citations":[]}'
+
+  run "$PROJECT_ROOT/scripts/assert-rlms-canary.sh" \
+    --status-file "$STATUS_FILE" \
+    --result-file "$RESULT_FILE" \
+    --min-citations 1
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "citation threshold failed" ]]
+}
+
+@test "assert-rlms-canary fails when only fallback citations are present" {
+  write_status "ok" "true"
+  write_result '{"ok":true,"highlights":["mock_root_complete"],"citations":[{"signal":"file_reference"}]}'
+
+  run "$PROJECT_ROOT/scripts/assert-rlms-canary.sh" \
+    --status-file "$STATUS_FILE" \
+    --result-file "$RESULT_FILE" \
+    --min-citations 1 \
+    --min-non-fallback-citations 1 \
+    --fallback-signals file_reference
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "non-fallback citation threshold failed" ]]
+}
+
+@test "assert-rlms-canary fails when required highlight pattern is missing" {
+  write_status "ok" "true"
+  write_result '{"ok":true,"highlights":["different_highlight"],"citations":[{"signal":"semantic_match"}]}'
+
+  run "$PROJECT_ROOT/scripts/assert-rlms-canary.sh" \
+    --status-file "$STATUS_FILE" \
+    --result-file "$RESULT_FILE" \
+    --require-highlight-pattern "mock_root_complete"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "required highlight pattern not found" ]]
+}


### PR DESCRIPTION
## Summary
- Adds deterministic RLMS canary assertions via `scripts/assert-rlms-canary.sh`.
- Adds deterministic RLMS mock root/subcall scripts for CI-safe canary execution.
- Extends CI with a dedicated `rlms-canary` job that validates config, runs canary, and enforces status/quality thresholds.
- Adds BATS regression coverage for canary assertion pass/fail behavior.
- Adds follow-on feature workflow docs:
  - `feat/rlms-integration/phase2-hardening/PLAN.MD`
  - `feat/rlms-integration/phase2-hardening/tasks/PHASE_1.MD`
- Updates README RLMS docs with canary gate thresholds and usage.

## Feature Workflow Metadata
- Feature Path: `feat/rlms-integration/phase2-hardening/`
- Branch: `feat/rlms-integration/phase2-hardening`
- Scope:
  - `feat/rlms-integration/phase2-hardening/tasks/PHASE_1.MD`

## Validation
- `bats tests/rlms.bats tests/superloop.bats tests/rlms-canary-gate.bats`
- `./scripts/build.sh`
- `./superloop.sh validate --repo .`
- Local CI-path simulation:
  - patched canary runner to local shell
  - executed `./superloop.sh run --repo . --loop rlms-canary`
  - executed `scripts/assert-rlms-canary.sh` on emitted artifacts

Refs #9
