### PR TITLE
feat: add ops manager threshold profiles and tuning summary

### DIFF
--- a/config/ops-manager-threshold-profiles.v1.json
+++ b/config/ops-manager-threshold-profiles.v1.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "v1",
+  "defaultProfile": "balanced",
+  "profiles": {
+    "strict": {
+      "degradedIngestLagSeconds": 120,
+      "criticalIngestLagSeconds": 300,
+      "degradedTransportFailureStreak": 1,
+      "criticalTransportFailureStreak": 2,
+      "description": "Fast detection for short-feedback loops with high signal confidence"
+    },
+    "balanced": {
+      "degradedIngestLagSeconds": 300,
+      "criticalIngestLagSeconds": 900,
+      "degradedTransportFailureStreak": 2,
+      "criticalTransportFailureStreak": 4,
+      "description": "Default dogfood profile balancing alert timeliness and noise"
+    },
+    "relaxed": {
+      "degradedIngestLagSeconds": 600,
+      "criticalIngestLagSeconds": 1800,
+      "degradedTransportFailureStreak": 3,
+      "criticalTransportFailureStreak": 6,
+      "description": "Noise-reduction profile for unstable environments or heavy churn"
+    }
+  }
+}

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -86,10 +86,20 @@ Purpose:
 - Computes reason-coded manager health (`healthy|degraded|critical`) and writes `.superloop/ops-manager/<loop>/health.json`.
 
 Observability thresholds:
+- `--threshold-profile <strict|balanced|relaxed>`
+- `--thresholds-file <path>`
 - `--degraded-ingest-lag-seconds <n>`
 - `--critical-ingest-lag-seconds <n>`
 - `--degraded-transport-failure-streak <n>`
 - `--critical-transport-failure-streak <n>`
+
+Threshold precedence:
+1. Explicit threshold flags (`--degraded-*`, `--critical-*`)
+2. Selected threshold profile (`--threshold-profile` or `OPS_MANAGER_THRESHOLD_PROFILE`)
+3. Profile catalog default (`defaultProfile` in thresholds file)
+
+Profile catalog default path:
+- `config/ops-manager-threshold-profiles.v1.json`
 
 ### Control Intent
 ```bash
@@ -132,6 +142,30 @@ scripts/ops-manager-status.sh \
 Purpose:
 - Provides operator-facing lifecycle + health summary for one loop run.
 - Normalizes state, health, cursor, latest control, and latest reconcile telemetry.
+- Includes tuning guidance fields from telemetry summaries (`recommendedProfile`, `confidence`, `rationale`).
+
+### Threshold Profile Resolver
+```bash
+scripts/ops-manager-threshold-profile.sh --profile strict --pretty
+```
+
+Purpose:
+- Resolves profile values from a versioned profile catalog.
+- Enforces fail-closed behavior for unknown/invalid profiles.
+- Lists available profiles via `--list`.
+
+### Telemetry Summary
+```bash
+scripts/ops-manager-telemetry-summary.sh \
+  --repo /path/to/repo \
+  --loop my-loop \
+  --window 200 \
+  --pretty
+```
+
+Purpose:
+- Summarizes reconcile/control telemetry over a bounded recent window.
+- Emits profile recommendation + confidence for dogfood threshold tuning.
 
 ## Sprite Service Transport
 Service implementation entrypoint:
@@ -160,6 +194,7 @@ Transport mode switch:
 - `.superloop/ops-manager/<loop>/telemetry/reconcile.jsonl` - reconcile attempt telemetry.
 - `.superloop/ops-manager/<loop>/telemetry/control.jsonl` - control attempt telemetry.
 - `.superloop/ops-manager/<loop>/telemetry/transport-health.json` - rolling transport failure streak state.
+- `config/ops-manager-threshold-profiles.v1.json` - threshold profile catalog (repo-level, versioned).
 
 ## Health Reason Codes
 Current reason-code surface used in health and escalation artifacts:

--- a/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/tasks/PHASE_2.MD
@@ -1,0 +1,36 @@
+# Phase 2 - Dogfood Threshold Tuning + Operator UX Hardening
+
+## P2.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD` phase-2 scope aligns with current repo state.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/49`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`, `#46`, `#48`).
+
+## P2.1 Threshold Profiles
+1. [x] Add versioned threshold profile catalog for dogfood operations (`strict|balanced|relaxed`).
+2. [x] Add profile resolver script and fail-closed behavior for unknown profiles.
+3. [x] Wire reconcile to accept `--threshold-profile` and `--thresholds-file` with deterministic precedence over defaults.
+
+## P2.2 Telemetry-Driven Tuning Surface
+1. [x] Add telemetry summary script that reads reconcile/control telemetry and emits machine-readable aggregates.
+2. [x] Compute suggested threshold profile from observed health/failure rates and include rationale.
+3. [x] Ensure summary script works without external services (file-first dogfood mode).
+
+## P2.3 Operator UX Hardening
+1. [x] Extend status output with applied threshold profile and tuning context.
+2. [x] Add clear guidance fields for operators (`recommendedProfile`, `summaryWindow`, `confidence`).
+3. [x] Keep status output backward-compatible for existing consumers.
+
+## P2.4 Test Coverage
+1. [x] Add tests for threshold profile resolution and reconcile profile wiring.
+2. [x] Add tests for telemetry summary recommendation behavior.
+3. [x] Add tests for status output profile/tuning fields.
+
+## P2.5 Docs and Runbook
+1. [x] Update `docs/ops-manager-v0.md` with threshold profile contract and script usage.
+2. [x] Update `docs/ops-manager-runbook.md` with telemetry-guided threshold tuning workflow.
+3. [x] Document precedence rules for explicit flags vs profile defaults.
+
+## P2.V Validation
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Updated docs match implemented profile names, fields, and commands.

