### PR TITLE
fix: avoid false-positive rate-limit detection from generic text

### DIFF
--- a/src/30-runner.sh
+++ b/src/30-runner.sh
@@ -277,18 +277,6 @@ def detect_rate_limit(line):
         info.update(parsed_info)
         return True, info
 
-    # Pattern: usage limit / rate limit errors
-    lower = line.lower()
-    if ('usage' in lower or 'rate' in lower) and 'limit' in lower:
-        if any(word in lower for word in ['reached', 'exceeded', 'error', 'failed', 'hit']):
-            info = {"message": "Rate limit error detected", "type": "generic"}
-            info.update(parsed_info)
-            # Try to extract reset time
-            match = re.search(r'resets?_?(at|in)["\s:]+(\d+)', line, re.IGNORECASE)
-            if match:
-                info["resets_at" if match.group(1).lower() == "at" else "resets_in"] = int(match.group(2))
-            return True, info
-
     return False, {}
 
 

--- a/src/36-usage-limits.sh
+++ b/src/36-usage-limits.sh
@@ -419,16 +419,6 @@ detect_rate_limit_in_line() {
     return 0
   fi
 
-  # Pattern: Claude rate limit
-  if echo "$line" | grep -qi "rate.limit\|usage.limit\|limit.*reached"; then
-    # Avoid false positives from normal usage discussions
-    if echo "$line" | grep -qiE "error|failed|exceeded|hit|reached"; then
-      RATE_LIMIT_DETECTED=1
-      RATE_LIMIT_MESSAGE="Rate limit error detected"
-      return 0
-    fi
-  fi
-
   return 1
 }
 

--- a/superloop.sh
+++ b/superloop.sh
@@ -1926,18 +1926,6 @@ def detect_rate_limit(line):
         info.update(parsed_info)
         return True, info
 
-    # Pattern: usage limit / rate limit errors
-    lower = line.lower()
-    if ('usage' in lower or 'rate' in lower) and 'limit' in lower:
-        if any(word in lower for word in ['reached', 'exceeded', 'error', 'failed', 'hit']):
-            info = {"message": "Rate limit error detected", "type": "generic"}
-            info.update(parsed_info)
-            # Try to extract reset time
-            match = re.search(r'resets?_?(at|in)["\s:]+(\d+)', line, re.IGNORECASE)
-            if match:
-                info["resets_at" if match.group(1).lower() == "at" else "resets_in"] = int(match.group(2))
-            return True, info
-
     return False, {}
 
 
@@ -3950,16 +3938,6 @@ detect_rate_limit_in_line() {
     RATE_LIMIT_DETECTED=1
     RATE_LIMIT_MESSAGE="HTTP 429 Too Many Requests"
     return 0
-  fi
-
-  # Pattern: Claude rate limit
-  if echo "$line" | grep -qi "rate.limit\|usage.limit\|limit.*reached"; then
-    # Avoid false positives from normal usage discussions
-    if echo "$line" | grep -qiE "error|failed|exceeded|hit|reached"; then
-      RATE_LIMIT_DETECTED=1
-      RATE_LIMIT_MESSAGE="Rate limit error detected"
-      return 0
-    fi
   fi
 
   return 1


### PR DESCRIPTION
## Summary
- remove broad generic rate-limit text matching in the runner Python detector
- remove broad shell fallback generic matching for `rate/usage + limit` phrases
- add regression coverage so generic text and historical Superloop log lines do not trigger the rate-limit short-circuit

## Validation
- scripts/build.sh
- bash -n superloop.sh
- ./superloop.sh --help (prints usage; currently exits 1)

## Note
`bats` is not available on this runner, so `tests/runner.bats` was not executed in this environment.
