### PR TITLE
feat: initiation packet for ops manager + superloop + sprites

### DIFF
--- a/docs/ops-manager-dogfood-rollout.md
+++ b/docs/ops-manager-dogfood-rollout.md
@@ -1,0 +1,64 @@
+# Ops Manager Dogfood Rollout Plan
+
+## Audience
+First adopter persona:
+- internal Supergent/Superloop builders operating loop runs in Sprite sandboxes
+
+## Stage 0: Contract Readiness
+Goal:
+- finalize `v1` envelope schema and adapter behavior
+
+Acceptance criteria:
+- snapshot and event adapters emit schema-consistent envelopes
+- cursor behavior is monotonic and fail-closed
+- required artifacts and failure modes are documented
+
+Fallback:
+- direct runtime inspection via `.superloop/` files and existing CLI commands
+
+## Stage 1: Passive Visibility
+Goal:
+- ops manager reads snapshot + events and renders lifecycle without sending controls
+
+Acceptance criteria:
+- manager lifecycle projection matches runtime truth on sampled runs
+- pending approval and terminal states are surfaced accurately
+- divergence detection triggers on inconsistent signals
+
+Fallback:
+- disable event stream consumption and use snapshot-only mode
+
+## Stage 2: Assisted Control
+Goal:
+- manager can issue controlled interventions with confirmation loop
+
+Acceptance criteria:
+- cancel and approval intents are reflected in runtime artifacts
+- manager requires post-intent confirmation before marking success
+- failed or ambiguous control attempts escalate to operator review
+
+Fallback:
+- revert control execution to manual CLI usage while keeping passive visibility
+
+## Stage 3: Sprite Service Integration
+Goal:
+- bind manager ingestion to sprite service APIs while keeping contract invariant
+
+Acceptance criteria:
+- transport swap does not change envelope schema
+- service path parity with pull path for lifecycle outcomes
+- error budget and retry behavior defined for service outages
+
+Fallback:
+- return to pull-based adapters for impacted sprites
+
+## Rollback Rules
+Rollback is required when any of the following occurs:
+- cursor regression causes ambiguous event ordering
+- manager marks control success without runtime confirmation
+- lifecycle projection disagrees with runtime artifacts beyond defined tolerance
+
+Rollback behavior:
+1. disable active control intents
+2. continue passive snapshot visibility only
+3. open incident note with artifact evidence and last known good cursor

--- a/docs/ops-manager-sprite-integration.md
+++ b/docs/ops-manager-sprite-integration.md
@@ -1,0 +1,65 @@
+# Ops Manager + Sprite Integration Boundaries
+
+## Default Isolation
+V0 default:
+- one loop run per sprite VM
+
+Rationale:
+- deterministic troubleshooting
+- simpler blast-radius and lifecycle ownership
+- cleaner event/cursor semantics per runtime
+
+## Boundary Model
+
+### Inside Sprite
+- Superloop runtime executes loop logic.
+- Runtime writes artifacts under `.superloop/`.
+- Optional sprite-local service endpoint can expose adapter outputs.
+
+### Outside Sprite (Ops Manager)
+- Polls or receives adapter envelopes.
+- Projects manager lifecycle state.
+- Issues control intents through approved control path.
+
+## Integration Paths
+
+1. Pull path (V0 default)
+- Manager invokes/read-accesses:
+  - `scripts/ops-manager-loop-run-snapshot.sh`
+  - `scripts/ops-manager-poll-events.sh`
+- Works without dedicated runtime service.
+
+2. Service path (follow-on)
+- Sprite service wraps same adapter contract over HTTP.
+- Manager consumes the same envelopes with transport abstraction.
+- Suggested endpoints:
+  - `GET /ops/snapshot?loopId=<id>`
+  - `GET /ops/events?loopId=<id>&cursor=<offset>`
+
+## Control Surface
+Manager control intents should map to explicit runtime operations:
+
+- `CANCEL_LOOP`
+  - Current path: `superloop.sh cancel --repo <repo>`
+  - Confirm by snapshot/event transition to non-running terminal/idle state.
+
+- `APPROVE_PENDING`
+  - Current path: `superloop.sh approve --repo <repo> --loop <id>`
+  - Confirm by `approval_consumed` and/or `loop_complete` semantics.
+
+- `REJECT_PENDING`
+  - Current path: `superloop.sh approve --repo <repo> --loop <id> --reject`
+  - Confirm by rejection event + continued run behavior.
+
+## Security and Trust Assumptions (V0)
+- Sprite runtime and manager are within trusted internal dogfood boundary.
+- Control commands are allowlisted; no arbitrary shell command pass-through.
+- Manager writes are intent-based and auditable.
+- Full authn/authz model is deferred beyond initiation.
+
+## Total Visibility Mode (Future)
+Minimum telemetry additions to approach full observability:
+- periodic runtime heartbeat with process metadata
+- explicit command invocation log for manager-issued actions
+- envelope sequence ids for stronger ordering diagnostics
+- optional trace ids spanning manager intent -> runtime effect

