### PR TITLE
Fix secret-scan job without gitleaks action license dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          version="8.30.0"
+          archive="gitleaks_${version}_linux_x64.tar.gz"
+          curl -fsSL -o "$archive" "https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive}"
+          mkdir -p "$RUNNER_TEMP/bin"
+          tar -xzf "$archive" -C "$RUNNER_TEMP/bin" gitleaks
+          chmod +x "$RUNNER_TEMP/bin/gitleaks"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/gitleaks" version
       - name: Detect secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gitleaks dir --redact --verbose --exit-code 1 --no-banner .
 
   validate:
     needs: [repo-hygiene, secret-scan]


### PR DESCRIPTION
## Summary
- replace licensed gitleaks-action usage with OSS gitleaks CLI install
- run filesystem scan via gitleaks dir (license-free)
- keep secret scan gate intact for CI dependency chain

## Why
Current CI fails in secret-scan because gitleaks/gitleaks-action requires GITLEAKS_LICENSE for org repos.

## Validation
- verified command syntax against gitleaks v8.30.0
- verified gitleaks dir --redact --verbose --exit-code 1 --no-banner . runs successfully on repository workspace
