### PR TITLE
feat(dev-env): phase 2/3 adapter kit and guardrails

### DIFF
--- a/.claude/skills/construct-superloop/SKILL.md
+++ b/.claude/skills/construct-superloop/SKILL.md
@@ -42,8 +42,14 @@ Constructor should be environment-aware but not environment-dependent:
 - Assume local baseline is `devenv` + `direnv` + `portless`.
 - Prefer wrapper commands and env-based URLs in guidance.
 - Treat `SUPERLOOP_DEV_BASE_URL`, `SUPERLOOP_VERIFY_BASE_URL`, and `SUPERLOOP_DEV_PORT` as canonical orchestration-level local env keys.
+- For cross-repo loops, require a target adapter manifest path (`.superloop/dev-env/adapter.manifest.json`) or create-task for it.
+- Require explicit adapter mapping mode per target: `canonical_only` or `canonical_with_aliases`.
 - For migrations, allow legacy target-repo aliases only as compatibility notes.
 - When a spec references local execution evidence, require explicit variable precedence: canonical `SUPERLOOP_*` first, then legacy alias, then approved fallback.
+- Require readiness evidence planning for:
+  - `script_resolution_proof`
+  - `runbook_alignment_proof`
+  - `guardrail_check_proof`
 - Do not make acceptance criteria require local stack tools as mandatory.
 - Preserve fallback compatibility (`PORTLESS=0`) and CI-localhost contracts unless scope explicitly changes them.
 

--- a/.claude/skills/local-dev-stack/SKILL.md
+++ b/.claude/skills/local-dev-stack/SKILL.md
@@ -68,6 +68,19 @@ Resolution order should be:
 
 See `docs/dev-env-contract-v1.md` for the full contract.
 
+## Target Adapter Readiness
+
+For target repos adopting the contract, require:
+
+1. Target adapter manifest at `.superloop/dev-env/adapter.manifest.json`.
+2. Manifest mode declaration: `canonical_only` or `canonical_with_aliases`.
+3. Evidence coverage for:
+   - `script_resolution_proof`
+   - `runbook_alignment_proof`
+   - `guardrail_check_proof`
+
+If a target has no active alias usage, set mode to `canonical_only` and keep this explicit in the manifest and runbook packet.
+
 ## Escape Hatches
 
 The baseline must remain optional for compatibility and incident response.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: ./superloop.sh runner-smoke --repo .
       - name: Validate static config checks
         run: ./superloop.sh validate --repo . --static
+      - name: Validate core decoupling
+        run: scripts/check-core-decoupling.sh
       - name: List loops
         run: ./superloop.sh list --repo .
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Use `PORTLESS=0` to bypass proxy routing temporarily.
 Cross-repo env contract:
 
 - Canonical local execution env keys are documented in `docs/dev-env-contract-v1.md`.
+- Target adoption contract (manifest + evidence) is documented in `docs/dev-env-target-adapter.md`.
+- Rollout/deprecation policy is documented in `docs/dev-env-rollout-v1.md`.
 - New loop construction should prefer `SUPERLOOP_*` keys; target-repo aliases are fallback-only during migration.
 - Use `scripts/check-core-decoupling.sh` to ensure core paths stay target-agnostic.
 

--- a/docs/dev-env-contract-v1.md
+++ b/docs/dev-env-contract-v1.md
@@ -2,6 +2,12 @@
 
 This document defines the canonical local execution environment contract for Superloop orchestration across target repositories.
 
+Related references:
+
+- `docs/dev-env-target-adapter.md`
+- `docs/dev-env-rollout-v1.md`
+- `schema/dev-env-target-adapter.schema.json`
+
 ## Contract Owner
 
 Superloop owns this contract. Target repositories implement adapters to consume it.
@@ -33,6 +39,35 @@ When reading dev/verify URL or port values in Superloop-aware scripts:
 - Legacy aliases remain supported until rollout criteria are met.
 - Constructor and local-dev skills must treat `SUPERLOOP_*` keys as canonical during new loop construction.
 