--- a/docs/ops-manager-state-machine.md
+++ b/docs/ops-manager-state-machine.md
@@ -1,0 +1,74 @@
+# Ops Manager Lifecycle State Machine (Loop Run)
+
+## Scope
+This is the outer operations lifecycle machine. It manages run-level state from normalized runtime envelopes and does not replace Superloop's internal role orchestration.
+
+## States
+
+1. `unknown`
+- No trustworthy runtime signal yet.
+
+2. `running`
+- Runtime indicates active execution for target loop.
+
+3. `awaiting_approval`
+- Approval gate is pending and run cannot complete without external decision.
+
+4. `complete`
+- Completion conditions satisfied and recorded in runtime summary.
+
+5. `stopped`
+- Runtime emitted an intentional stop condition (e.g., max iterations, manual stop path).
+
+6. `failed`
+- Runtime emitted error/timeout/blocked/rate-limited terminal conditions.
+
+7. `idle`
+- Loop has artifacts but no active execution and no terminal completion for current inference window.
+
+## Input Events
+- `SNAPSHOT_INGESTED`: `loop_run_snapshot` envelope accepted.
+- `EVENT_INGESTED`: `loop_run_event` envelope accepted.
+- `CONTROL_INTENT_SENT`: manager issued pause/cancel/approval action.
+- `CONTROL_INTENT_CONFIRMED`: runtime artifacts confirm intended effect.
+- `DIVERGENCE_DETECTED`: manager observed contradictory signals across sources.
+
+## Transition Mapping (Runtime -> Manager)
+
+### Direct mappings
+- pending approval (`approval.status == pending`) -> `awaiting_approval`
+- summary completion (`run.summary.completion_ok == true`) -> `complete`
+- active state (`state.active == true` and `state.current_loop_id == loop`) -> `running`
+- stop event (`loop_stop`, `rate_limit_stop`, `no_progress_stop`) -> `stopped`
+- error-like event status (`error`, `timeout`, `blocked`, `rate_limited`) -> `failed`
+
+### Fallback mapping
+- none of the above with known artifacts -> `idle`
+- no reliable artifacts -> `unknown`
+
+## Guards
+- Cursor monotonicity: reject event progression if cursor regresses.
+- Loop scope integrity: reject envelopes whose `source.loopId` mismatches manager target.
+- Contract version gate: reject unsupported `schemaVersion`.
+
+## Actions
+- `projectLifecycle`: compute current state from snapshot/event sequence.
+- `recordObservation`: persist envelope + computed state transition.
+- `raiseIntervention`: emit operator alert for pending approval, stuck drift, or failure conditions.
+- `issueControlIntent`: dispatch cancel/pause/approve actions through approved interface.
+- `reconcileAfterControl`: require post-control snapshot/event confirmation.
+
+## Intervention Semantics
+- Manager never assumes intent success without runtime confirmation.
+- Control intents are modeled as transitions with evidence, not side effects.
+- If confirmation does not arrive in time, transition to a manager-local divergence flag and require operator review.
+
+## Divergence Handling
+Divergence is raised when state and event signals conflict, for example:
+- state says active=false while new iteration events are still arriving
+- approval pending but completion marked true
+
+On divergence:
+1. Freeze automated control actions for that loop run.
+2. Request fresh snapshot + event replay from last stable cursor.
+3. Escalate to operator if conflict persists.

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -1,0 +1,78 @@
+# Ops Manager V0 Contract (Superloop + Sprites)
+
+## Purpose
+This document defines the V0 manager/runtime contract for operating Superloop runs from outside a Sprite sandbox VM.
+
+Primary managed unit:
+- `Loop Run`
+
+Default isolation policy:
+- one loop run per sprite VM
+
+## Contract Surfaces
+V0 exports two envelope types described by `schema/ops-manager.contract.schema.json`:
+
+1. `loop_run_snapshot`
+- point-in-time lifecycle projection for one loop id
+- includes run identity, manager health signals, and artifact metadata
+
+2. `loop_run_event`
+- incremental event envelope from `.superloop/loops/<loop>/events.jsonl`
+- cursor-aware, supports polling without event duplication
+
+## Required Runtime Artifacts
+Required for V0 snapshot/event ingestion:
+
+- `.superloop/loops/<loop>/events.jsonl`
+
+Optional but consumed when present:
+
+- `.superloop/loops/<loop>/run-summary.json`
+- `.superloop/state.json`
+- `.superloop/active-run.json`
+- `.superloop/loops/<loop>/approval.json`
+
+Adapter scripts fail closed when required artifacts are missing.
+
+## Adapter Commands
+
+### Snapshot
+```bash
+scripts/ops-manager-loop-run-snapshot.sh \
+  --repo /path/to/repo \
+  --loop my-loop
+```
+
+Options:
+- `--run-id <id>`: override inferred run id
+- `--pretty`: formatted JSON output
+
+### Incremental Events
+```bash
+scripts/ops-manager-poll-events.sh \
+  --repo /path/to/repo \
+  --loop my-loop \
+  --cursor-file /tmp/my-loop.cursor.json
+```
+
+Options:
+- `--from-start`: ignore existing cursor and replay from first event
+- `--max-events <n>`: cap events emitted in one poll
+
+## Compatibility and Versioning Rules
+- `schemaVersion` is required and currently fixed to `v1`.
+- New fields may be added only as backward-compatible additions.
+- Breaking changes require a new schema version and dual-read support during migration.
+- Manager logic must key off explicit lifecycle fields and not parse free-form text output.
+
+## Failure Behavior
+The adapters are intentionally fail-closed for contract safety:
+
+- missing required artifact root or required event file: non-zero exit
+- invalid JSON in source artifacts: non-zero exit
+- cursor offset ahead of available events: non-zero exit (explicit reset required)
+
+## Operator Notes
+- Use snapshot for current lifecycle state.
+- Use event polling for real-time progression.
+- Use both together to detect divergence between runtime activity and summary state.

