### PR TITLE
feat(ops-manager): profile drift detection and alerts (Phase 5)

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/PLAN.MD
@@ -1,0 +1,61 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 5 Profile Drift Alerts)
+
+## Goal
+Introduce automated profile-drift detection so ops policy and observed runtime behavior stay aligned across sustained dogfood operation.
+
+## Scope
+- Detect mismatch between applied threshold profile and telemetry-recommended profile.
+- Add confidence-gated streak logic before raising drift alerts to reduce noise.
+- Persist profile-drift state/history in deterministic manager artifact paths.
+- Emit reason-coded escalations when drift becomes active.
+- Surface drift state and operator guidance in status output.
+
+## Non-Goals (this iteration)
+- Autonomous profile switching without operator control.
+- External alerting integrations (Slack/PagerDuty/email).
+- Multi-loop global policy optimization.
+
+## Primary References
+- `feat/ops-manager-superloop-sprites/phase-4-dogfood-hardening-observability/PLAN.MD`
+- `scripts/ops-manager-reconcile.sh`
+- `scripts/ops-manager-status.sh`
+- `scripts/ops-manager-telemetry-summary.sh`
+- `config/ops-manager-threshold-profiles.v1.json`
+- `docs/ops-manager-v0.md`
+- `docs/ops-manager-runbook.md`
+
+## Architecture
+Phase 5 adds a drift-evaluation layer on top of existing health/tuning artifacts:
+
+1. Drift evaluator:
+- Compares applied profile vs recommended profile per reconcile window.
+- Applies confidence threshold + mismatch streak thresholds.
+- Outputs deterministic drift state for operator and automation consumers.
+
+2. Drift persistence:
+- Writes current drift state JSON per loop.
+- Appends drift events to telemetry history JSONL.
+
+3. Alert/evidence path:
+- Emits escalation records when drift transitions to active.
+- Includes rationale and recommendation context for operator action.
+
+## Decisions
+- Drift alerts are advisory; profile changes remain explicit operator actions.
+- Drift activation requires configurable consecutive mismatch streak.
+- Confidence gating defaults to `medium` to avoid low-signal noise.
+- All drift artifacts remain file-first under `.superloop/ops-manager/<loop>/`.
+
+## Risks / Constraints
+- Overly strict streak/confidence thresholds may suppress meaningful drift.
+- Overly loose thresholds may create alert fatigue.
+- Drift logic must remain transport-agnostic (`local` and `sprite_service`).
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Implement drift evaluator, persistence, escalations, status fields, tests, and docs.

--- a/feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/tasks/PHASE_1.MD
@@ -1,0 +1,36 @@
+# Phase 1 - Profile Drift Detection + Alerts
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/PLAN.MD` aligns with prior phases and current repo state.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/52`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`, `#46`, `#48`, `#50`).
+
+## P1.1 Drift Evaluator
+1. [x] Add profile-drift evaluator script with confidence-gated mismatch logic.
+2. [x] Add configurable activation controls (required mismatch streak, minimum confidence).
+3. [x] Fail closed on invalid inputs (unknown confidence/profile values).
+
+## P1.2 Persistence and Escalation
+1. [x] Persist current drift state JSON under `.superloop/ops-manager/<loop>/`.
+2. [x] Append drift history records under `.superloop/ops-manager/<loop>/telemetry/`.
+3. [x] Emit escalation entries when drift transitions to active.
+
+## P1.3 Pipeline Integration
+1. [x] Integrate drift evaluation into reconcile pipeline after telemetry summary recommendation.
+2. [x] Include drift context in reconcile/state outputs.
+3. [x] Ensure status output includes drift fields and actionable guidance.
+
+## P1.4 Test Coverage
+1. [x] Add `tests/ops-manager-profile-drift.bats` for drift activation/reset logic.
+2. [x] Add/extend tests proving reconcile and status include drift artifacts.
+3. [x] Verify transport parity for drift logic (`local` vs `sprite_service`) where applicable.
+
+## P1.5 Docs and Runbook
+1. [x] Update `docs/ops-manager-v0.md` with drift artifact schema and commands.
+2. [x] Update `docs/ops-manager-runbook.md` with drift triage workflow.
+3. [x] Document operator actions for active drift (advisory only, no auto-switch).
+
+## P1.V Validation
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Updated docs match implemented drift fields/artifacts and operator flow.