+## Target Adapter Manifest
+
+Target repositories adopt this contract through an adapter manifest:
+
+- Canonical runtime path: `.superloop/dev-env/adapter.manifest.json`
+- Schema: `schema/dev-env-target-adapter.schema.json`
+- Authoring guide: `docs/dev-env-target-adapter.md`
+
+Manifest mode options:
+
+1. `canonical_only`
+2. `canonical_with_aliases`
+
+## Required Readiness Evidence
+
+Each target adoption must plan and capture these artifacts:
+
+1. `script_resolution_proof`
+2. `runbook_alignment_proof`
+3. `guardrail_check_proof`
+
+See `docs/dev-env-target-adapter.md` for definitions and expected packet contents.
+
+## Rollout And Deprecation
+
+Wave sequencing, entry/exit criteria, failure handling, and alias-removal policy live in:
+
+- `docs/dev-env-rollout-v1.md`
+
 ## Allowed Localhost Exceptions
 
 Hardcoded localhost fallbacks are allowed only for scripts that intentionally validate raw-port local runtime behavior.
@@ -42,5 +77,6 @@ Hardcoded localhost fallbacks are allowed only for scripts that intentionally va
 `/construct-superloop` guidance should:
 
 1. Require canonical `SUPERLOOP_*` env contract awareness for target repos.
-2. Require adapter notes when target repos still use legacy naming.
-3. Keep runner parity across Claude Code and Codex.
+2. Require a target adapter manifest path and mapping mode (or an explicit follow-on task to create it).
+3. Require readiness evidence planning for script, runbook, and guardrail proofs.
+4. Keep runner parity across Claude Code and Codex.

--- a/docs/dev-env-rollout-v1.md
+++ b/docs/dev-env-rollout-v1.md
@@ -1,0 +1,52 @@
+# Dev Env Contract Rollout v1
+
+This document defines rollout and deprecation policy for adopting the canonical Superloop local env contract across target repositories.
+
+## Rollout Waves
+
+1. Wave 1: Supergent pilot
+   - entry: canonical keys available and adapter manifest committed.
+   - exit: required evidence artifacts complete and stable.
+2. Wave 2: one non-Supergent target
+   - entry: Wave 1 exit met and constructor guidance updated.
+   - exit: successful canonical or alias mode adoption in external target.
+3. Wave 3: remaining prioritized target repos
+   - entry: Wave 2 exit met.
+   - exit: all active targets declare mapping mode and pass guardrails.
+
+## Entry Criteria (Per Target)
+
+1. `.superloop/dev-env/adapter.manifest.json` exists and validates against `schema/dev-env-target-adapter.schema.json`.
+2. Target scripts resolve canonical contract keys first.
+3. Evidence plan includes required artifacts.
+
+## Exit Criteria (Per Target)
+
+1. `script_resolution_proof` captured.
+2. `runbook_alignment_proof` captured.
+3. `guardrail_check_proof` captured.
+4. No unresolved contract drift findings.
+
+## Failure Handling
+
+If adoption fails:
+
+1. Keep target on current mapping mode.
+2. Revert only adapter-layer changes for the target.
+3. Preserve canonical contract in Superloop core (do not rollback core naming).
+
+## Alias Deprecation Policy
+
+Legacy aliases can be removed only when all are true:
+
+1. Target is running in `canonical_only` mode for one completed rollout wave.
+2. No open incidents linked to local env contract.
+3. Constructor packets for the target no longer emit alias paths.
+
+## Communication Requirements
+
+Before alias removal in a target repo:
+
+1. Publish migration notice with exact key changes and effective date.
+2. Include rollback instructions and owner contacts.
+3. Keep one tagged commit for quick rollback to alias-compatible mode.