--- a/feat/ops-manager-superloop-sprites/initiation/CONTEXT.MD
+++ b/feat/ops-manager-superloop-sprites/initiation/CONTEXT.MD
@@ -1,0 +1,90 @@
+# Context: Ops Manager for Superloop + Sprites
+
+## Problem Statement
+Superloop already executes complex run lifecycles and emits rich local artifacts, but there is no external operations control-plane that treats each run as a first-class managed unit across isolated Sprite sandbox VMs.
+
+Today this creates three operational gaps for the team dogfooding Supergent/Superloop:
+
+1. Visibility gap:
+- Operators can inspect a repo-local `.superloop/` tree, but cannot reliably aggregate run state from outside the runtime boundary.
+
+2. Control gap:
+- Intervention exists (`cancel`, approval decisions), but there is no explicit manager contract that can safely issue run control intents and reconcile outcomes.
+
+3. Coordination gap:
+- Sprite isolation gives deterministic execution, but there is no canonical mapping from sprite runtime signals to a manager lifecycle state machine.
+
+## Why Loop Run Is Primary
+`Loop Run` is the operational primitive that aligns with both technical and product goals:
+
+- It maps directly to execution and outcomes that users care about (started, running, stuck, blocked, complete).
+- It has stable artifact surfaces already emitted by Superloop (`events.jsonl`, `run-summary.json`, `state.json`, `active-run.json`).
+- It remains composable: workspace/repo abstractions can be attached as dimensions without changing run-level control semantics.
+
+## Runtime Boundaries
+
+### Inside Sprite (Runtime Plane)
+- Superloop orchestrates planner/implementer/tester/reviewer and writes canonical local artifacts.
+- Runtime remains source of truth for role execution details.
+
+### Outside Sprite (Ops Plane)
+- Ops manager ingests snapshot + event envelopes.
+- Ops manager computes lifecycle state and policy actions.
+- Ops manager issues control intents (pause/cancel/approval decisions) through explicit interfaces.
+
+### Contract Boundary
+- V0 is pull-first: manager reads normalized outputs from adapter scripts.
+- Streaming/service integrations are follow-on after contract stabilization.
+
+## Primary Internal User Persona (Dogfood)
+The first user persona is the internal Supergent/Superloop operator-builder:
+
+- Runs many loop executions during active feature work.
+- Needs deterministic isolation (one loop per sprite by default).
+- Needs fast answers to: "what is running", "what is blocked", "what needs intervention", "what completed safely".
+
+## Operator Journeys (V0)
+
+### Journey 1: Observe Current Run
+1. Operator selects loop id + runtime repo path.
+2. Manager obtains a normalized snapshot.
+3. Manager renders lifecycle state, gate posture, and current intervention requirements.
+
+Success criteria:
+- Snapshot resolves to one lifecycle state with no ambiguous status.
+- Operator can identify latest run id and iteration.
+
+### Journey 2: Stream New Events
+1. Manager polls event envelopes with a cursor.
+2. Cursor advances monotonically.
+3. Manager updates lifecycle projection and activity feed.
+
+Success criteria:
+- No duplicated or skipped events under normal operation.
+- Cursor mismatch/fork conditions fail closed and require explicit reset.
+
+### Journey 3: Intervene Safely
+1. Manager detects risk (stuck threshold, pending approval, runtime stop event).
+2. Manager issues control intent through approved commands.
+3. Manager verifies resulting runtime state via fresh snapshot/events.
+
+Success criteria:
+- Control intents are externally visible in runtime artifacts.
+- Manager records outcome as an explicit transition, not implicit guesswork.
+
+## Constraints and Assumptions
+- Superloop artifact formats are authoritative and may evolve; adapter outputs must be versioned (`v1` now).
+- V0 prioritizes deterministic behavior and debugging over maximum throughput.
+- One loop per sprite is the default compute isolation policy.
+- Multi-tenant security and billing are out of scope for initiation.
+
+## Risks
+- Artifact schema drift without envelope versioning can silently break ops state projection.
+- Cursor handling errors can create visibility gaps (duplicate or dropped events).
+- Manager policies can conflict with runtime recovery if control semantics are not clearly layered.
+
+## Mitigations in This Iteration
+- Contract schema for snapshot and event envelopes.
+- Script adapters that fail closed on missing required artifacts.
+- Explicit lifecycle mapping document to separate runtime facts from manager interpretation.
+- Dogfood rollout stages with acceptance criteria and rollback behavior.

--- a/feat/ops-manager-superloop-sprites/initiation/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/initiation/PLAN.MD
@@ -1,0 +1,64 @@
+# Feature: Ops Manager for Superloop + Sprites
+
+## Goal
+Deliver a dogfooding-ready operations layer that can create, observe, and control `Loop Run` execution in Sprite Sandbox VMs with a stable event/state contract.
+
+## Scope
+- Define `Loop Run` as the primary managed unit, with explicit mapping hooks for workspace/repo entities later.
+- Establish default compute isolation policy: one loop run per sprite VM (configurable in future phases).
+- Add a normalized ops contract for snapshot + incremental event ingestion from Superloop runtime artifacts.
+- Add initial control hooks and lifecycle semantics for run start, pause/cancel intent, and terminalization visibility.
+- Document architecture and rollout path for first internal operators (Supergent/Superloop team).
+
+## Non-Goals (this iteration)
+- Multi-tenant auth, billing, and organizational access controls.
+- Full production-grade distributed tracing stack (vendor lock-in decision deferred).
+- Replacing Superloop's internal role loop logic.
+- Automated multi-loop packing/scheduling optimization beyond the default one-loop-per-sprite policy.
+
+## Primary References
+- `superloop.sh` - runtime orchestration and artifact emission surfaces.
+- `src/60-commands.sh` - command/module parity for core runtime behaviors.
+- `schema/config.schema.json` - loop configuration contract and extension points.
+- `docs/dev-env-contract-v1.md` - environment contract patterns relevant to manager/runtime boundaries.
+- `handbook/features/INITIATION.MD` - required feature initiation process.
+
+## Architecture
+The architecture is split into three layers:
+
+1. Runtime layer (inside sprite):
+- Superloop executes role iterations and writes canonical artifacts/events.
+- A lightweight adapter (script-first in v0) reads artifacts and emits normalized envelopes.
+
+2. Ops manager layer (outside sprite):
+- Maintains the authoritative lifecycle state machine per `Loop Run`.
+- Ingests snapshot + delta events and computes run health, phase, and operator-facing status.
+- Applies policy (timeouts, stuck detection, intervention thresholds) and issues control intents.
+
+3. Transport/control boundary:
+- Pull-based ingestion first (poll/cursor) to reduce coupling.
+- Push/streaming path (sprite service APIs) staged for follow-on phases once contract stabilizes.
+
+## Decisions
+- Primary managed entity is `Loop Run` now; repo/workspace become associated dimensions.
+- Default isolation is one loop per sprite for deterministic debugging and blast-radius control.
+- Ops manager uses an outer lifecycle state machine and treats Superloop as managed runtime.
+- Contract-first integration: snapshot + incremental event envelopes before deep runtime rewrites.
+- Dogfooding is the first launch track and acceptance environment.
+
+## Risks / Constraints
+- Artifact schema drift can break ingestion unless versioned envelopes are enforced.
+- Visibility can be partial if sprite-side adapters are not consistently deployed.
+- Bidirectional control must avoid conflicting with in-runtime recovery logic.
+- Over-instrumentation can add latency/noise; minimal required telemetry must be defined early.
+
+## Gate Baseline
+- Tests mode: `disabled` (initiation documentation phase only).
+- Tests commands: `N/A`.
+- Validation require on completion: `false` (for initiation packet).
+- Validation checklist mapping file: `N/A`.
+
+## Phases
+- **Phase 1**: Finalize contracts, initiation docs, and v0 ingestion/control packet.
+- **Phase 2**: Implement runtime adapters and manager state-machine core for loop lifecycle.
+- **Phase 3**: Integrate sprite service interfaces for richer observability/control and dogfood hardening.

