### PR TITLE
Harden CI and add real CLI e2e command coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   repo-hygiene:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Ensure generated/vendor directories are not tracked
         run: |
           set -euo pipefail
@@ -29,32 +39,43 @@ jobs:
 
   secret-scan:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Detect secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   validate:
+    needs: [repo-hygiene, secret-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Build wrapper
         run: ./scripts/build.sh
       - name: Verify generated script is up to date
         run: git diff --exit-code superloop.sh
       - name: Validate config schema
         run: ./superloop.sh validate --repo .
+      - name: Validate static config checks
+        run: ./superloop.sh validate --repo . --static
       - name: List loops
         run: ./superloop.sh list --repo .
 
   rlms-canary:
+    needs: [repo-hygiene, secret-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Build wrapper
         run: ./scripts/build.sh
       - name: Verify generated script is up to date
@@ -112,28 +133,37 @@ jobs:
           cat .superloop/loops/rlms-canary/rlms/latest/reviewer.json
 
   test:
+    needs: [repo-hygiene, secret-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup bats
-        uses: mig4/setup-bats@v1
+        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
         with:
           bats-version: 1.10.0
       - name: Run tests
         run: bats tests/
 
   package-tests:
+    needs: [repo-hygiene, secret-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+      # superloop-viz is deprecated and intentionally excluded from package CI.
       - name: Install dependencies - json-render-core
-        run: cd packages/json-render-core && bun install
+        run: cd packages/json-render-core && bun install --frozen-lockfile
       - name: Install dependencies - json-render-react
-        run: cd packages/json-render-react && bun install
+        run: cd packages/json-render-react && bun install --frozen-lockfile
       - name: Install dependencies - superloop-ui
-        run: cd packages/superloop-ui && bun install
+        run: cd packages/superloop-ui && bun install --frozen-lockfile
       - name: Run tests - json-render-core
         run: cd packages/json-render-core && bun run test:coverage
       - name: Run tests - json-render-react
@@ -141,7 +171,7 @@ jobs:
       - name: Run tests - superloop-ui
         run: cd packages/superloop-ui && bun run test:coverage
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           directory: ./packages/*/coverage
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- harden CI workflow with pinned action SHAs, least-privilege defaults, checkout credential hardening, concurrency, and job timeouts
- update Bun/Codecov action generations and enforce frozen lockfile installs for package tests
- add static config validation to CI
- keep superloop-viz excluded from package CI with explicit deprecation note
- replace simulated e2e checks with real CLI-path tests for cancel, usage, approve, and report

## Validation
- bats tests/e2e/full-loop.bats
- bats tests/rlms-canary-gate.bats
- bats tests/superloop.bats (one pre-existing failure: "list shows configured loops")
