### PR TITLE
feat: initiate ops manager phase 4 observability hardening

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD
@@ -1,0 +1,66 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 4 Dogfood Hardening + Observability)
+
+## Goal
+Harden dogfood operations with explicit observability, staleness/health signaling, and operator-facing evidence so loop-run supervision is trustworthy under real internal load.
+
+## Scope
+- Add manager observability outputs for runtime health, transport health, ingest lag, and control-intent outcomes.
+- Add dogfood guardrails for stale snapshots/events, repeated transport failures, and ambiguous control confirmations.
+- Add explicit escalation levels and reason codes suitable for operator triage.
+- Add runbook-level operational playbooks for sprite outage, degraded transport, and recovery verification.
+- Add tests validating observability parity across `local` and `sprite_service` transports.
+
+## Non-Goals (this iteration)
+- Full external telemetry vendor integration (Datadog/Grafana/OpenTelemetry backend lock-in).
+- Multi-tenant RBAC, billing, and org-level policy controls.
+- Scheduler/packing policy changes beyond one-loop-per-sprite default.
+- Autonomous remediation workflows that execute write-side actions without operator intent.
+
+## Primary References
+- `feat/ops-manager-superloop-sprites/initiation/PLAN.MD` - initial architecture and rollout assumptions.
+- `feat/ops-manager-superloop-sprites/phase-2-manager-core/PLAN.MD` - lifecycle projection + control semantics.
+- `feat/ops-manager-superloop-sprites/phase-3-sprite-service-transport/PLAN.MD` - service transport baseline.
+- `scripts/ops-manager-reconcile.sh` - ingest/projection entrypoint.
+- `scripts/ops-manager-control.sh` - control-intent path and confirmation semantics.
+- `docs/ops-manager-v0.md` - contract baseline and artifact model.
+- `docs/ops-manager-runbook.md` - operational procedures.
+
+## Architecture
+Phase 4 introduces a dedicated observability layer on top of the existing manager runtime:
+
+1. Telemetry capture:
+- Emit structured operation records for reconcile/control cycles.
+- Track transport attempts, retries, result codes, and latency buckets.
+- Track ingest cursor lag and last-seen runtime progress timestamps.
+
+2. Health and SLO projection:
+- Compute manager health states (`healthy`, `degraded`, `critical`) from telemetry + lifecycle context.
+- Generate machine-readable escalation records with deterministic reason codes.
+- Distinguish transport failures from runtime divergence for clearer operator action.
+
+3. Operator surfaces:
+- Add script/JSON outputs for concise per-loop operational health snapshots.
+- Preserve backward compatibility for existing state and intent artifacts.
+- Keep local and sprite-service observability semantics aligned.
+
+## Decisions
+- Keep observability artifacts file-first under `.superloop/ops-manager/<loop>/` for deterministic dogfood debugging.
+- Introduce health metadata as additive fields to avoid schema-breaking churn.
+- Treat ambiguous control confirmations as first-class operational events.
+- Prefer explicit reason codes over free-text summaries in machine-consumed outputs.
+
+## Risks / Constraints
+- Overly aggressive thresholds can create noisy escalations and operator fatigue.
+- Under-sensitive thresholds can hide genuine regressions in runtime/transport behavior.
+- Additional telemetry writes can increase I/O overhead in tight reconcile loops.
+- Cross-transport parity can drift without fixture-backed tests.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Implement observability artifacts, health projection, reason-coded escalations, docs, and tests.
+- **Phase 2**: Dogfood threshold tuning and operator UX hardening from internal feedback.

--- a/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/tasks/PHASE_1.MD
@@ -1,0 +1,36 @@
+# Phase 1 - Observability + Dogfood Hardening Baseline
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD` aligns with prior phases and current repo state.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/45`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`).
+
+## P1.1 Telemetry Artifact Model
+1. [ ] Define and emit per-loop telemetry artifacts for reconcile/control cycles.
+2. [ ] Record transport attempts, retry counts, latency, and result status with stable field names.
+3. [ ] Persist telemetry artifacts under `.superloop/ops-manager/<loop>/` with deterministic paths.
+
+## P1.2 Health Projection and Reason Codes
+1. [ ] Add health-state projection (`healthy|degraded|critical`) derived from telemetry + lifecycle state.
+2. [ ] Add reason-coded degradation/escalation output (e.g. `transport_unreachable`, `ingest_stale`, `control_ambiguous`).
+3. [ ] Ensure reasons are machine-readable and documented.
+
+## P1.3 Guardrails and Escalation Policy
+1. [ ] Add configurable thresholds for ingest lag and transport failure streaks.
+2. [ ] Escalate when thresholds breach, without executing autonomous write-side remediation.
+3. [ ] Preserve explicit operator intent as the only control trigger path.
+
+## P1.4 Operator Surface + Runbook
+1. [ ] Add an operator-facing status surface (script/JSON) summarizing health + reasons per loop run.
+2. [ ] Update `docs/ops-manager-v0.md` with observability artifact contracts.
+3. [ ] Update `docs/ops-manager-runbook.md` with incident triage/recovery flows using new reason codes.
+
+## P1.5 Test Coverage
+1. [ ] Add `tests/ops-manager-observability.bats` covering healthy/degraded/critical projections.
+2. [ ] Add fixtures for transport outage, ingest staleness, and ambiguous confirmation scenarios.
+3. [ ] Assert local and sprite-service transports produce equivalent observability outcomes.
+
+## P1.V Validation
+1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats` passes.
+2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+3. [ ] Updated docs match implemented artifact paths and reason codes.


### PR DESCRIPTION
## Summary
- add Phase 4 packet for Ops Manager + Superloop + Sprites focused on dogfood hardening and observability
- add phase plan at `feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD`
- add execution checklist at `feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/tasks/PHASE_1.MD`
- link the phase checklist to issue `#45` and prior phase context (`#40`, `#42`, `#44`)

## Validation
- docs/packet only change (no runtime code changes)

Closes #45