--- a/feat/ops-manager-superloop-sprites/initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/initiation/tasks/PHASE_1.MD
@@ -1,0 +1,43 @@
+# Phase 1 - Ops Manager Contract + V0 Integration Packet
+
+## P1.0 Initiation and Scope Baseline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/initiation/PLAN.MD` reflects final scope, non-goals, and rollout assumptions.
+2. [x] Add `feat/ops-manager-superloop-sprites/initiation/CONTEXT.MD` with operator journeys, sprite runtime boundaries, and control-plane constraints.
+3. [x] Open/attach the feature issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/39`).
+
+## P1.1 Loop Run Contract Definition
+1. [x] Add `schema/ops-manager.contract.schema.json` for:
+   1. [x] Loop run snapshot envelope.
+   2. [x] Incremental event envelope (with version and cursor fields).
+   3. [x] Health and lifecycle status projection fields.
+2. [x] Add contract notes to `docs/ops-manager-v0.md` covering compatibility/versioning rules.
+3. [x] Add fixtures under `tests/fixtures/ops-manager/` for snapshot/event examples.
+
+## P1.2 Runtime Artifact Ingestion Adapters
+1. [x] Add `scripts/ops-manager-loop-run-snapshot.sh` to emit one normalized snapshot from Superloop artifacts.
+2. [x] Add `scripts/ops-manager-poll-events.sh` to emit incremental NDJSON envelopes with cursor persistence.
+3. [x] Ensure adapters fail closed on missing required artifacts and emit actionable errors.
+4. [x] Document required runtime artifact inputs in `docs/ops-manager-v0.md`.
+
+## P1.3 Outer Lifecycle State Machine Spec
+1. [x] Add `docs/ops-manager-state-machine.md` with canonical states/events/guards/actions for loop-run management.
+2. [x] Define state mapping from Superloop runtime signals to manager lifecycle states.
+3. [x] Specify intervention transitions (pause intent, cancel intent, terminalization handling).
+
+## P1.4 Sprite Integration Boundaries
+1. [x] Add `docs/ops-manager-sprite-integration.md` covering:
+   1. [x] One loop per sprite default policy and future override hooks.
+   2. [x] Service/API integration points for observability and control.
+   3. [x] Security boundary assumptions for manager-to-sprite commands.
+2. [x] Capture minimum telemetry contract needed for "total visibility" mode.
+
+## P1.5 Dogfood Rollout Plan
+1. [x] Add `docs/ops-manager-dogfood-rollout.md` with staged adoption for Supergent/Superloop internal use.
+2. [x] Define acceptance criteria per stage (visibility, control reliability, failure handling).
+3. [x] Define rollback/fallback behavior when manager and runtime state disagree.
+
+## P1.V Validation
+1. [x] `bats tests/ops-manager-contract.bats` passes.
+2. [x] All new docs cross-link correctly and reference real files/commands.
+3. [x] `schema/ops-manager.contract.schema.json` validates provided fixtures.
+4. [x] Initiation packet is reviewable without external context.

--- a/schema/ops-manager.contract.schema.json
+++ b/schema/ops-manager.contract.schema.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://superloop.sh/schemas/ops-manager-contract-v1.json",
+  "title": "OpsManagerContractV1",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/loopRunSnapshotEnvelope"
+    },
+    {
+      "$ref": "#/$defs/loopRunEventEnvelope"
+    }
+  ],
+  "$defs": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repoPath",
+        "loopId"
+      ],
+      "properties": {
+        "repoPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "loopId": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "exists",
+        "sizeBytes",
+        "lineCount",
+        "sha256",
+        "mtimeEpoch"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "exists": {
+          "type": "boolean"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lineCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mtimeEpoch": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      }
+    },
+    "cursor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventLineOffset",
+        "eventLineCount"
+      ],
+      "properties": {
+        "eventLineOffset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eventLineCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tests",
+        "validation",
+        "prerequisites",
+        "checklist",
+        "evidence",
+        "approval"
+      ],
+      "properties": {
+        "tests": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "string"
+        },
+        "prerequisites": {
+          "type": "string"
+        },
+        "checklist": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "string"
+        },
+        "approval": {
+          "type": "string"
+        }
+      }
+    },
+    "stuck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "streak",
+        "threshold"
+      ],
+      "properties": {
+        "streak": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "threshold": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "runStatus": {
+      "type": "string",
+      "enum": [
+        "running",
+        "awaiting_approval",
+        "complete",
+        "stopped",
+        "failed",
+        "idle",
+        "unknown"
+      ]
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runId",
+        "iteration"
+      ],
+      "properties": {
+        "runId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "iteration": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timestamp",
+        "name",
+        "role",
+        "status",
+        "message",
+        "payload",
+        "raw"
+      ],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "payload": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "raw": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "loopRunSnapshotEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "envelopeType",
+        "emittedAt",
+        "source",
+        "run",
+        "runtime",
+        "artifacts",
+        "cursor",
+        "health"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "envelopeType": {
+          "type": "string",
+          "const": "loop_run_snapshot"
+        },
+        "emittedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "run": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "runId",
+            "iteration",
+            "status",
+            "summary"
+          ],
+          "properties": {
+            "runId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "iteration": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "status": {
+              "$ref": "#/$defs/runStatus"
+            },
+            "summary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "superloopState",
+            "activeRun",
+            "approval"
+          ],
+          "properties": {
+            "superloopState": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "activeRun": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "approval": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        "artifacts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "events",
+            "runSummary",
+            "state",
+            "activeRun",
+            "approval"
+          ],
+          "properties": {
+            "events": {
+              "$ref": "#/$defs/artifactRef"
+            },
+            "runSummary": {
+              "$ref": "#/$defs/artifactRef"
+            },
+            "state": {
+              "$ref": "#/$defs/artifactRef"
+            },
+            "activeRun": {
+              "$ref": "#/$defs/artifactRef"
+            },
+            "approval": {
+              "$ref": "#/$defs/artifactRef"
+            }
+          }
+        },
+        "cursor": {
+          "$ref": "#/$defs/cursor"
+        },
+        "health": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "eventCount",
+            "lastEventAt",
+            "lastEventName",
+            "lastSummaryAt",
+            "hasPendingApproval",
+            "gates",
+            "stuck"
+          ],
+          "properties": {
+            "eventCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "lastEventAt": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lastEventName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lastSummaryAt": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "hasPendingApproval": {
+              "type": "boolean"
+            },
+            "gates": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/gates"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "stuck": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/stuck"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "loopRunEventEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "envelopeType",
+        "emittedAt",
+        "source",
+        "cursor",
+        "run",
+        "event"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "envelopeType": {
+          "type": "string",
+          "const": "loop_run_event"
+        },
+        "emittedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "cursor": {
+          "$ref": "#/$defs/cursor"
+        },
+        "run": {
+          "$ref": "#/$defs/run"
+        },
+        "event": {
+          "$ref": "#/$defs/event"
+        }
+      }
+    }
+  }
+}

--- a/scripts/ops-manager-loop-run-snapshot.sh
+++ b/scripts/ops-manager-loop-run-snapshot.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-loop-run-snapshot.sh --repo <path> --loop <id> [options]
+
+Options:
+  --run-id <id>   Override inferred run id in emitted snapshot.
+  --pretty        Pretty-print JSON output.
+  --help          Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+file_mtime_epoch() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "null"
+    return 0
+  fi
+
+  if stat -f "%m" "$path" >/dev/null 2>&1; then
+    stat -f "%m" "$path"
+    return 0
+  fi
+
+  if stat -c "%Y" "$path" >/dev/null 2>&1; then
+    stat -c "%Y" "$path"
+    return 0
+  fi
+
+  echo "null"
+}
+
+file_sha256() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo ""
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return 0
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return 0
+  fi
+
+  echo ""
+}
+
+file_ref_json() {
+  local repo="$1"
+  local path="$2"
+
+  local display_path="$path"
+  if [[ "$path" == "$repo/"* ]]; then
+    display_path="${path#$repo/}"
+  fi
+
+  local exists="false"
+  local size_bytes="0"
+  local line_count="0"
+  local sha=""
+  local mtime_epoch="null"
+
+  if [[ -f "$path" ]]; then
+    exists="true"
+    size_bytes=$(wc -c < "$path" | tr -d ' ')
+    line_count=$(wc -l < "$path" | tr -d ' ')
+    sha=$(file_sha256 "$path")
+    mtime_epoch=$(file_mtime_epoch "$path")
+  fi
+
+  jq -cn \
+    --arg path "$display_path" \
+    --argjson exists "$exists" \
+    --argjson size_bytes "$size_bytes" \
+    --argjson line_count "$line_count" \
+    --arg sha "$sha" \
+    --argjson mtime_epoch "$mtime_epoch" \
+    '{
+      path: $path,
+      exists: $exists,
+      sizeBytes: $size_bytes,
+      lineCount: $line_count,
+      sha256: (if ($sha | length) > 0 then $sha else null end),
+      mtimeEpoch: $mtime_epoch
+    }'
+}
+
+json_or_null_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    jq -c '.' "$path" 2>/dev/null || die "invalid JSON in $path"
+  else
+    echo 'null'
+  fi
+}
+
+repo=""
+loop_id=""
+requested_run_id=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --loop)
+      loop_id="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      requested_run_id="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ -z "$loop_id" ]]; then
+  die "--loop is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+superloop_dir="$repo/.superloop"
+loop_dir="$superloop_dir/loops/$loop_id"
+
+state_file="$superloop_dir/state.json"
+active_run_file="$superloop_dir/active-run.json"
+approval_file="$loop_dir/approval.json"
+events_file="$loop_dir/events.jsonl"
+summary_file="$loop_dir/run-summary.json"
+
+if [[ ! -d "$loop_dir" ]]; then
+  die "required artifact root missing: $loop_dir"
+fi
+if [[ ! -f "$events_file" ]]; then
+  die "required artifact missing: $events_file"
+fi
+
+event_line_count=$(wc -l < "$events_file" | tr -d ' ')
+if [[ -z "$event_line_count" ]]; then
+  event_line_count="0"
+fi
+
+last_event_json='null'
+if [[ "$event_line_count" -gt 0 ]]; then
+  last_event_json=$(tail -n 1 "$events_file" | jq -c '.' 2>/dev/null) || die "invalid JSON in final events line: $events_file"
+fi
+
+state_json=$(json_or_null_file "$state_file")
+active_run_json=$(json_or_null_file "$active_run_file")
+approval_json=$(json_or_null_file "$approval_file")
+summary_json=$(json_or_null_file "$summary_file")
+latest_summary_entry=$(jq -cn --argjson s "$summary_json" '$s.entries[-1] // null')
+
+resolved_run_id="$requested_run_id"
+if [[ -z "$resolved_run_id" ]]; then
+  resolved_run_id=$(jq -rn --argjson summary "$latest_summary_entry" --argjson event "$last_event_json" '
+    ($summary.run_id // "") as $summary_run |
+    ($event.run_id // "") as $event_run |
+    if ($summary_run | length) > 0 then
+      $summary_run
+    elif ($event_run | length) > 0 then
+      $event_run
+    else
+      "unknown"
+    end
+  ')
+fi
+
+resolved_iteration=$(jq -rn --argjson summary "$latest_summary_entry" --argjson event "$last_event_json" --argjson state "$state_json" '
+  ($summary.iteration // $event.iteration // $state.iteration // 0) | tonumber? // 0
+')
+
+run_status=$(jq -rn --arg loop_id "$loop_id" --argjson state "$state_json" --argjson approval "$approval_json" --argjson summary "$latest_summary_entry" --argjson event "$last_event_json" '
+  def in_list($name; $list): ($list | index($name)) != null;
+
+  ($event.event // $event.type // "") as $event_name |
+  ($event.status // "") as $event_status |
+
+  if ($approval != null and (($approval.status // "") == "pending")) then
+    "awaiting_approval"
+  elif ($summary != null and (($summary.completion_ok // false) == true)) then
+    "complete"
+  elif ($state != null and (($state.active // false) == true) and (($state.current_loop_id // "") == $loop_id)) then
+    "running"
+  elif in_list($event_name; ["loop_stop", "rate_limit_stop", "no_progress_stop"]) then
+    "stopped"
+  elif in_list($event_status; ["error", "timeout", "blocked", "rate_limited"]) then
+    "failed"
+  elif ($state != null and (($state.active // false) == false) and $summary != null) then
+    "idle"
+  else
+    "unknown"
+  end
+')
+
+last_event_at=$(jq -rn --argjson event "$last_event_json" '($event.timestamp // "")')
+last_event_name=$(jq -rn --argjson event "$last_event_json" '($event.event // $event.type // "")')
+last_summary_at=$(jq -rn --argjson summary "$summary_json" --argjson latest "$latest_summary_entry" '
+  ($summary.updated_at // $latest.ended_at // "")
+')
+has_pending_approval=$(jq -rn --argjson approval "$approval_json" 'if $approval != null and (($approval.status // "") == "pending") then true else false end')
+gates_json=$(jq -cn --argjson latest "$latest_summary_entry" '$latest.gates // null')
+stuck_json=$(jq -cn --argjson latest "$latest_summary_entry" '$latest.stuck // null')
+
+events_ref=$(file_ref_json "$repo" "$events_file")
+summary_ref=$(file_ref_json "$repo" "$summary_file")
+state_ref=$(file_ref_json "$repo" "$state_file")
+active_run_ref=$(file_ref_json "$repo" "$active_run_file")
+approval_ref=$(file_ref_json "$repo" "$approval_file")
+
+snapshot_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg emitted_at "$(timestamp)" \
+  --arg repo_path "$repo" \
+  --arg loop_id "$loop_id" \
+  --arg run_id "$resolved_run_id" \
+  --arg run_status "$run_status" \
+  --arg last_event_at "$last_event_at" \
+  --arg last_event_name "$last_event_name" \
+  --arg last_summary_at "$last_summary_at" \
+  --argjson iteration "$resolved_iteration" \
+  --argjson state "$state_json" \
+  --argjson active_run "$active_run_json" \
+  --argjson approval "$approval_json" \
+  --argjson latest_summary "$latest_summary_entry" \
+  --argjson events_ref "$events_ref" \
+  --argjson summary_ref "$summary_ref" \
+  --argjson state_ref "$state_ref" \
+  --argjson active_run_ref "$active_run_ref" \
+  --argjson approval_ref "$approval_ref" \
+  --argjson event_count "$event_line_count" \
+  --argjson has_pending_approval "$has_pending_approval" \
+  --argjson gates "$gates_json" \
+  --argjson stuck "$stuck_json" \
+  '{
+    schemaVersion: $schema_version,
+    envelopeType: "loop_run_snapshot",
+    emittedAt: $emitted_at,
+    source: {
+      repoPath: $repo_path,
+      loopId: $loop_id
+    },
+    run: {
+      runId: $run_id,
+      iteration: $iteration,
+      status: $run_status,
+      summary: $latest_summary
+    },
+    runtime: {
+      superloopState: $state,
+      activeRun: $active_run,
+      approval: $approval
+    },
+    artifacts: {
+      events: $events_ref,
+      runSummary: $summary_ref,
+      state: $state_ref,
+      activeRun: $active_run_ref,
+      approval: $approval_ref
+    },
+    cursor: {
+      eventLineOffset: $event_count,
+      eventLineCount: $event_count
+    },
+    health: {
+      eventCount: $event_count,
+      lastEventAt: (if ($last_event_at | length) > 0 then $last_event_at else null end),
+      lastEventName: (if ($last_event_name | length) > 0 then $last_event_name else null end),
+      lastSummaryAt: (if ($last_summary_at | length) > 0 then $last_summary_at else null end),
+      hasPendingApproval: $has_pending_approval,
+      gates: $gates,
+      stuck: $stuck
+    }
+  }')
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$snapshot_json"
+else
+  jq -c '.' <<<"$snapshot_json"
+fi

--- a/scripts/ops-manager-poll-events.sh
+++ b/scripts/ops-manager-poll-events.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-poll-events.sh --repo <path> --loop <id> [options]
+
+Options:
+  --cursor-file <path>  Cursor JSON path. Default: <repo>/.superloop/loops/<loop>/ops-manager.cursor.json
+  --from-start          Ignore existing cursor and emit from first line.
+  --max-events <n>      Emit at most n events in this call (n > 0).
+  --help                Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+repo=""
+loop_id=""
+cursor_file=""
+from_start="0"
+max_events="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --loop)
+      loop_id="${2:-}"
+      shift 2
+      ;;
+    --cursor-file)
+      cursor_file="${2:-}"
+      shift 2
+      ;;
+    --from-start)
+      from_start="1"
+      shift
+      ;;
+    --max-events)
+      max_events="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ -z "$loop_id" ]]; then
+  die "--loop is required"
+fi
+if [[ ! "$max_events" =~ ^[0-9]+$ ]]; then
+  die "--max-events must be a non-negative integer"
+fi
+
+repo="$(cd "$repo" && pwd)"
+loop_dir="$repo/.superloop/loops/$loop_id"
+events_file="$loop_dir/events.jsonl"
+
+if [[ -z "$cursor_file" ]]; then
+  cursor_file="$loop_dir/ops-manager.cursor.json"
+fi
+
+if [[ ! -d "$loop_dir" ]]; then
+  die "required artifact root missing: $loop_dir"
+fi
+if [[ ! -f "$events_file" ]]; then
+  die "required artifact missing: $events_file"
+fi
+
+total_lines=$(wc -l < "$events_file" | tr -d ' ')
+if [[ -z "$total_lines" ]]; then
+  total_lines="0"
+fi
+
+start_offset="0"
+if [[ "$from_start" != "1" && -f "$cursor_file" ]]; then
+  cursor_json=$(jq -c '.' "$cursor_file" 2>/dev/null) || die "invalid JSON in cursor file: $cursor_file"
+  start_offset=$(jq -r '.eventLineOffset // 0' <<<"$cursor_json")
+fi
+
+if [[ ! "$start_offset" =~ ^[0-9]+$ ]]; then
+  die "invalid cursor offset in $cursor_file"
+fi
+if [[ "$start_offset" -gt "$total_lines" ]]; then
+  die "cursor offset ($start_offset) exceeds available events ($total_lines); reset cursor or use --from-start"
+fi
+
+lines_emitted=0
+last_emitted_line="$start_offset"
+line_no=0
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line_no=$((line_no + 1))
+  if [[ "$line_no" -le "$start_offset" ]]; then
+    continue
+  fi
+
+  if [[ -z "$line" ]]; then
+    continue
+  fi
+
+  event_json=$(printf '%s\n' "$line" | jq -c '.' 2>/dev/null) || die "invalid JSON event at line $line_no in $events_file"
+
+  event_name=$(jq -r '(.event // .type // "")' <<<"$event_json")
+  event_timestamp=$(jq -r '.timestamp // ""' <<<"$event_json")
+  run_id=$(jq -r '.run_id // "unknown"' <<<"$event_json")
+  iteration=$(jq -r '(.iteration // 0) | tonumber? // 0' <<<"$event_json")
+  role=$(jq -r '.role // ""' <<<"$event_json")
+  status=$(jq -r '.status // ""' <<<"$event_json")
+  message=$(jq -r '.message // ""' <<<"$event_json")
+  payload=$(jq -c '.data // null' <<<"$event_json")
+
+  if [[ -z "$event_name" ]]; then
+    die "missing event name at line $line_no in $events_file"
+  fi
+  if [[ -z "$event_timestamp" ]]; then
+    die "missing event timestamp at line $line_no in $events_file"
+  fi
+
+  jq -cn \
+    --arg schema_version "v1" \
+    --arg emitted_at "$(timestamp)" \
+    --arg repo_path "$repo" \
+    --arg loop_id "$loop_id" \
+    --argjson line_offset "$line_no" \
+    --argjson line_count "$total_lines" \
+    --arg run_id "$run_id" \
+    --argjson iteration "$iteration" \
+    --arg event_timestamp "$event_timestamp" \
+    --arg event_name "$event_name" \
+    --arg role "$role" \
+    --arg status "$status" \
+    --arg message "$message" \
+    --argjson payload "$payload" \
+    --argjson raw "$event_json" \
+    '{
+      schemaVersion: $schema_version,
+      envelopeType: "loop_run_event",
+      emittedAt: $emitted_at,
+      source: {
+        repoPath: $repo_path,
+        loopId: $loop_id
+      },
+      cursor: {
+        eventLineOffset: $line_offset,
+        eventLineCount: $line_count
+      },
+      run: {
+        runId: $run_id,
+        iteration: $iteration
+      },
+      event: {
+        timestamp: $event_timestamp,
+        name: $event_name,
+        role: (if ($role | length) > 0 then $role else null end),
+        status: (if ($status | length) > 0 then $status else null end),
+        message: (if ($message | length) > 0 then $message else null end),
+        payload: $payload,
+        raw: $raw
+      }
+    }'
+
+  lines_emitted=$((lines_emitted + 1))
+  last_emitted_line="$line_no"
+
+  if [[ "$max_events" -gt 0 && "$lines_emitted" -ge "$max_events" ]]; then
+    break
+  fi
+done < "$events_file"
+
+mkdir -p "$(dirname "$cursor_file")"
+tmp_cursor="$(mktemp)"
+
+jq -n \
+  --arg schema_version "v1" \
+  --arg repo_path "$repo" \
+  --arg loop_id "$loop_id" \
+  --arg events_path "${events_file#$repo/}" \
+  --arg updated_at "$(timestamp)" \
+  --argjson line_offset "$last_emitted_line" \
+  --argjson line_count "$total_lines" \
+  '{
+    schemaVersion: $schema_version,
+    repoPath: $repo_path,
+    loopId: $loop_id,
+    eventsFile: $events_path,
+    eventLineOffset: $line_offset,
+    eventLineCount: $line_count,
+    updatedAt: $updated_at
+  }' > "$tmp_cursor"
+
+mv "$tmp_cursor" "$cursor_file"

--- a/tests/fixtures/ops-manager/event.v1.json
+++ b/tests/fixtures/ops-manager/event.v1.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "v1",
+  "envelopeType": "loop_run_event",
+  "emittedAt": "2026-02-22T03:45:05Z",
+  "source": {
+    "repoPath": "/tmp/repo",
+    "loopId": "demo-loop"
+  },
+  "cursor": {
+    "eventLineOffset": 43,
+    "eventLineCount": 128
+  },
+  "run": {
+    "runId": "20260222T034500Z",
+    "iteration": 3
+  },
+  "event": {
+    "timestamp": "2026-02-22T03:45:05Z",
+    "name": "role_end",
+    "role": "planner",
+    "status": "ok",
+    "message": null,
+    "payload": {
+      "duration_ms": 1320,
+      "result": "success"
+    },
+    "raw": {
+      "timestamp": "2026-02-22T03:45:05Z",
+      "event": "role_end",
+      "loop_id": "demo-loop",
+      "run_id": "20260222T034500Z",
+      "iteration": 3,
+      "role": "planner",
+      "status": "ok",
+      "data": {
+        "duration_ms": 1320,
+        "result": "success"
+      }
+    }
+  }
+}

--- a/tests/fixtures/ops-manager/snapshot.v1.json
+++ b/tests/fixtures/ops-manager/snapshot.v1.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": "v1",
+  "envelopeType": "loop_run_snapshot",
+  "emittedAt": "2026-02-22T03:45:00Z",
+  "source": {
+    "repoPath": "/tmp/repo",
+    "loopId": "demo-loop"
+  },
+  "run": {
+    "runId": "20260222T034500Z",
+    "iteration": 3,
+    "status": "running",
+    "summary": {
+      "run_id": "20260222T034500Z",
+      "iteration": 2,
+      "gates": {
+        "tests": "ok",
+        "validation": "ok",
+        "prerequisites": "ok",
+        "checklist": "ok",
+        "evidence": "skipped",
+        "approval": "none"
+      },
+      "stuck": {
+        "streak": 0,
+        "threshold": 3
+      },
+      "completion_ok": false
+    }
+  },
+  "runtime": {
+    "superloopState": {
+      "active": true,
+      "loop_index": 0,
+      "iteration": 3,
+      "current_loop_id": "demo-loop",
+      "updated_at": "2026-02-22T03:45:00Z"
+    },
+    "activeRun": {
+      "repo": "/tmp/repo",
+      "pid": 12345,
+      "pgid": 12345,
+      "loop_id": "demo-loop",
+      "iteration": 3,
+      "stage": "loop_start",
+      "updated_at": "2026-02-22T03:45:00Z"
+    },
+    "approval": null
+  },
+  "artifacts": {
+    "events": {
+      "path": ".superloop/loops/demo-loop/events.jsonl",
+      "exists": true,
+      "sizeBytes": 2048,
+      "lineCount": 42,
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mtimeEpoch": 1763330000
+    },
+    "runSummary": {
+      "path": ".superloop/loops/demo-loop/run-summary.json",
+      "exists": true,
+      "sizeBytes": 4096,
+      "lineCount": 1,
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mtimeEpoch": 1763330001
+    },
+    "state": {
+      "path": ".superloop/state.json",
+      "exists": true,
+      "sizeBytes": 256,
+      "lineCount": 1,
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "mtimeEpoch": 1763330002
+    },
+    "activeRun": {
+      "path": ".superloop/active-run.json",
+      "exists": true,
+      "sizeBytes": 256,
+      "lineCount": 1,
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "mtimeEpoch": 1763330003
+    },
+    "approval": {
+      "path": ".superloop/loops/demo-loop/approval.json",
+      "exists": false,
+      "sizeBytes": 0,
+      "lineCount": 0,
+      "sha256": null,
+      "mtimeEpoch": null
+    }
+  },
+  "cursor": {
+    "eventLineOffset": 42,
+    "eventLineCount": 42
+  },
+  "health": {
+    "eventCount": 42,
+    "lastEventAt": "2026-02-22T03:45:00Z",
+    "lastEventName": "iteration_start",
+    "lastSummaryAt": "2026-02-22T03:44:59Z",
+    "hasPendingApproval": false,
+    "gates": {
+      "tests": "ok",
+      "validation": "ok",
+      "prerequisites": "ok",
+      "checklist": "ok",
+      "evidence": "skipped",
+      "approval": "none"
+    },
+    "stuck": {
+      "streak": 0,
+      "threshold": 3
+    }
+  }
+}

--- a/tests/ops-manager-contract.bats
+++ b/tests/ops-manager-contract.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  LOOP_ID="demo-loop"
+
+  mkdir -p "$TEMP_DIR/.superloop/loops/$LOOP_ID"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+write_base_runtime_artifacts() {
+  local loop_dir="$TEMP_DIR/.superloop/loops/$LOOP_ID"
+
+  mkdir -p "$TEMP_DIR/.superloop"
+
+  cat > "$TEMP_DIR/.superloop/state.json" << 'JSON'
+{"active":true,"loop_index":0,"iteration":2,"current_loop_id":"demo-loop","updated_at":"2026-02-22T04:00:00Z"}
+JSON
+
+  cat > "$TEMP_DIR/.superloop/active-run.json" << 'JSON'
+{"repo":"/tmp/demo","pid":1200,"pgid":1200,"loop_id":"demo-loop","iteration":2,"stage":"loop_start","updated_at":"2026-02-22T04:00:00Z"}
+JSON
+
+  cat > "$loop_dir/run-summary.json" << 'JSON'
+{
+  "version": 1,
+  "loop_id": "demo-loop",
+  "updated_at": "2026-02-22T04:00:01Z",
+  "entries": [
+    {
+      "run_id": "run-123",
+      "iteration": 1,
+      "gates": {
+        "tests": "ok",
+        "validation": "ok",
+        "prerequisites": "ok",
+        "checklist": "ok",
+        "evidence": "skipped",
+        "approval": "none"
+      },
+      "stuck": {
+        "streak": 0,
+        "threshold": 3
+      },
+      "completion_ok": false,
+      "ended_at": "2026-02-22T04:00:01Z"
+    }
+  ]
+}
+JSON
+
+  cat > "$loop_dir/events.jsonl" << 'JSONL'
+{"timestamp":"2026-02-22T04:00:00Z","event":"loop_start","loop_id":"demo-loop","run_id":"run-123","iteration":1,"data":{"max_iterations":5}}
+{"timestamp":"2026-02-22T04:00:05Z","event":"iteration_start","loop_id":"demo-loop","run_id":"run-123","iteration":2,"data":{"started_at":"2026-02-22T04:00:05Z"}}
+{"timestamp":"2026-02-22T04:00:20Z","event":"role_end","loop_id":"demo-loop","run_id":"run-123","iteration":2,"role":"planner","status":"ok","data":{"duration_ms":1200}}
+JSONL
+}
+
+@test "ops manager snapshot emits loop_run_snapshot envelope" {
+  write_base_runtime_artifacts
+
+  run "$PROJECT_ROOT/scripts/ops-manager-loop-run-snapshot.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID"
+  [ "$status" -eq 0 ]
+
+  output_file="$TEMP_DIR/snapshot.json"
+  printf '%s\n' "$output" > "$output_file"
+
+  run jq -r '.schemaVersion' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v1" ]
+
+  run jq -r '.envelopeType' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop_run_snapshot" ]
+
+  run jq -r '.source.loopId' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$LOOP_ID" ]
+
+  run jq -r '.run.runId' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "run-123" ]
+
+  run jq -r '.cursor.eventLineOffset' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}
+
+@test "ops manager snapshot fails closed when events artifact is missing" {
+  mkdir -p "$TEMP_DIR/.superloop/loops/$LOOP_ID"
+  cat > "$TEMP_DIR/.superloop/loops/$LOOP_ID/run-summary.json" << 'JSON'
+{"version":1,"loop_id":"demo-loop","entries":[]}
+JSON
+
+  run "$PROJECT_ROOT/scripts/ops-manager-loop-run-snapshot.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "required artifact missing" ]]
+}
+
+@test "ops manager event poll emits cursor-safe loop_run_event envelopes" {
+  write_base_runtime_artifacts
+
+  cursor_file="$TEMP_DIR/cursor.json"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-poll-events.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --cursor-file "$cursor_file"
+  [ "$status" -eq 0 ]
+
+  line_count=$(printf '%s\n' "$output" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$line_count" = "3" ]
+
+  printf '%s\n' "$output" > "$TEMP_DIR/events.ndjson"
+  run jq -r 'select(.envelopeType == "loop_run_event") | .envelopeType' "$TEMP_DIR/events.ndjson"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.eventLineOffset' "$cursor_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-poll-events.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --cursor-file "$cursor_file"
+  [ "$status" -eq 0 ]
+  line_count_second=$(printf '%s\n' "$output" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$line_count_second" = "0" ]
+
+  cat >> "$TEMP_DIR/.superloop/loops/$LOOP_ID/events.jsonl" << 'JSONL'
+{"timestamp":"2026-02-22T04:00:30Z","event":"iteration_end","loop_id":"demo-loop","run_id":"run-123","iteration":2,"data":{"completed":true}}
+JSONL
+
+  run "$PROJECT_ROOT/scripts/ops-manager-poll-events.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --cursor-file "$cursor_file" --max-events 1
+  [ "$status" -eq 0 ]
+  line_count_third=$(printf '%s\n' "$output" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$line_count_third" = "1" ]
+
+  run jq -r '.eventLineOffset' "$cursor_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "4" ]
+}
+
+@test "ops manager contract fixtures include required envelope fields" {
+  run jq -e '
+    .schemaVersion == "v1"
+    and .envelopeType == "loop_run_snapshot"
+    and (.source.repoPath | length) > 0
+    and (.source.loopId | length) > 0
+    and (.cursor.eventLineOffset >= 0)
+    and (.health.eventCount >= 0)
+  ' "$PROJECT_ROOT/tests/fixtures/ops-manager/snapshot.v1.json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    .schemaVersion == "v1"
+    and .envelopeType == "loop_run_event"
+    and (.source.repoPath | length) > 0
+    and (.source.loopId | length) > 0
+    and (.event.name | length) > 0
+    and (.run.iteration >= 0)
+  ' "$PROJECT_ROOT/tests/fixtures/ops-manager/event.v1.json"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add initiation packet for `feat/ops-manager-superloop-sprites/initiation`
- define `Loop Run` ops contract schema (`v1`) for snapshot and incremental event envelopes
- add runtime adapter scripts for snapshot extraction and cursor-safe event polling
- add docs for lifecycle state machine, sprite integration boundaries, and dogfood rollout
- add fixtures and BATS tests for contract and adapter behavior

## Validation
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats`
  - `ok 1` snapshot envelope
  - `ok 2` fail-closed missing events
  - `ok 3` cursor-safe polling
  - `ok 4` fixture contract fields

Closes #39
