### PR TITLE
Add enforceable prerequisites gate to Superloop

### DIFF
--- a/.claude/skills/construct-superloop/SKILL.md
+++ b/.claude/skills/construct-superloop/SKILL.md
@@ -268,7 +268,7 @@ The Reviewer decides if the feature is complete:
 Responsibilities:
 1. Read reviewer packet (summary of current state)
 2. Verify requirements are met
-3. Check all gates are green (tests pass, checklists done)
+3. Check all gates are green (tests pass, prerequisites pass when enabled, checklists done)
 4. Write review report
 5. If complete: output <promise>SUPERLOOP_COMPLETE</promise>
 6. If not complete: explain what's missing (triggers next iteration)
@@ -981,6 +981,8 @@ Hard requirements when constructing loops:
 - If `tests.mode` is `every` or `on_promise`, `tests.commands` must include at least one real command.
 - Set `validation.enabled: true` and `validation.require_on_completion: true` unless the user explicitly chooses a looser policy.
 - Include an `automated_checklist.mapping_file` path when validation is enabled, and ensure the file exists.
+- If delivery is phase-gated (PLAN/PHASE artifacts), configure `prerequisites.enabled: true` with concrete checks so execution cannot skip readiness artifacts.
+  - Prefer check types: `markdown_checklist_complete`, `file_regex_absent` (placeholder detection), and `file_contains_all` (required content anchors).
 
 ```json
 {
@@ -1021,6 +1023,11 @@ Hard requirements when constructing loops:
           "enabled": true,
           "mapping_file": ".superloop/validation/<loop-id>-checklist.json"
         }
+      },
+      "prerequisites": {
+        "enabled": false,
+        "require_on_completion": false,
+        "checks": []
       },
       "evidence": {
         "enabled": false,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In Codex, restart after install so new skills are discovered.
 ./superloop.sh run --repo /path/to/repo
 ```
 
-The loop runs until all gates pass: promise emitted, tests pass, checklists complete, evidence exists.
+The loop runs until all gates pass: promise emitted, tests pass, prerequisites pass (when enabled), checklists complete, evidence exists.
 
 ## Feature Initiation (Repository Workflow)
 
@@ -115,6 +115,23 @@ The loop completes when the Reviewer outputs `<promise>COMPLETION_TAG</promise>`
         "enabled": true,
         "mapping_file": ".superloop/validation/my-feature-checklist.json"
       }
+    },
+    "prerequisites": {
+      "enabled": true,
+      "require_on_completion": true,
+      "checks": [
+        {
+          "id": "phase-3-complete",
+          "type": "markdown_checklist_complete",
+          "path": "feat/lab-v0/initiation/tasks/PHASE_3.MD"
+        },
+        {
+          "id": "jtbd-filled",
+          "type": "file_regex_absent",
+          "path": "feat/lab-v0/initiation/USER_SEGMENTS_AND_JTBD.MD",
+          "pattern": "\\\\| US-00[1-3] \\\\|\\\\s*\\\\|"
+        }
+      ]
     },
     "evidence": {
       "enabled": false,
@@ -508,6 +525,7 @@ The loop only completes when ALL gates pass:
 
 - **Promise**: Reviewer outputs exact `completion_promise` tag
 - **Tests**: All test commands exit 0
+- **Prerequisites**: Configured readiness checks pass (if enabled)
 - **Checklists**: All `[ ]` items checked `[x]`
 - **Evidence**: All artifact files exist (with hash verification)
 - **Approval**: Human approval recorded (if enabled)
@@ -522,6 +540,8 @@ implementer.md       # Implementation summary
 test-report.md       # Test analysis
 review.md            # Reviewer assessment
 test-status.json     # Pass/fail status
+prerequisites-status.json # Prerequisites gate status (if enabled)
+prerequisites-results.json # Prerequisite check details (if enabled)
 evidence.json        # Artifact hashes
 gate-summary.txt     # Gate statuses
 events.jsonl         # Event stream

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -333,6 +333,73 @@
             },
             "required": ["enabled", "require_on_completion"]
           },
