### PR TITLE
fix(ci): decoupling check fallback when rg is unavailable

### DIFF
--- a/scripts/check-core-decoupling.sh
+++ b/scripts/check-core-decoupling.sh
@@ -16,19 +16,31 @@ CORE_PATHS=(
 # Product-specific env names or lab-specific canonical keys are not allowed in core paths.
 PATTERN='SUPERGENT_|SUPERLOOP_LAB_BASE_URL|supergent\.localhost|lab\.supergent'
 
-if ! command -v rg >/dev/null 2>&1; then
-  echo "error: rg is required for decoupling check" >&2
-  exit 2
+if command -v rg >/dev/null 2>&1; then
+  SEARCH_TOOL="rg"
+else
+  SEARCH_TOOL="grep"
 fi
 
 cd "$ROOT_DIR"
+
+search_path_for_pattern() {
+  local path="$1"
+  if [[ "$SEARCH_TOOL" == "rg" ]]; then
+    rg -n -S -e "$PATTERN" "$path" || true
+  else
+    grep -n -R -E "$PATTERN" "$path" 2>/dev/null || true
+  fi
+}
 
 FOUND=0
 for path in "${CORE_PATHS[@]}"; do
   if [[ ! -e "$path" ]]; then
     continue
   fi
-  if rg -n -S -e "$PATTERN" "$path"; then
+  matches="$(search_path_for_pattern "$path")"
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches"
     FOUND=1
   fi
 done


### PR DESCRIPTION
Closes #36

## Summary
- make `scripts/check-core-decoupling.sh` auto-select `rg` when available and fallback to recursive `grep` when not
- preserve same decoupling pattern checks and failure behavior

## Validation
- `bash -n scripts/check-core-decoupling.sh`
- `scripts/check-core-decoupling.sh`
- `PATH=/usr/bin:/bin scripts/check-core-decoupling.sh`