### PR TITLE
feat(initiation): dev env contract v1

### DIFF
--- a/feat/dev-env-contract-v1/initiation/PLAN.MD
+++ b/feat/dev-env-contract-v1/initiation/PLAN.MD
@@ -1,0 +1,58 @@
+# dev-env-contract-v1: Initiation Plan
+
+## Goal
+
+Define a Superloop-owned local execution environment contract for cross-repo orchestration, then wire constructor-facing guidance so both Claude Code and Codex consistently emit and consume that contract.
+
+## Scope
+
+- Define canonical variable names, precedence rules, and fallback policy for dev and lab execution URLs/ports.
+- Update constructor/skill guidance to require the contract during loop construction.
+- Provide target-repo adapter onboarding guidance for repos that currently use product-specific env keys.
+- Add rollout guardrails to prevent new hardcoded localhost/port assumptions.
+
+## Non-Goals (this iteration)
+
+- Migrating every existing target repository in this single PR.
+- Removing all legacy env aliases immediately.
+- Changing hosted production runtime configuration.
+
+## Primary References
+
+- `handbook/features/INITIATION.MD`
+- `.claude/skills/construct-superloop/SKILL.md`
+- `.claude/skills/local-dev-stack/SKILL.md`
+- `.claude/skills/feature-initiation/SKILL.md`
+- `README.md`
+
+## Architecture
+
+1. Superloop defines canonical contract keys (`SUPERLOOP_DEV_BASE_URL`, `SUPERLOOP_LAB_BASE_URL`, optional `SUPERLOOP_DEV_PORT`) and precedence behavior.
+2. `/construct-superloop` guidance treats these keys as orchestration-level inputs independent of target product naming.
+3. Target repos consume the contract through adapter patches (dual-read canonical + legacy keys during migration).
+4. Validation and rollout docs enforce one contract source and explicit exception handling for raw localhost tests.
+
+## Decisions
+
+- Namespace ownership follows orchestration ownership (`SUPERLOOP_*`) rather than any single target product.
+- Constructor guidance remains runner-agnostic and explicitly applies to both Claude Code and Codex.
+- Migration uses compatibility aliases first, then deprecates legacy prefixes after adoption criteria are met.
+
+## Risks / Constraints
+
+- Inconsistent env naming across target repos can cause silent run divergence.
+- Overly aggressive enforcement can break legitimate raw-localhost diagnostic flows.
+- Skill/docs drift can reintroduce contract ambiguity if not validated in rollout checks.
+
+## Gate Baseline
+
+- Tests mode: N/A (documentation/policy initiation)
+- Tests commands: N/A for initiation packet
+- Validation require on completion: N/A
+- Validation checklist mapping file: N/A
+
+## Phases
+
+- **Phase 1**: Contract v1 specification and constructor skill alignment.
+- **Phase 2**: Target-repo adapter onboarding kit and migration guidance.
+- **Phase 3**: Enforcement guardrails, rollout sequencing, and deprecation policy.

--- a/feat/dev-env-contract-v1/initiation/tasks/PHASE_1.MD
+++ b/feat/dev-env-contract-v1/initiation/tasks/PHASE_1.MD
@@ -1,0 +1,23 @@
+# Phase 1 - Contract v1 And Constructor Alignment
+
+## P1.1 Contract Specification
+
+1. [ ] Add a contract document in `docs/` defining canonical env keys and meanings.
+2. [ ] Define strict resolution order (canonical -> legacy/product-specific -> generic -> explicit fallback).
+3. [ ] Document approved localhost fallback exceptions and when they are allowed.
+
+## P1.2 Constructor Skill Integration
+
+1. [ ] Update `.claude/skills/construct-superloop/SKILL.md` to require contract awareness during loop construction.
+2. [ ] Ensure the skill explicitly states runner parity for Claude Code and Codex in contract handling guidance.
+3. [ ] Ensure skill references to companion skills remain current and non-contradictory.
+
+## P1.3 Local Dev Skill Alignment
+
+1. [ ] Update `.claude/skills/local-dev-stack/SKILL.md` with canonical contract keys and migration alias behavior.
+2. [ ] Cross-link to the contract spec from relevant skill sections.
+
+## P1.V Validation
+
+1. [ ] Validate all new contract and skill references resolve to existing paths.
+2. [ ] Verify no contradictory variable ordering between skill docs.

--- a/feat/dev-env-contract-v1/initiation/tasks/PHASE_2.MD
+++ b/feat/dev-env-contract-v1/initiation/tasks/PHASE_2.MD
@@ -1,0 +1,22 @@
+# Phase 2 - Target Repo Adapter Kit
+
+## P2.1 Adapter Onboarding Guide
+
+1. [ ] Create a target-repo onboarding guide that describes minimal adapter patch requirements.
+2. [ ] Include required touch points (`.envrc`, `devenv.nix`, dev wrappers, verification scripts).
+3. [ ] Document compatibility strategy for legacy/product-specific env names.
+
+## P2.2 Constructor Output Expectations
+
+1. [ ] Define what `/construct-superloop` should verify before declaring a target repo contract-ready.
+2. [ ] Specify required evidence artifacts for contract adoption in a target repo.
+
+## P2.3 Examples
+
+1. [ ] Add one concrete migration example from product-specific naming to canonical naming.
+2. [ ] Add one exception example for intentionally raw localhost test scripts.
+
+## P2.V Validation
+
+1. [ ] Confirm onboarding checklist is executable as-is by an engineer unfamiliar with this repo.
+2. [ ] Confirm examples match the canonical contract spec language exactly.

--- a/feat/dev-env-contract-v1/initiation/tasks/PHASE_3.MD
+++ b/feat/dev-env-contract-v1/initiation/tasks/PHASE_3.MD
@@ -1,0 +1,23 @@
+# Phase 3 - Enforcement, Rollout, Deprecation
+
+## P3.1 Enforcement Strategy
+
+1. [ ] Define automated checks to flag new hardcoded localhost/port assumptions in orchestration-critical scripts.
+2. [ ] Define explicit allowlist criteria and ownership for exceptions.
+3. [ ] Document failure handling when contract violations are detected.
+
+## P3.2 Rollout Plan
+
+1. [ ] Define phased rollout order (pilot repos -> broader target set).
+2. [ ] Define entry/exit criteria for each rollout wave.
+3. [ ] Define rollback procedure for contract-related regressions.
+
+## P3.3 Deprecation Policy
+
+1. [ ] Define objective criteria for removing legacy aliases after adoption.
+2. [ ] Define communication and timeline requirements before alias removal.
+
+## P3.V Validation
+
+1. [ ] Verify rollout/deprecation criteria are testable and unambiguous.
+2. [ ] Ensure the initiation issue scope links all phase files and current PR links.


### PR DESCRIPTION
Refs #30

## Summary
- add initiation packet at `feat/dev-env-contract-v1/initiation/`
- add `PLAN.MD` for canonical Superloop env contract ownership
- add phase task files:
  - `tasks/PHASE_1.MD`
  - `tasks/PHASE_2.MD`
  - `tasks/PHASE_3.MD`

## Scope
- planning and task scaffolding only (no runtime behavior changes in this PR)