--- a/docs/dev-env-target-adapter.md
+++ b/docs/dev-env-target-adapter.md
@@ -1,0 +1,65 @@
+# Dev Env Target Adapter Contract
+
+This document defines how target repositories declare adoption of the canonical Superloop local env contract.
+
+## Purpose
+
+Keep Superloop core target-agnostic while allowing each target repository to map canonical keys to local conventions safely.
+
+## Manifest Schema
+
+- Schema file: `schema/dev-env-target-adapter.schema.json`
+- Version: `v1`
+
+The manifest should live inside the target repo at:
+
+- `.superloop/dev-env/adapter.manifest.json`
+
+## Required Fields
+
+1. `target.id` and `target.repoPath`
+2. Canonical contract keys:
+   - `SUPERLOOP_DEV_BASE_URL`
+   - `SUPERLOOP_VERIFY_BASE_URL`
+   - `SUPERLOOP_DEV_PORT`
+3. Mapping mode:
+   - `canonical_only`
+   - `canonical_with_aliases`
+4. Required evidence artifacts list
+
+## Mapping Modes
+
+1. `canonical_only`
+   - Use only canonical keys.
+   - Missing canonical keys should fail fast with explicit errors.
+2. `canonical_with_aliases`
+   - Resolve canonical keys first.
+   - Resolve target-repo aliases second.
+   - Keep explicit fallback behavior documented.
+
+## Required Readiness Evidence
+
+Each target adoption should include evidence proving:
+
+1. `script_resolution_proof`
+   - dev and verification scripts resolve canonical keys first.
+2. `runbook_alignment_proof`
+   - runbooks and gate docs match script resolution order.
+3. `guardrail_check_proof`
+   - hardcoding/decoupling checks pass.
+
+## Constructor Requirements
+
+`/construct-superloop` should require the adapter manifest (or create-task for it) before treating target-repo local execution as contract-ready.
+
+Minimum constructor outputs for target readiness:
+
+1. Manifest path.
+2. Mapping mode.
+3. Evidence artifact plan for the three required proofs.
+4. Explicit note when aliases are not used (`canonical_only` mode).
+
+## Examples
+
+- Canonical-only example: `docs/examples/dev-env-target-adapter.canonical.json`
+- Alias-compatible example: `docs/examples/dev-env-target-adapter.aliases.json`

--- a/docs/examples/dev-env-target-adapter.aliases.json
+++ b/docs/examples/dev-env-target-adapter.aliases.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "v1",
+  "target": {
+    "id": "target-repo",
+    "repoPath": "/path/to/target-repo"
+  },
+  "contract": {
+    "devBaseUrl": "SUPERLOOP_DEV_BASE_URL",
+    "verifyBaseUrl": "SUPERLOOP_VERIFY_BASE_URL",
+    "devPort": "SUPERLOOP_DEV_PORT"
+  },
+  "mappings": {
+    "mode": "canonical_with_aliases",
+    "fallbackAliases": [
+      {
+        "canonical": "SUPERLOOP_DEV_BASE_URL",
+        "alias": "TARGET_BASE_URL"
+      },
+      {
+        "canonical": "SUPERLOOP_VERIFY_BASE_URL",
+        "alias": "TARGET_VERIFY_BASE_URL"
+      },
+      {
+        "canonical": "SUPERLOOP_DEV_PORT",
+        "alias": "TARGET_DEV_PORT"
+      }
+    ]
+  },
+  "evidence": {
+    "requiredArtifacts": [
+      "script_resolution_proof",
+      "runbook_alignment_proof",
+      "guardrail_check_proof"
+    ]
+  }
+}

--- a/docs/examples/dev-env-target-adapter.canonical.json
+++ b/docs/examples/dev-env-target-adapter.canonical.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "v1",
+  "target": {
+    "id": "target-repo",
+    "repoPath": "/path/to/target-repo"
+  },
+  "contract": {
+    "devBaseUrl": "SUPERLOOP_DEV_BASE_URL",
+    "verifyBaseUrl": "SUPERLOOP_VERIFY_BASE_URL",
+    "devPort": "SUPERLOOP_DEV_PORT"
+  },
+  "mappings": {
+    "mode": "canonical_only",
+    "fallbackAliases": []
+  },
+  "evidence": {
+    "requiredArtifacts": [
+      "script_resolution_proof",
+      "runbook_alignment_proof",
+      "guardrail_check_proof"
+    ]
+  }
+}