--- a/scripts/ops-manager-health.sh
+++ b/scripts/ops-manager-health.sh
@@ -11,6 +11,7 @@ Options:
   --transport-health-file <path>              Optional transport health JSON file.
   --intents-file <path>                       Optional intents JSONL file.
   --transport <local|sprite_service>          Transport mode label (default: local)
+  --threshold-profile <name>                  Optional applied threshold profile label.
   --ingest-status <success|failed>            Reconcile ingest result (default: success)
   --failure-code <code>                       Optional reconcile failure code.
   --degraded-ingest-lag-seconds <n>           Degraded threshold (default: 300)
@@ -43,6 +44,7 @@ state_file=""
 transport_health_file=""
 intents_file=""
 transport="local"
+threshold_profile=""
 ingest_status="success"
 failure_code=""
 degraded_ingest_lag_seconds="300"
@@ -68,6 +70,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --transport)
       transport="${2:-}"
+      shift 2
+      ;;
+    --threshold-profile)
+      threshold_profile="${2:-}"
       shift 2
       ;;
     --ingest-status)
@@ -299,6 +305,7 @@ health_json=$(jq -cn \
   --arg updated_at "$now_iso" \
   --arg status "$health_status" \
   --arg transport "$transport" \
+  --arg threshold_profile "$threshold_profile" \
   --arg ingest_status "$ingest_status" \
   --arg failure_code "$failure_code" \
   --arg last_transport_failure_code "$last_transport_failure_code" \
@@ -326,6 +333,7 @@ health_json=$(jq -cn \
       lifecycleState: $lifecycle_state
     },
     thresholds: {
+      profile: (if ($threshold_profile | length) > 0 then $threshold_profile else null end),
       degradedIngestLagSeconds: $degraded_ingest,
       criticalIngestLagSeconds: $critical_ingest,
       degradedTransportFailureStreak: $degraded_streak,

--- a/scripts/ops-manager-telemetry-summary.sh
+++ b/scripts/ops-manager-telemetry-summary.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-telemetry-summary.sh --repo <path> --loop <id> [options]
+
+Options:
+  --reconcile-telemetry-file <path>   Reconcile telemetry JSONL path.
+  --control-telemetry-file <path>     Control telemetry JSONL path.
+  --window <n>                        Number of most recent entries to summarize (default: 200).
+  --pretty                            Pretty-print output JSON.
+  --help                              Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+repo=""
+loop_id=""
+reconcile_file=""
+control_file=""
+window="200"
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --loop)
+      loop_id="${2:-}"
+      shift 2
+      ;;
+    --reconcile-telemetry-file)
+      reconcile_file="${2:-}"
+      shift 2
+      ;;
+    --control-telemetry-file)
+      control_file="${2:-}"
+      shift 2
+      ;;
+    --window)
+      window="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ -z "$loop_id" ]]; then
+  die "--loop is required"
+fi
+if [[ ! "$window" =~ ^[0-9]+$ || "$window" -lt 1 ]]; then
+  die "--window must be an integer >= 1"
+fi
+
+repo="$(cd "$repo" && pwd)"
+ops_dir="$repo/.superloop/ops-manager/$loop_id"
+telemetry_dir="$ops_dir/telemetry"
+
+if [[ -z "$reconcile_file" ]]; then
+  reconcile_file="$telemetry_dir/reconcile.jsonl"
+fi
+if [[ -z "$control_file" ]]; then
+  control_file="$telemetry_dir/control.jsonl"
+fi
+
+if [[ ! -f "$reconcile_file" ]]; then
+  die "reconcile telemetry file not found: $reconcile_file"
+fi
+
+reconcile_sample="$(mktemp)"
+control_sample="$(mktemp)"
+trap 'rm -f "$reconcile_sample" "$control_sample"' EXIT
+
+tail -n "$window" "$reconcile_file" > "$reconcile_sample"
+if [[ -f "$control_file" ]]; then
+  tail -n "$window" "$control_file" > "$control_sample"
+else
+  : > "$control_sample"
+fi
+
+summary_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg generated_at "$(timestamp)" \
+  --arg repo_path "$repo" \
+  --arg loop_id "$loop_id" \
+  --arg reconcile_file "$reconcile_file" \
+  --arg control_file "$control_file" \
+  --argjson window "$window" \
+  --slurpfile rec "$reconcile_sample" \
+  --slurpfile ctl "$control_sample" '
+  def percentile($arr; $p):
+    if ($arr | length) == 0 then null
+    else ($arr | sort | .[((($arr | length) - 1) * $p | floor)])
+    end;
+  def ratio($num; $den): if $den == 0 then 0 else ($num / $den) end;
+  def freq_map($arr):
+    ($arr
+      | group_by(.)
+      | map({code: .[0], count: length})
+      | sort_by(.count)
+      | reverse);
+
+  ($rec // []) as $reconcile
+  | ($ctl // []) as $control
+  | ($reconcile | length) as $attempts
+  | ($reconcile | map(select(.status == "success")) | length) as $success_count
+  | ($reconcile | map(select(.status == "failed")) | length) as $failed_count
+  | ($reconcile | map(select(.healthStatus == "degraded")) | length) as $degraded_count
+  | ($reconcile | map(select(.healthStatus == "critical")) | length) as $critical_count
+  | ($reconcile | map(.healthReasonCodes[]?)) as $all_reason_codes
+  | ($reconcile | map(.durationSeconds | tonumber? // empty)) as $durations
+  | ($control | map(select(.status == "ambiguous" or .reasonCode == "control_ambiguous")) | length) as $ambiguous_count
+  | ratio($failed_count; $attempts) as $failed_rate
+  | ratio($degraded_count; $attempts) as $degraded_rate
+  | ratio($critical_count; $attempts) as $critical_rate
+  | (if $attempts >= 100 then "high" elif $attempts >= 30 then "medium" else "low" end) as $confidence
+  | (if $attempts == 0 then "balanced"
+     elif ($critical_rate >= 0.20 or $failed_rate >= 0.25) then "relaxed"
+     elif ($critical_rate == 0 and $degraded_rate <= 0.05 and $failed_rate <= 0.02 and $ambiguous_count == 0) then "strict"
+     else "balanced"
+     end) as $recommended_profile
+  | (if $attempts == 0 then "No telemetry window yet; keep balanced defaults"
+     elif $recommended_profile == "relaxed" then "Observed high critical/failure rates; reduce alert noise while stabilizing"
+     elif $recommended_profile == "strict" then "Observed stable healthy runs; tighten thresholds for faster detection"
+     else "Observed mixed signals; keep balanced thresholds"
+     end) as $rationale
+  | {
+      schemaVersion: $schema_version,
+      generatedAt: $generated_at,
+      source: {
+        repoPath: $repo_path,
+        loopId: $loop_id,
+        reconcileTelemetryFile: $reconcile_file,
+        controlTelemetryFile: $control_file,
+        window: $window
+      },
+      observed: {
+        reconcileAttempts: $attempts,
+        reconcileSuccessCount: $success_count,
+        reconcileFailedCount: $failed_count,
+        health: {
+          degradedCount: $degraded_count,
+          criticalCount: $critical_count,
+          degradedRate: $degraded_rate,
+          criticalRate: $critical_rate,
+          reasonCodeFrequency: freq_map($all_reason_codes)
+        },
+        control: {
+          ambiguousCount: $ambiguous_count
+        },
+        durationSeconds: {
+          p50: percentile($durations; 0.50),
+          p95: percentile($durations; 0.95),
+          max: (if ($durations | length) == 0 then null else ($durations | max) end)
+        }
+      },
+      recommendedProfile: $recommended_profile,
+      confidence: $confidence,
+      rationale: $rationale
+    }')
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$summary_json"
+else
+  jq -c '.' <<<"$summary_json"
+fi

--- a/scripts/ops-manager-threshold-profile.sh
+++ b/scripts/ops-manager-threshold-profile.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-threshold-profile.sh [options]
+
+Options:
+  --profiles-file <path>   Profile catalog JSON file.
+  --profile <name>         Profile name. Defaults to catalog defaultProfile.
+  --list                   List available profile names and exit.
+  --pretty                 Pretty-print output JSON.
+  --help                   Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+profiles_file=""
+profile_name=""
+list_only="0"
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profiles-file)
+      profiles_file="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      profile_name="${2:-}"
+      shift 2
+      ;;
+    --list)
+      list_only="1"
+      shift
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+
+if [[ -z "$profiles_file" ]]; then
+  profiles_file="${OPS_MANAGER_THRESHOLD_PROFILES_FILE:-$root_dir/config/ops-manager-threshold-profiles.v1.json}"
+fi
+
+if [[ ! -f "$profiles_file" ]]; then
+  die "threshold profiles file not found: $profiles_file"
+fi
+
+profiles_json=$(jq -c '.' "$profiles_file" 2>/dev/null) || die "invalid threshold profiles JSON: $profiles_file"
+
+if ! jq -e '.schemaVersion == "v1" and (.profiles | type == "object") and ((.profiles | keys | length) > 0)' <<<"$profiles_json" >/dev/null; then
+  die "threshold profiles file has invalid shape"
+fi
+
+if [[ "$list_only" == "1" ]]; then
+  jq -r '.profiles | keys[]' <<<"$profiles_json"
+  exit 0
+fi
+
+if [[ -z "$profile_name" ]]; then
+  profile_name=$(jq -r '.defaultProfile // empty' <<<"$profiles_json")
+fi
+if [[ -z "$profile_name" ]]; then
+  die "profile name is required and defaultProfile is missing"
+fi
+
+if ! jq -e --arg profile "$profile_name" '.profiles[$profile] != null' <<<"$profiles_json" >/dev/null; then
+  die "unknown threshold profile: $profile_name"
+fi
+
+if ! jq -e --arg profile "$profile_name" '
+  .profiles[$profile] as $p
+  | ($p.degradedIngestLagSeconds | type == "number")
+    and ($p.criticalIngestLagSeconds | type == "number")
+    and ($p.degradedTransportFailureStreak | type == "number")
+    and ($p.criticalTransportFailureStreak | type == "number")
+    and ($p.criticalIngestLagSeconds >= $p.degradedIngestLagSeconds)
+    and ($p.criticalTransportFailureStreak >= $p.degradedTransportFailureStreak)
+' <<<"$profiles_json" >/dev/null; then
+  die "threshold profile values are invalid: $profile_name"
+fi
+
+resolved_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg source_file "$profiles_file" \
+  --arg profile "$profile_name" \
+  --argjson root "$profiles_json" \
+  '{
+    schemaVersion: $schema_version,
+    sourceFile: $source_file,
+    profile: $profile,
+    values: {
+      degradedIngestLagSeconds: ($root.profiles[$profile].degradedIngestLagSeconds | tonumber),
+      criticalIngestLagSeconds: ($root.profiles[$profile].criticalIngestLagSeconds | tonumber),
+      degradedTransportFailureStreak: ($root.profiles[$profile].degradedTransportFailureStreak | tonumber),
+      criticalTransportFailureStreak: ($root.profiles[$profile].criticalTransportFailureStreak | tonumber)
+    },
+    description: ($root.profiles[$profile].description // null)
+  } | with_entries(select(.value != null))')
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$resolved_json"
+else
+  jq -c '.' <<<"$resolved_json"
+fi

--- a/tests/ops-manager-threshold-tuning.bats
+++ b/tests/ops-manager-threshold-tuning.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+write_runtime_artifacts() {
+  local repo="$1"
+  local loop_id="$2"
+  local event_ts="$3"
+
+  mkdir -p "$repo/.superloop/loops/$loop_id"
+
+  cat > "$repo/.superloop/state.json" <<JSON
+{"active":true,"loop_index":0,"iteration":2,"current_loop_id":"$loop_id","updated_at":"$event_ts"}
+JSON
+
+  cat > "$repo/.superloop/loops/$loop_id/run-summary.json" <<JSON
+{"version":1,"loop_id":"$loop_id","updated_at":"$event_ts","entries":[{"run_id":"run-123","iteration":1,"gates":{"tests":"ok","validation":"ok","prerequisites":"ok","checklist":"ok","evidence":"skipped","approval":"none"},"stuck":{"streak":0,"threshold":3},"completion_ok":false,"ended_at":"$event_ts"}]}
+JSON
+
+  cat > "$repo/.superloop/loops/$loop_id/events.jsonl" <<JSONL
+{"timestamp":"$event_ts","event":"loop_start","loop_id":"$loop_id","run_id":"run-123","iteration":1,"data":{"max_iterations":5}}
+{"timestamp":"$event_ts","event":"iteration_start","loop_id":"$loop_id","run_id":"run-123","iteration":2,"data":{"started_at":"$event_ts"}}
+JSONL
+}
+
+@test "threshold profile resolver lists expected profiles" {
+  run "$PROJECT_ROOT/scripts/ops-manager-threshold-profile.sh" --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"strict"* ]]
+  [[ "$output" == *"balanced"* ]]
+  [[ "$output" == *"relaxed"* ]]
+}
+
+@test "threshold profile resolver uses balanced catalog default" {
+  run "$PROJECT_ROOT/scripts/ops-manager-threshold-profile.sh"
+  [ "$status" -eq 0 ]
+  local resolver_json="$output"
+
+  run jq -r '.profile' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "balanced" ]
+
+  run jq -r '.values.criticalTransportFailureStreak' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "4" ]
+}
+
+@test "threshold profile resolver fails on unknown profile" {
+  run "$PROJECT_ROOT/scripts/ops-manager-threshold-profile.sh" --profile unknown
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown threshold profile"* ]]
+}
+
+@test "reconcile applies strict threshold profile into health output" {
+  local loop_id="demo-loop"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  write_runtime_artifacts "$TEMP_DIR" "$loop_id" "$now_ts"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --threshold-profile strict
+  [ "$status" -eq 0 ]
+  local state_json="$output"
+
+  run jq -r '.health.thresholds.profile' <<<"$state_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "strict" ]
+
+  run jq -r '.health.thresholds.degradedIngestLagSeconds' <<<"$state_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "120" ]
+}
+
+@test "reconcile explicit threshold flags override profile defaults" {
+  local loop_id="demo-loop"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  write_runtime_artifacts "$TEMP_DIR" "$loop_id" "$now_ts"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --threshold-profile strict \
+    --critical-ingest-lag-seconds 777
+  [ "$status" -eq 0 ]
+  local state_json="$output"
+
+  run jq -r '.health.thresholds.profile' <<<"$state_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "strict" ]
+
+  run jq -r '.health.thresholds.criticalIngestLagSeconds' <<<"$state_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "777" ]
+}
+
+@test "telemetry summary recommends relaxed for high critical and failed rates" {
+  local loop_id="demo-loop"
+  local telemetry_dir="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry"
+  mkdir -p "$telemetry_dir"
+
+  cat > "$telemetry_dir/reconcile.jsonl" <<'JSONL'
+{"timestamp":"2026-02-22T10:00:00Z","status":"failed","healthStatus":"critical","healthReasonCodes":["transport_unreachable"],"durationSeconds":3}
+{"timestamp":"2026-02-22T10:01:00Z","status":"failed","healthStatus":"critical","healthReasonCodes":["transport_unreachable"],"durationSeconds":4}
+{"timestamp":"2026-02-22T10:02:00Z","status":"success","healthStatus":"degraded","healthReasonCodes":["ingest_stale"],"durationSeconds":2}
+{"timestamp":"2026-02-22T10:03:00Z","status":"success","healthStatus":"healthy","healthReasonCodes":[],"durationSeconds":1}
+JSONL
+
+  run "$PROJECT_ROOT/scripts/ops-manager-telemetry-summary.sh" --repo "$TEMP_DIR" --loop "$loop_id" --window 50
+  [ "$status" -eq 0 ]
+  local summary_json="$output"
+
+  run jq -r '.recommendedProfile' <<<"$summary_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "relaxed" ]
+}
+
+@test "telemetry summary recommends strict for stable healthy window" {
+  local loop_id="demo-loop"
+  local telemetry_dir="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry"
+  mkdir -p "$telemetry_dir"
+
+  for i in $(seq 1 40); do
+    printf '{"timestamp":"2026-02-22T10:%02d:00Z","status":"success","healthStatus":"healthy","healthReasonCodes":[],"durationSeconds":1}\n' "$i" >> "$telemetry_dir/reconcile.jsonl"
+  done
+
+  run "$PROJECT_ROOT/scripts/ops-manager-telemetry-summary.sh" --repo "$TEMP_DIR" --loop "$loop_id" --window 40
+  [ "$status" -eq 0 ]
+  local summary_json="$output"
+
+  run jq -r '.recommendedProfile' <<<"$summary_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "strict" ]
+
+  run jq -r '.confidence' <<<"$summary_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "medium" ]
+}
+
+@test "status includes tuning guidance fields" {
+  local loop_id="demo-loop"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  write_runtime_artifacts "$TEMP_DIR" "$loop_id" "$now_ts"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --threshold-profile balanced
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-status.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --summary-window 25
+  [ "$status" -eq 0 ]
+  local status_json="$output"
+
+  run jq -r '.tuning.appliedProfile' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "balanced" ]
+
+  run jq -r '.tuning.summaryWindow' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "25" ]
+
+  run jq -r '.tuning.recommendedProfile' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}


### PR DESCRIPTION
## Summary
- add dogfood threshold profile catalog at `config/ops-manager-threshold-profiles.v1.json` (`strict|balanced|relaxed`)
- add `scripts/ops-manager-threshold-profile.sh` for profile resolution and fail-closed validation
- add `scripts/ops-manager-telemetry-summary.sh` for telemetry aggregates + recommended profile + rationale
- wire `scripts/ops-manager-reconcile.sh` to support:
  - `--threshold-profile`
  - `--thresholds-file`
  - deterministic threshold precedence (explicit flags > selected profile > catalog default)
  - profile propagation into health + telemetry
- extend `scripts/ops-manager-status.sh` with tuning context (`appliedProfile`, `recommendedProfile`, `confidence`, `summaryWindow`)
- update `scripts/ops-manager-health.sh` to carry `thresholds.profile`
- add `tests/ops-manager-threshold-tuning.bats` and update docs/checklists for phase 4 P2

## Validation
- `bash -n scripts/ops-manager-reconcile.sh scripts/ops-manager-health.sh scripts/ops-manager-status.sh scripts/ops-manager-threshold-profile.sh scripts/ops-manager-telemetry-summary.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats`

Closes #49