--- a/scripts/ops-manager-profile-drift.sh
+++ b/scripts/ops-manager-profile-drift.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-profile-drift.sh --repo <path> --loop <id> [options]
+
+Options:
+  --applied-profile <name>             Applied threshold profile.
+  --recommended-profile <name>         Recommended threshold profile.
+  --thresholds-file <path>             Threshold profile catalog JSON path.
+  --recommendation-confidence <level>  Recommendation confidence (low|medium|high).
+  --min-confidence <level>             Minimum confidence to count mismatch (default: medium).
+  --required-streak <n>                Consecutive eligible mismatches to activate drift (default: 3).
+  --summary-window <n>                 Summary window metadata (default: 200).
+  --rationale <text>                   Recommendation rationale text.
+  --drift-state-file <path>            Drift state JSON path. Default: <repo>/.superloop/ops-manager/<loop>/profile-drift.json
+  --drift-history-file <path>          Drift history JSONL path. Default: <repo>/.superloop/ops-manager/<loop>/telemetry/profile-drift.jsonl
+  --pretty                             Pretty-print output JSON.
+  --help                               Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+confidence_rank() {
+  case "$1" in
+    low) echo 1 ;;
+    medium) echo 2 ;;
+    high) echo 3 ;;
+    *) return 1 ;;
+  esac
+}
+
+repo=""
+loop_id=""
+applied_profile=""
+recommended_profile=""
+thresholds_file=""
+recommendation_confidence="low"
+min_confidence="medium"
+required_streak="3"
+summary_window="200"
+rationale=""
+drift_state_file=""
+drift_history_file=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --loop)
+      loop_id="${2:-}"
+      shift 2
+      ;;
+    --applied-profile)
+      applied_profile="${2:-}"
+      shift 2
+      ;;
+    --recommended-profile)
+      recommended_profile="${2:-}"
+      shift 2
+      ;;
+    --thresholds-file)
+      thresholds_file="${2:-}"
+      shift 2
+      ;;
+    --recommendation-confidence)
+      recommendation_confidence="${2:-}"
+      shift 2
+      ;;
+    --min-confidence)
+      min_confidence="${2:-}"
+      shift 2
+      ;;
+    --required-streak)
+      required_streak="${2:-}"
+      shift 2
+      ;;
+    --summary-window)
+      summary_window="${2:-}"
+      shift 2
+      ;;
+    --rationale)
+      rationale="${2:-}"
+      shift 2
+      ;;
+    --drift-state-file)
+      drift_state_file="${2:-}"
+      shift 2
+      ;;
+    --drift-history-file)
+      drift_history_file="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ -z "$loop_id" ]]; then
+  die "--loop is required"
+fi
+if [[ ! "$required_streak" =~ ^[0-9]+$ || "$required_streak" -lt 1 ]]; then
+  die "--required-streak must be an integer >= 1"
+fi
+if [[ ! "$summary_window" =~ ^[0-9]+$ || "$summary_window" -lt 1 ]]; then
+  die "--summary-window must be an integer >= 1"
+fi
+if ! confidence_rank "$recommendation_confidence" >/dev/null; then
+  die "--recommendation-confidence must be one of: low, medium, high"
+fi
+if ! confidence_rank "$min_confidence" >/dev/null; then
+  die "--min-confidence must be one of: low, medium, high"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+ops_dir="$repo/.superloop/ops-manager/$loop_id"
+telemetry_dir="$ops_dir/telemetry"
+
+if [[ -z "$thresholds_file" && -n "${OPS_MANAGER_THRESHOLD_PROFILES_FILE:-}" ]]; then
+  thresholds_file="$OPS_MANAGER_THRESHOLD_PROFILES_FILE"
+fi
+if [[ -z "$thresholds_file" ]]; then
+  thresholds_file="$root_dir/config/ops-manager-threshold-profiles.v1.json"
+fi
+if ! jq -e '.profiles | type == "object"' "$thresholds_file" >/dev/null 2>&1; then
+  die "invalid threshold profiles file: $thresholds_file"
+fi
+if [[ -n "$applied_profile" ]] && ! jq -e --arg p "$applied_profile" '.profiles[$p] != null' "$thresholds_file" >/dev/null 2>&1; then
+  die "unknown applied profile: $applied_profile"
+fi
+if [[ -n "$recommended_profile" ]] && ! jq -e --arg p "$recommended_profile" '.profiles[$p] != null' "$thresholds_file" >/dev/null 2>&1; then
+  die "unknown recommended profile: $recommended_profile"
+fi
+
+if [[ -z "$drift_state_file" ]]; then
+  drift_state_file="$ops_dir/profile-drift.json"
+fi
+if [[ -z "$drift_history_file" ]]; then
+  drift_history_file="$telemetry_dir/profile-drift.jsonl"
+fi
+
+mkdir -p "$(dirname "$drift_state_file")"
+mkdir -p "$(dirname "$drift_history_file")"
+
+previous_json='{}'
+if [[ -f "$drift_state_file" ]]; then
+  previous_json=$(jq -c '.' "$drift_state_file" 2>/dev/null) || die "invalid drift state JSON: $drift_state_file"
+fi
+
+previous_streak=$(jq -r '.mismatchStreak // 0' <<<"$previous_json")
+if [[ ! "$previous_streak" =~ ^[0-9]+$ ]]; then
+  previous_streak=0
+fi
+previous_active=$(jq -r '.driftActive // false' <<<"$previous_json")
+
+recommendation_rank=$(confidence_rank "$recommendation_confidence")
+minimum_rank=$(confidence_rank "$min_confidence")
+confidence_ok="false"
+if (( recommendation_rank >= minimum_rank )); then
+  confidence_ok="true"
+fi
+
+mismatch="false"
+if [[ -n "$applied_profile" && -n "$recommended_profile" && "$applied_profile" != "$recommended_profile" ]]; then
+  mismatch="true"
+fi
+
+eligible_mismatch="false"
+if [[ "$mismatch" == "true" && "$confidence_ok" == "true" ]]; then
+  eligible_mismatch="true"
+fi
+
+mismatch_streak=0
+if [[ "$eligible_mismatch" == "true" ]]; then
+  mismatch_streak=$(( previous_streak + 1 ))
+fi
+
+drift_active="false"
+if (( mismatch_streak >= required_streak )); then
+  drift_active="true"
+fi
+
+transition_to_active="false"
+transition_to_resolved="false"
+if [[ "$drift_active" == "true" && "$previous_active" != "true" ]]; then
+  transition_to_active="true"
+fi
+if [[ "$drift_active" != "true" && "$previous_active" == "true" ]]; then
+  transition_to_resolved="true"
+fi
+
+status="aligned"
+reason_code=""
+if [[ -z "$recommended_profile" ]]; then
+  status="no_recommendation"
+elif [[ "$mismatch" != "true" ]]; then
+  status="aligned"
+elif [[ "$confidence_ok" != "true" ]]; then
+  status="insufficient_confidence"
+elif [[ "$drift_active" == "true" ]]; then
+  status="drift_active"
+  reason_code="profile_drift_detected"
+else
+  status="mismatch_pending"
+fi
+
+drift_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg updated_at "$(timestamp)" \
+  --arg loop_id "$loop_id" \
+  --arg applied_profile "$applied_profile" \
+  --arg recommended_profile "$recommended_profile" \
+  --arg recommendation_confidence "$recommendation_confidence" \
+  --arg min_confidence "$min_confidence" \
+  --argjson required_streak "$required_streak" \
+  --argjson summary_window "$summary_window" \
+  --argjson mismatch_streak "$mismatch_streak" \
+  --argjson recommendation_rank "$recommendation_rank" \
+  --argjson minimum_rank "$minimum_rank" \
+  --argjson mismatch "$mismatch" \
+  --argjson confidence_ok "$confidence_ok" \
+  --argjson eligible_mismatch "$eligible_mismatch" \
+  --argjson drift_active "$drift_active" \
+  --argjson transition_to_active "$transition_to_active" \
+  --argjson transition_to_resolved "$transition_to_resolved" \
+  --arg status "$status" \
+  --arg reason_code "$reason_code" \
+  --arg rationale "$rationale" \
+  '{
+    schemaVersion: $schema_version,
+    updatedAt: $updated_at,
+    loopId: $loop_id,
+    status: $status,
+    reasonCode: (if ($reason_code | length) > 0 then $reason_code else null end),
+    appliedProfile: (if ($applied_profile | length) > 0 then $applied_profile else null end),
+    recommendedProfile: (if ($recommended_profile | length) > 0 then $recommended_profile else null end),
+    recommendationConfidence: $recommendation_confidence,
+    minimumConfidence: $min_confidence,
+    recommendationRank: $recommendation_rank,
+    minimumRank: $minimum_rank,
+    requiredStreak: $required_streak,
+    summaryWindow: $summary_window,
+    mismatch: $mismatch,
+    confidenceOk: $confidence_ok,
+    eligibleMismatch: $eligible_mismatch,
+    mismatchStreak: $mismatch_streak,
+    driftActive: $drift_active,
+    transitioned: {
+      toActive: $transition_to_active,
+      toResolved: $transition_to_resolved
+    },
+    rationale: (if ($rationale | length) > 0 then $rationale else null end),
+    action: (
+      if $drift_active == true then "review_threshold_profile"
+      elif $status == "mismatch_pending" then "monitor_additional_windows"
+      elif $status == "insufficient_confidence" then "collect_more_confident_telemetry"
+      else null
+      end
+    )
+  } | with_entries(select(.value != null))')
+
+jq -c '.' <<<"$drift_json" > "$drift_state_file"
+
+history_entry=$(jq -cn \
+  --arg timestamp "$(timestamp)" \
+  --arg loop_id "$loop_id" \
+  --argjson drift "$drift_json" \
+  '{
+    timestamp: $timestamp,
+    loopId: $loop_id,
+    category: "profile_drift_evaluation",
+    drift: $drift
+  }')
+printf '%s\n' "$history_entry" >> "$drift_history_file"
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$drift_json"
+else
+  jq -c '.' <<<"$drift_json"
+fi