--- a/feat/dev-env-contract-v1/phase-2-3-adapter-guardrails/PLAN.MD
+++ b/feat/dev-env-contract-v1/phase-2-3-adapter-guardrails/PLAN.MD
@@ -1,0 +1,31 @@
+# dev-env-contract-v1: Phase 2-3 Adapter Kit + Guardrails
+
+## Goal
+
+Complete phase-2/phase-3 rollout for the Superloop dev env contract by shipping target adapter onboarding artifacts, constructor readiness requirements, and enforceable core decoupling guardrails.
+
+## Scope
+
+- Add target adapter manifest contract documentation and schema.
+- Add constructor readiness/evidence requirements for adapter adoption.
+- Add rollout + deprecation policy guidance.
+- Enforce core-path decoupling in CI.
+
+## Non-Goals
+
+- Full migration of every external target repo in this change.
+- Removing legacy aliases in all targets immediately.
+
+## References
+
+- `feat/dev-env-contract-v1/initiation/PLAN.MD`
+- `docs/dev-env-contract-v1.md`
+- `.claude/skills/construct-superloop/SKILL.md`
+- `.claude/skills/local-dev-stack/SKILL.md`
+- `scripts/check-core-decoupling.sh`
+- `.github/workflows/ci.yml`
+
+## Phases
+
+- Phase 2: Adapter manifest + constructor readiness contract.
+- Phase 3: CI enforcement + rollout/deprecation policy.

--- a/feat/dev-env-contract-v1/phase-2-3-adapter-guardrails/tasks/PHASE_1.MD
+++ b/feat/dev-env-contract-v1/phase-2-3-adapter-guardrails/tasks/PHASE_1.MD
@@ -1,0 +1,27 @@
+# PHASE 1: Adapter Kit And Guardrails
+
+## P1.1 Adapter Contract
+
+1. [x] Add target adapter manifest documentation and schema.
+2. [x] Add examples for canonical-only and legacy-alias modes.
+3. [x] Document required readiness evidence artifacts.
+
+## P1.2 Constructor And Skill Alignment
+
+1. [x] Update constructor guidance to require adapter manifest/readiness checks.
+2. [x] Update local-dev skill guidance for adapter contract usage.
+
+## P1.3 Enforcement
+
+1. [x] Integrate core decoupling check into CI workflow.
+2. [x] Document violation handling and operator remediation path.
+
+## P1.4 Rollout + Deprecation
+
+1. [x] Add rollout wave policy and entry/exit criteria.
+2. [x] Add alias deprecation policy and rollback procedure.
+
+## P1.V Validation
+
+1. [x] Run syntax and decoupling checks.
+2. [x] Verify docs/skills reference existing files and schema paths.

--- a/schema/dev-env-target-adapter.schema.json
+++ b/schema/dev-env-target-adapter.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://superloop.sh/schemas/dev-env-target-adapter-v1.json",
+  "title": "DevEnvTargetAdapterV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "target",
+    "contract",
+    "mappings",
+    "evidence"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repoPath"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repoPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "devBaseUrl",
+        "verifyBaseUrl",
+        "devPort"
+      ],
+      "properties": {
+        "devBaseUrl": {
+          "type": "string",
+          "const": "SUPERLOOP_DEV_BASE_URL"
+        },
+        "verifyBaseUrl": {
+          "type": "string",
+          "const": "SUPERLOOP_VERIFY_BASE_URL"
+        },
+        "devPort": {
+          "type": "string",
+          "const": "SUPERLOOP_DEV_PORT"
+        }
+      }
+    },
+    "mappings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "fallbackAliases"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "canonical_only",
+            "canonical_with_aliases"
+          ]
+        },
+        "fallbackAliases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "canonical",
+              "alias"
+            ],
+            "properties": {
+              "canonical": {
+                "type": "string",
+                "enum": [
+                  "SUPERLOOP_DEV_BASE_URL",
+                  "SUPERLOOP_VERIFY_BASE_URL",
+                  "SUPERLOOP_DEV_PORT"
+                ]
+              },
+              "alias": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requiredArtifacts"
+      ],
+      "properties": {
+        "requiredArtifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "script_resolution_proof",
+              "runbook_alignment_proof",
+              "guardrail_check_proof"
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #35

## Summary
- add target adapter schema, docs, and canonical/alias examples
- wire constructor + local-dev skills to adapter readiness/evidence requirements
- add rollout/deprecation policy and enforce core decoupling check in CI

## Validation
- `./scripts/build.sh`
- `./superloop.sh validate --repo . --static`
- `scripts/check-core-decoupling.sh`
- `jq` validation for schema/examples