+          "prerequisites": {
+            "type": "object",
+            "description": "Artifact/readiness checks that must pass before a loop can complete.",
+            "properties": {
+              "enabled": {"type": "boolean"},
+              "require_on_completion": {"type": "boolean"},
+              "checks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "string"},
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "markdown_checklist_complete",
+                        "file_regex_present",
+                        "file_regex_absent",
+                        "file_contains_all",
+                        "file_not_contains_any",
+                        "file_exists",
+                        "file_nonempty"
+                      ]
+                    },
+                    "path": {"type": "string"},
+                    "pattern": {"type": "string"},
+                    "flags": {"type": "string"},
+                    "needles": {
+                      "type": "array",
+                      "items": {"type": "string"}
+                    },
+                    "min_chars": {"type": "integer", "minimum": 0}
+                  },
+                  "required": ["type", "path"],
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {"enum": ["file_regex_present", "file_regex_absent"]}
+                        }
+                      },
+                      "then": {
+                        "required": ["pattern"]
+                      }
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {"enum": ["file_contains_all", "file_not_contains_any"]}
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "needles": {
+                            "type": "array",
+                            "minItems": 1
+                          }
+                        },
+                        "required": ["needles"]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "required": ["enabled", "require_on_completion", "checks"]
+          },
           "evidence": {
             "type": "object",
             "properties": {

--- a/scripts/prerequisite-verifier.js
+++ b/scripts/prerequisite-verifier.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function parseArgs(argv) {
+  const args = { repo: process.cwd(), config: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--repo" && argv[i + 1]) {
+      args.repo = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--config" && argv[i + 1]) {
+      args.config = argv[i + 1];
+      i += 1;
+      continue;
+    }
+  }
+  return args;
+}
+
+function loadConfig(raw) {
+  if (!raw) return null;
+  if (raw.trim().startsWith("{")) {
+    return JSON.parse(raw);
+  }
+  if (fs.existsSync(raw)) {
+    return JSON.parse(fs.readFileSync(raw, "utf8"));
+  }
+  return JSON.parse(raw);
+}
+
+function resolveRepoPath(repo, filePath) {
+  if (!filePath || typeof filePath !== "string") return null;
+  if (path.isAbsolute(filePath)) return filePath;
+  return path.resolve(repo, filePath);
+}
+
+function loadFileOrError(repo, filePath) {
+  const resolved = resolveRepoPath(repo, filePath);
+  if (!resolved) {
+    return { ok: false, reason: "missing_path", resolved: null };
+  }
+  if (!fs.existsSync(resolved)) {
+    return { ok: false, reason: "file_not_found", resolved };
+  }
+  if (!fs.statSync(resolved).isFile()) {
+    return { ok: false, reason: "not_a_file", resolved };
+  }
+  return { ok: true, resolved, content: fs.readFileSync(resolved, "utf8") };
+}
+
+function compileRegex(pattern, flags = "") {
+  try {
+    return { ok: true, regex: new RegExp(pattern, flags) };
+  } catch (error) {
+    return { ok: false, error: `invalid_regex:${error.message}` };
+  }
+}
+
+function runMarkdownChecklistComplete(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+
+  const unchecked = [];
+  const lines = file.content.split(/\r?\n/);
+  let inCodeFence = false;
+
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = lines[idx];
+    if (/^\s*```/.test(line)) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+    if (inCodeFence) continue;
+    if (/\[[ ]\]/.test(line)) {
+      unchecked.push({ line: idx + 1, text: line.trim() });
+    }
+  }
+
+  if (unchecked.length > 0) {
+    return {
+      ok: false,
+      reason: "unchecked_items_remaining",
+      details: { count: unchecked.length, first: unchecked.slice(0, 10) },
+    };
+  }
+
+  return { ok: true };
+}
+
+function runFileRegexPresent(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+  const compiled = compileRegex(check.pattern || "", check.flags || "");
+  if (!compiled.ok) {
+    return { ok: false, reason: compiled.error };
+  }
+  if (!compiled.regex.test(file.content)) {
+    return { ok: false, reason: "pattern_not_found", details: { pattern: check.pattern } };
+  }
+  return { ok: true };
+}
+
+function runFileRegexAbsent(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+  const compiled = compileRegex(check.pattern || "", check.flags || "");
+  if (!compiled.ok) {
+    return { ok: false, reason: compiled.error };
+  }
+  if (compiled.regex.test(file.content)) {
+    return { ok: false, reason: "pattern_present", details: { pattern: check.pattern } };
+  }
+  return { ok: true };
+}
+
+function runFileContainsAll(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+  const needles = Array.isArray(check.needles) ? check.needles : [];
+  const missing = needles.filter((needle) => typeof needle === "string" && !file.content.includes(needle));
+  if (missing.length > 0) {
+    return { ok: false, reason: "missing_required_content", details: { missing } };
+  }
+  return { ok: true };
+}
+
+function runFileNotContainsAny(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+  const needles = Array.isArray(check.needles) ? check.needles : [];
+  const present = needles.filter((needle) => typeof needle === "string" && file.content.includes(needle));
+  if (present.length > 0) {
+    return { ok: false, reason: "forbidden_content_present", details: { present } };
+  }
+  return { ok: true };
+}
+
+function runFileExists(check, repo) {
+  const resolved = resolveRepoPath(repo, check.path);
+  if (!resolved || !fs.existsSync(resolved)) {
+    return { ok: false, reason: "file_not_found", details: { path: check.path } };
+  }
+  return { ok: true };
+}
+
+function runFileNonempty(check, repo) {
+  const file = loadFileOrError(repo, check.path);
+  if (!file.ok) {
+    return { ok: false, reason: file.reason, details: { path: check.path } };
+  }
+  const minChars = Number.isFinite(check.min_chars) ? Math.max(0, check.min_chars) : 1;
+  const size = file.content.trim().length;
+  if (size < minChars) {
+    return { ok: false, reason: "file_too_short", details: { size, min_chars: minChars } };
+  }
+  return { ok: true };
+}
+
+function runCheck(check, repo) {
+  if (!check || typeof check !== "object") {
+    return { ok: false, reason: "invalid_check" };
+  }
+
+  switch (check.type) {
+    case "markdown_checklist_complete":
+      return runMarkdownChecklistComplete(check, repo);
+    case "file_regex_present":
+      return runFileRegexPresent(check, repo);
+    case "file_regex_absent":
+      return runFileRegexAbsent(check, repo);
+    case "file_contains_all":
+      return runFileContainsAll(check, repo);
+    case "file_not_contains_any":
+      return runFileNotContainsAny(check, repo);
+    case "file_exists":
+      return runFileExists(check, repo);
+    case "file_nonempty":
+      return runFileNonempty(check, repo);
+    default:
+      return { ok: false, reason: `unsupported_check_type:${check.type || "unknown"}` };
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  let config;
+  try {
+    config = loadConfig(args.config);
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        ok: false,
+        error: "invalid_config",
+        message: error.message,
+      })
+    );
+    process.exit(1);
+  }
+
+  const checks = Array.isArray(config?.checks) ? config.checks : [];
+  const verified = [];
+  const failed = [];
+
+  for (let i = 0; i < checks.length; i += 1) {
+    const check = checks[i] || {};
+    const id =
+      (typeof check.id === "string" && check.id.length > 0 && check.id) ||
+      `${check.type || "unknown"}:${check.path || i}`;
+
+    let result;
+    try {
+      result = runCheck(check, args.repo);
+    } catch (error) {
+      result = { ok: false, reason: `check_runtime_error:${error.message}` };
+    }
+
+    if (result.ok) {
+      verified.push(id);
+    } else {
+      failed.push({
+        id,
+        type: check.type || "unknown",
+        path: check.path || null,
+        reason: result.reason || "unknown_error",
+        details: result.details || null,
+      });
+    }
+  }
+
+  const output = {
+    ok: failed.length === 0,
+    generated_at: new Date().toISOString(),
+    total: checks.length,
+    passed: verified.length,
+    verified,
+    failed,
+  };
+
+  console.log(JSON.stringify(output));
+  process.exit(output.ok ? 0 : 1);
+}
+
+main();

--- a/src/00-header.sh
+++ b/src/00-header.sh
@@ -47,7 +47,7 @@ Options:
 Notes:
 - This wrapper runs the configured runner in a multi-role loop (planner, implementer, tester, reviewer).
 - The loop stops only when the reviewer outputs a matching promise AND gates pass.
-- Gates: checklists, tests, validation, evidence, and optional approval (per config).
+- Gates: tests, validation, prerequisites, checklists, evidence, and optional approval (per config).
 USAGE
 }
 

--- a/src/40-gates.sh
+++ b/src/40-gates.sh
@@ -123,12 +123,13 @@ write_iteration_notes() {
   local promise_matched="$4"
   local tests_status="$5"
   local validation_status="$6"
-  local checklist_status="$7"
-  local tests_mode="$8"
-  local evidence_status="${9:-}"
-  local stuck_streak="${10:-}"
-  local stuck_threshold="${11:-}"
-  local approval_status="${12:-}"
+  local prerequisites_status="$7"
+  local checklist_status="$8"
+  local tests_mode="$9"
+  local evidence_status="${10:-}"
+  local stuck_streak="${11:-}"
+  local stuck_threshold="${12:-}"
+  local approval_status="${13:-}"
 
   cat <<EOF > "$notes_file"
 Iteration: $iteration
@@ -136,6 +137,7 @@ Loop: $loop_id
 Promise matched: $promise_matched
 Tests: $tests_status (mode: $tests_mode)
 Validation: ${validation_status:-skipped}
+Prerequisites: ${prerequisites_status:-skipped}
 Checklist: $checklist_status
 Evidence: ${evidence_status:-skipped}
 Approval: ${approval_status:-skipped}
@@ -153,13 +155,14 @@ write_gate_summary() {
   local promise_matched="$2"
   local tests_status="$3"
   local validation_status="$4"
-  local checklist_status="$5"
-  local evidence_status="$6"
-  local stuck_status="$7"
-  local approval_status="${8:-skipped}"
+  local prerequisites_status="$5"
+  local checklist_status="$6"
+  local evidence_status="$7"
+  local stuck_status="$8"
+  local approval_status="${9:-skipped}"
 
-  printf 'promise=%s tests=%s validation=%s checklist=%s evidence=%s stuck=%s approval=%s\n' \
-    "$promise_matched" "$tests_status" "$validation_status" "$checklist_status" "$evidence_status" "$stuck_status" "$approval_status" \
+  printf 'promise=%s tests=%s validation=%s prerequisites=%s checklist=%s evidence=%s stuck=%s approval=%s\n' \
+    "$promise_matched" "$tests_status" "$validation_status" "$prerequisites_status" "$checklist_status" "$evidence_status" "$stuck_status" "$approval_status" \
     > "$summary_file"
 }
 
@@ -191,14 +194,15 @@ write_approval_request() {
   local promise_matched="$9"
   local tests_status="${10}"
   local validation_status="${11}"
-  local checklist_status="${12}"
-  local evidence_status="${13}"
-  local gate_summary_file="${14}"
-  local evidence_file="${15}"
-  local reviewer_report="${16}"
-  local test_report="${17}"
-  local plan_file="${18}"
-  local notes_file="${19}"
+  local prerequisites_status="${12}"
+  local checklist_status="${13}"
+  local evidence_status="${14}"
+  local gate_summary_file="${15}"
+  local evidence_file="${16}"
+  local reviewer_report="${17}"
+  local test_report="${18}"
+  local plan_file="${19}"
+  local notes_file="${20}"
 
   local promise_matched_json="false"
   if [[ "$promise_matched" == "true" ]]; then
@@ -218,6 +222,7 @@ write_approval_request() {
     --argjson promise_matched "$promise_matched_json" \
     --arg tests_status "$tests_status" \
     --arg validation_status "$validation_status" \
+    --arg prerequisites_status "$prerequisites_status" \
     --arg checklist_status "$checklist_status" \
     --arg evidence_status "$evidence_status" \
     --arg gate_summary_file "$gate_summary_file" \
@@ -243,6 +248,7 @@ write_approval_request() {
         gates: {
           tests: $tests_status,
           validation: $validation_status,
+          prerequisites: $prerequisites_status,
           checklist: $checklist_status,
           evidence: $evidence_status
         }


### PR DESCRIPTION
## Summary
- add a first-class `prerequisites` gate to loop config schema
- execute prerequisites checks during run lifecycle and surface gate status in summaries/events/approval payloads
- add static validation for prerequisites config correctness
- add `scripts/prerequisite-verifier.js` with file/checklist predicates
- update construct-superloop skill guidance and docs
- add tests for gate output and verifier behavior

## Validation
- `./scripts/build.sh`
- `bash -n src/*.sh`
- `node --check scripts/prerequisite-verifier.js`
- `./superloop.sh validate --repo . --schema schema/config.schema.json --static`

## Notes
- `bats` CLI is not available in this environment, so BATS tests were not executed here.