--- a/tests/ops-manager-profile-drift.bats
+++ b/tests/ops-manager-profile-drift.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+@test "profile drift activates after required mismatch streak" {
+  local loop_id="demo-loop"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile balanced \
+    --recommended-profile relaxed \
+    --recommendation-confidence high \
+    --required-streak 2 \
+    --summary-window 40
+  [ "$status" -eq 0 ]
+  local first_json="$output"
+
+  run jq -r '.status' <<<"$first_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "mismatch_pending" ]
+
+  run jq -r '.mismatchStreak' <<<"$first_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.driftActive' <<<"$first_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile balanced \
+    --recommended-profile relaxed \
+    --recommendation-confidence high \
+    --required-streak 2 \
+    --summary-window 40
+  [ "$status" -eq 0 ]
+  local second_json="$output"
+
+  run jq -r '.status' <<<"$second_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "drift_active" ]
+
+  run jq -r '.driftActive' <<<"$second_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.transitioned.toActive' <<<"$second_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  local drift_state_file="$TEMP_DIR/.superloop/ops-manager/$loop_id/profile-drift.json"
+  local drift_history_file="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry/profile-drift.jsonl"
+  [ -f "$drift_state_file" ]
+  [ -f "$drift_history_file" ]
+
+  run jq -r '.status' "$drift_state_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "drift_active" ]
+
+  run bash -lc "wc -l < '$drift_history_file' | tr -d ' '"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+}
+
+@test "profile drift resolves when profiles realign" {
+  local loop_id="demo-loop"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile balanced \
+    --recommended-profile strict \
+    --recommendation-confidence high \
+    --required-streak 1
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile balanced \
+    --recommended-profile balanced \
+    --recommendation-confidence high \
+    --required-streak 1
+  [ "$status" -eq 0 ]
+  local resolved_json="$output"
+
+  run jq -r '.status' <<<"$resolved_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "aligned" ]
+
+  run jq -r '.driftActive' <<<"$resolved_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.mismatchStreak' <<<"$resolved_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+
+  run jq -r '.transitioned.toResolved' <<<"$resolved_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "profile drift mismatch is gated when confidence is below minimum" {
+  local loop_id="demo-loop"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile balanced \
+    --recommended-profile strict \
+    --recommendation-confidence low \
+    --min-confidence high \
+    --required-streak 1
+  [ "$status" -eq 0 ]
+  local drift_json="$output"
+
+  run jq -r '.status' <<<"$drift_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "insufficient_confidence" ]
+
+  run jq -r '.eligibleMismatch' <<<"$drift_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.mismatchStreak' <<<"$drift_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "profile drift fails closed on unknown threshold profile names" {
+  local loop_id="demo-loop"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-profile-drift.sh" \
+    --repo "$TEMP_DIR" \
+    --loop "$loop_id" \
+    --applied-profile unknown-profile \
+    --recommended-profile balanced \
+    --recommendation-confidence high
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown applied profile"* ]]
+}


### PR DESCRIPTION
## Summary
- add `scripts/ops-manager-profile-drift.sh` with confidence-gated mismatch streak evaluation and fail-closed profile validation
- integrate drift evaluation into `ops-manager-reconcile.sh` after telemetry summary, persist drift artifacts, and emit `profile_drift_detected` escalations on active transition
- extend `ops-manager-status.sh` to surface drift state/action fields and drift artifact file paths
- add test coverage for drift evaluator behavior, reconcile/status drift artifacts, and local vs sprite_service parity
- update ops manager v0 contract/runbook docs and Phase 5 packet checklist

## Validation
- `bash -n scripts/ops-manager-reconcile.sh`
- `bash -n scripts/ops-manager-status.sh`
- `bash -n scripts/ops-manager-profile-drift.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats`

Closes #52
