### PR TITLE
chore(ops-manager): scaffold phase 6 external alert sinks packet

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/PLAN.MD
@@ -1,0 +1,64 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 6 External Alert Sinks)
+
+## Goal
+Add operator-configurable external alert sinks so profile drift and health escalations can be pushed out of file artifacts into actionable notification channels.
+
+## Scope
+- Introduce sink-agnostic alert dispatch from manager escalation artifacts.
+- Add configurable sink routing policy for severity/category mapping.
+- Support first sink targets through deterministic adapters (`webhook`, `slack`, `pagerduty_events`).
+- Preserve existing file-first artifacts while adding non-blocking delivery telemetry.
+- Surface delivery status in operator status output and runbook workflows.
+
+## Non-Goals (this iteration)
+- Autonomous remediation actions (dispatch remains notify-only).
+- Rich incident management workflows (ack, assign, resolve lifecycles).
+- Multi-tenant org-level alert policy management.
+- Vendor lock-in SDK dependencies beyond lightweight HTTP adapters.
+
+## Primary References
+- `feat/ops-manager-superloop-sprites/phase-5-profile-drift-alerts/PLAN.MD`
+- `scripts/ops-manager-reconcile.sh`
+- `scripts/ops-manager-status.sh`
+- `scripts/ops-manager-control.sh`
+- `docs/ops-manager-v0.md`
+- `docs/ops-manager-runbook.md`
+
+## Architecture
+Phase 6 layers a delivery plane on top of existing escalation generation:
+
+1. Alert dispatch adapter:
+- Read newly emitted escalation records and map each to sink payload envelopes.
+- Enforce per-sink validation and normalized category/severity fields.
+- Record delivery attempts and outcomes as append-only telemetry.
+
+2. Routing and policy:
+- Add a versioned alert sink config with enabled sinks, categories, and delivery thresholds.
+- Support environment-driven secrets/tokens with fail-closed config validation.
+- Keep dispatch idempotent to avoid duplicate notifications on repeated reconcile passes.
+
+3. Operator surfaces:
+- Extend status with last alert delivery state and failure reason summary.
+- Update runbook with alert outage triage and safe fallback behavior.
+- Keep local and sprite_service dispatch semantics aligned.
+
+## Decisions
+- Keep alert dispatch advisory-only and side-effect isolated from control intent flows.
+- Default delivery behavior is fail-open for reconcile execution, fail-closed for invalid sink configuration.
+- Start with HTTP-based adapters to keep portability high and operational overhead low.
+- Persist all delivery telemetry under `.superloop/ops-manager/<loop>/telemetry/`.
+
+## Risks / Constraints
+- Misconfigured sink credentials/endpoints can create silent notification gaps.
+- Alert fanout without deduplication can cause noisy repeats during churn.
+- External API rate limits and transient failures can delay notifications.
+- Payload schema drift across sink providers can break adapter compatibility.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Implement alert sink config/dispatch, status exposure, docs, and tests.

--- a/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD
@@ -1,0 +1,36 @@
+# Phase 1 - External Alert Sink Dispatch
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-6-alert-sinks/PLAN.MD` aligns with prior phases and current repo state.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/54`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`, `#46`, `#48`, `#50`, `#53`).
+
+## P1.1 Alert Sink Config Contract
+1. [ ] Add versioned alert sink config file and schema (enabled sinks, routing policy, severity/category mapping).
+2. [ ] Add config resolver script with fail-closed validation and env-secret references.
+3. [ ] Document defaults and override precedence.
+
+## P1.2 Dispatch Pipeline Integration
+1. [ ] Add alert dispatch script that consumes newly emitted escalation entries.
+2. [ ] Integrate dispatch invocation into reconcile flow without breaking existing reconcile exit semantics.
+3. [ ] Ensure dispatch is idempotent across repeated reconciles.
+
+## P1.3 Sink Adapters and Telemetry
+1. [ ] Implement adapter support for `webhook`, `slack`, and `pagerduty_events`.
+2. [ ] Persist delivery attempt/outcome telemetry under `.superloop/ops-manager/<loop>/telemetry/`.
+3. [ ] Record reason-coded delivery failures for operator triage.
+
+## P1.4 Operator Surface + Runbook
+1. [ ] Extend `scripts/ops-manager-status.sh` with last alert delivery summary fields.
+2. [ ] Update `docs/ops-manager-v0.md` with alert sink contract and telemetry artifacts.
+3. [ ] Update `docs/ops-manager-runbook.md` with alert failure/outage triage and fallback guidance.
+
+## P1.5 Test Coverage
+1. [ ] Add `tests/ops-manager-alert-sinks.bats` for config validation, dispatch success/failure, and idempotency.
+2. [ ] Add/extend tests proving status includes alert delivery summaries.
+3. [ ] Verify transport parity for alert dispatch (`local` vs `sprite_service`) where applicable.
+
+## P1.V Validation
+1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats` passes.
+2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+3. [ ] Updated docs match implemented alert sink artifacts, fields, and operator flow.


### PR DESCRIPTION
## Summary
- scaffold Phase 6 planning packet for ops-manager external alert sinks
- add Phase 6 plan (`PLAN.MD`) covering scope, architecture, decisions, risks, and gate baseline
- add Phase 6 task checklist (`tasks/PHASE_1.MD`) with implementation, testing, and doc workstreams
- open and link tracking issue #54 in the phase checklist baseline

## Files
- `feat/ops-manager-superloop-sprites/phase-6-alert-sinks/PLAN.MD`
- `feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD`

Refs #54
