### PR TITLE
feat(ops-manager): add alert sink config resolver contract

### DIFF
--- a/config/ops-manager-alert-sinks.v1.json
+++ b/config/ops-manager-alert-sinks.v1.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "v1",
+  "defaultMinSeverity": "warning",
+  "sinks": {
+    "webhook-default": {
+      "enabled": false,
+      "type": "webhook",
+      "urlEnv": "OPS_MANAGER_ALERT_WEBHOOK_URL",
+      "authTokenEnv": "OPS_MANAGER_ALERT_WEBHOOK_TOKEN",
+      "timeoutSeconds": 5,
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    },
+    "slack-default": {
+      "enabled": false,
+      "type": "slack",
+      "webhookUrlEnv": "OPS_MANAGER_ALERT_SLACK_WEBHOOK_URL",
+      "channel": "#ops-alerts",
+      "username": "ops-manager",
+      "iconEmoji": ":rotating_light:",
+      "timeoutSeconds": 5
+    },
+    "pagerduty-default": {
+      "enabled": false,
+      "type": "pagerduty_events",
+      "routingKeyEnv": "OPS_MANAGER_ALERT_PAGERDUTY_ROUTING_KEY",
+      "source": "superloop-ops-manager",
+      "component": "ops-manager",
+      "group": "loop-run",
+      "class": "escalation",
+      "timeoutSeconds": 5
+    }
+  },
+  "routing": {
+    "defaultSinks": [
+      "webhook-default"
+    ],
+    "categorySeverity": {
+      "divergence_detected": "warning",
+      "health_degraded": "warning",
+      "health_critical": "critical",
+      "profile_drift_detected": "warning"
+    },
+    "routes": [
+      {
+        "category": "health_critical",
+        "sinks": [
+          "pagerduty-default",
+          "slack-default"
+        ],
+        "minSeverity": "critical",
+        "enabled": true
+      },
+      {
+        "category": "health_degraded",
+        "sinks": [
+          "slack-default"
+        ],
+        "minSeverity": "warning",
+        "enabled": true
+      },
+      {
+        "category": "divergence_detected",
+        "sinks": [
+          "slack-default"
+        ],
+        "minSeverity": "warning",
+        "enabled": true
+      },
+      {
+        "category": "profile_drift_detected",
+        "sinks": [
+          "slack-default"
+        ],
+        "minSeverity": "warning",
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/docs/ops-manager-runbook.md
+++ b/docs/ops-manager-runbook.md
@@ -19,6 +19,7 @@ Operational procedures for manager core behavior across local and sprite-service
 - profile drift telemetry: `.superloop/ops-manager/<loop>/telemetry/profile-drift.jsonl`
 - transport health: `.superloop/ops-manager/<loop>/telemetry/transport-health.json`
 - threshold profiles: `config/ops-manager-threshold-profiles.v1.json`
+- alert sinks config: `config/ops-manager-alert-sinks.v1.json`
 - runtime events: `.superloop/loops/<loop>/events.jsonl`
 
 ## Standard Reconcile
@@ -167,6 +168,24 @@ Operational reason codes expected in this flow:
 - `transport_unreachable`
 - `invalid_transport_payload`
 - `ingest_stale` (if outage delays event freshness long enough)
+
+## Alert Sink Config Baseline
+Resolve config and route behavior before enabling external dispatch:
+
+```bash
+scripts/ops-manager-alert-sink-config.sh --pretty
+scripts/ops-manager-alert-sink-config.sh --category health_critical --severity critical --pretty
+```
+
+Secret env checks:
+- Enabled sinks require configured env-secret references to be set.
+- Resolver is fail-closed by default when enabled sink secrets are missing.
+- Use `--no-env-check` only for dry-run catalog inspection.
+
+Config precedence:
+1. `--config-file`
+2. `OPS_MANAGER_ALERT_SINKS_FILE`
+3. `config/ops-manager-alert-sinks.v1.json`
 
 ## Threshold Tuning
 Default profile catalog (`config/ops-manager-threshold-profiles.v1.json`):

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -160,6 +160,22 @@ Purpose:
 - Enforces fail-closed behavior for unknown/invalid profiles.
 - Lists available profiles via `--list`.
 
+### Alert Sink Config Resolver
+```bash
+scripts/ops-manager-alert-sink-config.sh --pretty
+scripts/ops-manager-alert-sink-config.sh --category health_critical --severity critical --pretty
+```
+
+Purpose:
+- Resolves a versioned alert sink catalog with routing policy and category severity mapping.
+- Validates sink definitions and route references with fail-closed behavior.
+- Validates env-secret references for enabled sinks (can be bypassed with `--no-env-check`).
+
+Config file precedence:
+1. Explicit `--config-file`
+2. `OPS_MANAGER_ALERT_SINKS_FILE`
+3. `config/ops-manager-alert-sinks.v1.json`
+
 ### Telemetry Summary
 ```bash
 scripts/ops-manager-telemetry-summary.sh \
@@ -221,6 +237,8 @@ Transport mode switch:
 - `.superloop/ops-manager/<loop>/telemetry/profile-drift.jsonl` - profile drift history.
 - `.superloop/ops-manager/<loop>/telemetry/transport-health.json` - rolling transport failure streak state.
 - `config/ops-manager-threshold-profiles.v1.json` - threshold profile catalog (repo-level, versioned).
+- `config/ops-manager-alert-sinks.v1.json` - alert sink routing/catalog config (repo-level, versioned).
+- `schema/ops-manager-alert-sinks.config.schema.json` - JSON schema reference for alert sink config.
 
 ## Health Reason Codes
 Current reason-code surface used in health and escalation artifacts:

--- a/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD
@@ -6,9 +6,9 @@
 3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`, `#46`, `#48`, `#50`, `#53`).
 
 ## P1.1 Alert Sink Config Contract
-1. [ ] Add versioned alert sink config file and schema (enabled sinks, routing policy, severity/category mapping).
-2. [ ] Add config resolver script with fail-closed validation and env-secret references.
-3. [ ] Document defaults and override precedence.
+1. [x] Add versioned alert sink config file and schema (enabled sinks, routing policy, severity/category mapping).
+2. [x] Add config resolver script with fail-closed validation and env-secret references.
+3. [x] Document defaults and override precedence.
 
 ## P1.2 Dispatch Pipeline Integration
 1. [ ] Add alert dispatch script that consumes newly emitted escalation entries.

--- a/schema/ops-manager-alert-sinks.config.schema.json
+++ b/schema/ops-manager-alert-sinks.config.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://superloop.sh/schemas/ops-manager-alert-sinks-config-v1.json",
+  "title": "OpsManagerAlertSinksConfigV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "defaultMinSeverity",
+    "sinks",
+    "routing"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "defaultMinSeverity": {
+      "$ref": "#/$defs/severity"
+    },
+    "sinks": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/sink"
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "defaultSinks",
+        "categorySeverity",
+        "routes"
+      ],
+      "properties": {
+        "defaultSinks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "categorySeverity": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/severity"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/route"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "envVarName": {
+      "type": "string",
+      "pattern": "^[A-Z_][A-Z0-9_]*$"
+    },
+    "sinkCommon": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "enabled",
+        "type"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "webhook",
+            "slack",
+            "pagerduty_events"
+          ]
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 120
+        }
+      }
+    },
+    "sinkWebhook": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/sinkCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "urlEnv"
+          ],
+          "properties": {
+            "type": {
+              "const": "webhook"
+            },
+            "urlEnv": {
+              "$ref": "#/$defs/envVarName"
+            },
+            "authTokenEnv": {
+              "$ref": "#/$defs/envVarName"
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "sinkSlack": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/sinkCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "webhookUrlEnv"
+          ],
+          "properties": {
+            "type": {
+              "const": "slack"
+            },
+            "webhookUrlEnv": {
+              "$ref": "#/$defs/envVarName"
+            },
+            "channel": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            },
+            "iconEmoji": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "sinkPagerDuty": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/sinkCommon"
+        },
+        {
+          "type": "object",
+          "required": [
+            "routingKeyEnv"
+          ],
+          "properties": {
+            "type": {
+              "const": "pagerduty_events"
+            },
+            "routingKeyEnv": {
+              "$ref": "#/$defs/envVarName"
+            },
+            "source": {
+              "type": "string"
+            },
+            "component": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "sink": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sinkWebhook"
+        },
+        {
+          "$ref": "#/$defs/sinkSlack"
+        },
+        {
+          "$ref": "#/$defs/sinkPagerDuty"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "category"
+      ],
+      "properties": {
+        "category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "minSeverity": {
+          "$ref": "#/$defs/severity"
+        },
+        "sinks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/ops-manager-alert-sink-config.sh
+++ b/scripts/ops-manager-alert-sink-config.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-alert-sink-config.sh [options]
+
+Options:
+  --config-file <path>        Alert sink config JSON path.
+  --category <name>           Resolve routing for a specific escalation category.
+  --severity <level>          Event severity override for route resolution (info|warning|critical).
+  --list-sinks                List sink ids, types, and enabled flags.
+  --no-env-check              Skip fail-closed checks for enabled sink secret env vars.
+  --pretty                    Pretty-print output JSON.
+  --help                      Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+severity_rank() {
+  case "$1" in
+    info) echo 1 ;;
+    warning) echo 2 ;;
+    critical) echo 3 ;;
+    *) return 1 ;;
+  esac
+}
+
+config_file=""
+category=""
+severity=""
+list_only="0"
+env_check="1"
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config-file)
+      config_file="${2:-}"
+      shift 2
+      ;;
+    --category)
+      category="${2:-}"
+      shift 2
+      ;;
+    --severity)
+      severity="${2:-}"
+      shift 2
+      ;;
+    --list-sinks)
+      list_only="1"
+      shift
+      ;;
+    --no-env-check)
+      env_check="0"
+      shift
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ "$list_only" == "1" && -n "$category" ]]; then
+  die "--list-sinks cannot be combined with --category"
+fi
+if [[ -z "$category" && -n "$severity" ]]; then
+  die "--severity requires --category"
+fi
+if [[ -n "$severity" ]] && ! severity_rank "$severity" >/dev/null; then
+  die "--severity must be one of: info, warning, critical"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+
+if [[ -z "$config_file" ]]; then
+  config_file="${OPS_MANAGER_ALERT_SINKS_FILE:-$root_dir/config/ops-manager-alert-sinks.v1.json}"
+fi
+if [[ ! -f "$config_file" ]]; then
+  die "alert sink config file not found: $config_file"
+fi
+
+config_json=$(jq -c '.' "$config_file" 2>/dev/null) || die "invalid alert sink config JSON: $config_file"
+
+if ! jq -e '
+  def is_severity: . == "info" or . == "warning" or . == "critical";
+  (.schemaVersion == "v1")
+  and (.defaultMinSeverity | is_severity)
+  and (.sinks | type == "object" and (keys | length) > 0)
+  and (.routing | type == "object")
+  and ((.routing.defaultSinks // null) | type == "array")
+  and ((.routing.categorySeverity // null) | type == "object")
+  and ((.routing.routes // []) | type == "array")
+' <<<"$config_json" >/dev/null; then
+  die "alert sink config has invalid top-level shape"
+fi
+
+if ! jq -e '
+  def is_env_ref: type == "string" and test("^[A-Z_][A-Z0-9_]*$");
+  def timeout_ok: ((. // 5) | type == "number" and . >= 1 and . <= 120);
+  .sinks
+  | to_entries
+  | all(
+      .[];
+      (.value.enabled | type == "boolean")
+      and (.value.type == "webhook" or .value.type == "slack" or .value.type == "pagerduty_events")
+      and (.value.timeoutSeconds | timeout_ok)
+      and (
+        if .value.type == "webhook" then
+          (.value.urlEnv | is_env_ref)
+          and ((.value.authTokenEnv? // null) == null or (.value.authTokenEnv | is_env_ref))
+          and ((.value.headers? // null) == null or (.value.headers | type == "object" and all(to_entries[]; (.value | type == "string"))))
+        elif .value.type == "slack" then
+          (.value.webhookUrlEnv | is_env_ref)
+        else
+          (.value.routingKeyEnv | is_env_ref)
+        end
+      )
+    )
+' <<<"$config_json" >/dev/null; then
+  die "alert sink config sink definitions are invalid"
+fi
+
+if ! jq -e '
+  def is_severity: . == "info" or . == "warning" or . == "critical";
+  .sinks as $sinks
+  | (.routing.defaultSinks // []) as $default_sinks
+  | (.routing.routes // []) as $routes
+  | (.routing.categorySeverity // {}) as $category_severity
+  | all($default_sinks[]?; $sinks[.] != null)
+    and all(
+      $routes[]?;
+      (.category | type == "string" and (length > 0))
+      and ((.enabled? // true) | type == "boolean")
+      and ((.minSeverity? // "warning") | is_severity)
+      and all((.sinks // [])[]; $sinks[.] != null)
+    )
+    and all($category_severity | to_entries[]; (.value | is_severity))
+' <<<"$config_json" >/dev/null; then
+  die "alert sink config routing is invalid"
+fi
+
+mapfile -t all_secret_env_refs < <(
+  jq -r '
+    .sinks
+    | to_entries[]
+    | .value as $sink
+    | if $sink.type == "webhook" then [$sink.urlEnv, ($sink.authTokenEnv // empty)]
+      elif $sink.type == "slack" then [$sink.webhookUrlEnv]
+      elif $sink.type == "pagerduty_events" then [$sink.routingKeyEnv]
+      else []
+      end
+    | .[]
+  ' <<<"$config_json" | awk 'NF' | sort -u
+)
+
+env_status_json='{}'
+for env_ref in "${all_secret_env_refs[@]}"; do
+  env_present="false"
+  if [[ -n "${!env_ref-}" ]]; then
+    env_present="true"
+  fi
+  env_status_json=$(jq -c --arg env_ref "$env_ref" --argjson env_present "$env_present" '. + {($env_ref): {present: $env_present}}' <<<"$env_status_json")
+done
+
+if [[ "$env_check" == "1" ]]; then
+  mapfile -t required_secret_env_refs < <(
+    jq -r '
+      .sinks
+      | to_entries[]
+      | select(.value.enabled == true)
+      | .value as $sink
+      | if $sink.type == "webhook" then [$sink.urlEnv, ($sink.authTokenEnv // empty)]
+        elif $sink.type == "slack" then [$sink.webhookUrlEnv]
+        elif $sink.type == "pagerduty_events" then [$sink.routingKeyEnv]
+        else []
+        end
+      | .[]
+    ' <<<"$config_json" | awk 'NF' | sort -u
+  )
+
+  missing_secret_env_refs=()
+  for env_ref in "${required_secret_env_refs[@]}"; do
+    if [[ -z "${!env_ref-}" ]]; then
+      missing_secret_env_refs+=("$env_ref")
+    fi
+  done
+
+  if (( ${#missing_secret_env_refs[@]} > 0 )); then
+    die "enabled sink secret env var(s) are unset: ${missing_secret_env_refs[*]}"
+  fi
+fi
+
+if [[ "$list_only" == "1" ]]; then
+  jq -r '.sinks | to_entries[] | "\(.key)\t\(.value.type)\t\(.value.enabled)"' <<<"$config_json"
+  exit 0
+fi
+
+env_check_enabled="false"
+if [[ "$env_check" == "1" ]]; then
+  env_check_enabled="true"
+fi
+
+if [[ -n "$category" ]]; then
+  route_json=$(jq -c --arg category "$category" '
+    ((.routing.routes // []) | map(select(.category == $category and (.enabled // true) == true)) | first // null)
+  ' <<<"$config_json")
+
+  route_sink_ids_json=$(jq -c --arg category "$category" '
+    ((.routing.routes // []) | map(select(.category == $category and (.enabled // true) == true)) | first // null) as $route
+    | if $route != null and (($route.sinks // []) | length) > 0 then ($route.sinks)
+      else (.routing.defaultSinks // [])
+      end
+  ' <<<"$config_json")
+
+  min_severity=$(jq -r --arg category "$category" '
+    ((.routing.routes // []) | map(select(.category == $category and (.enabled // true) == true)) | first // null) as $route
+    | ($route.minSeverity // .defaultMinSeverity // "warning")
+  ' <<<"$config_json")
+
+  mapped_category_severity=$(jq -r --arg category "$category" '.routing.categorySeverity[$category] // empty' <<<"$config_json")
+
+  event_severity="$severity"
+  if [[ -z "$event_severity" ]]; then
+    event_severity="$mapped_category_severity"
+  fi
+  if [[ -z "$event_severity" ]]; then
+    event_severity="$min_severity"
+  fi
+  if ! severity_rank "$event_severity" >/dev/null; then
+    die "resolved event severity is invalid for category '$category': $event_severity"
+  fi
+
+  selected_sinks_json=$(jq -c --argjson sink_ids "$route_sink_ids_json" '
+    .sinks as $sinks
+    | [
+        $sink_ids[]? as $sink_id
+        | $sinks[$sink_id] as $sink
+        | select($sink != null)
+        | {
+            id: $sink_id,
+            type: $sink.type,
+            enabled: $sink.enabled,
+            timeoutSeconds: ($sink.timeoutSeconds // 5),
+            secretRefs: (
+              if $sink.type == "webhook" then
+                {urlEnv: $sink.urlEnv, authTokenEnv: ($sink.authTokenEnv // null)}
+              elif $sink.type == "slack" then
+                {webhookUrlEnv: $sink.webhookUrlEnv}
+              else
+                {routingKeyEnv: $sink.routingKeyEnv}
+              end
+            ),
+            config: (
+              if $sink.type == "webhook" then
+                {headers: ($sink.headers // {})}
+              elif $sink.type == "slack" then
+                {
+                  channel: ($sink.channel // null),
+                  username: ($sink.username // null),
+                  iconEmoji: ($sink.iconEmoji // null)
+                }
+              else
+                {
+                  source: ($sink.source // "superloop-ops-manager"),
+                  component: ($sink.component // null),
+                  group: ($sink.group // null),
+                  class: ($sink.class // null)
+                }
+              end
+            )
+          }
+      ]
+  ' <<<"$config_json")
+
+  dispatchable_sinks_json=$(jq -c '[.[] | select(.enabled == true)]' <<<"$selected_sinks_json")
+
+  event_severity_rank=$(severity_rank "$event_severity")
+  min_severity_rank=$(severity_rank "$min_severity")
+
+  should_dispatch="false"
+  if (( event_severity_rank >= min_severity_rank )); then
+    should_dispatch="true"
+  fi
+
+  resolved_json=$(jq -cn \
+    --arg schema_version "v1" \
+    --arg source_file "$config_file" \
+    --arg category "$category" \
+    --arg event_severity "$event_severity" \
+    --arg mapped_category_severity "$mapped_category_severity" \
+    --arg min_severity "$min_severity" \
+    --argjson should_dispatch "$should_dispatch" \
+    --argjson route "$route_json" \
+    --argjson selected_sinks "$selected_sinks_json" \
+    --argjson dispatchable_sinks "$dispatchable_sinks_json" \
+    --argjson env_status "$env_status_json" \
+    --argjson env_check_enabled "$env_check_enabled" \
+    '{
+      schemaVersion: $schema_version,
+      sourceFile: $source_file,
+      category: $category,
+      eventSeverity: $event_severity,
+      categoryMappedSeverity: (if ($mapped_category_severity | length) > 0 then $mapped_category_severity else null end),
+      minSeverity: $min_severity,
+      shouldDispatch: $should_dispatch,
+      route: $route,
+      selectedSinks: $selected_sinks,
+      dispatchableSinks: (if $should_dispatch == true then $dispatchable_sinks else [] end),
+      envStatus: $env_status,
+      validation: {
+        envCheckEnabled: $env_check_enabled
+      }
+    } | with_entries(select(.value != null))')
+else
+  sinks_resolved_json=$(jq -c '
+    .sinks
+    | to_entries
+    | map({
+        id: .key,
+        enabled: .value.enabled,
+        type: .value.type,
+        timeoutSeconds: (.value.timeoutSeconds // 5),
+        secretRefs: (
+          if .value.type == "webhook" then
+            {urlEnv: .value.urlEnv, authTokenEnv: (.value.authTokenEnv // null)}
+          elif .value.type == "slack" then
+            {webhookUrlEnv: .value.webhookUrlEnv}
+          else
+            {routingKeyEnv: .value.routingKeyEnv}
+          end
+        )
+      })
+  ' <<<"$config_json")
+
+  resolved_json=$(jq -cn \
+    --arg schema_version "v1" \
+    --arg source_file "$config_file" \
+    --argjson root "$config_json" \
+    --argjson sinks_resolved "$sinks_resolved_json" \
+    --argjson env_status "$env_status_json" \
+    --argjson env_check_enabled "$env_check_enabled" \
+    '{
+      schemaVersion: $schema_version,
+      sourceFile: $source_file,
+      defaultMinSeverity: $root.defaultMinSeverity,
+      sinks: $sinks_resolved,
+      enabledSinkCount: (($sinks_resolved | map(select(.enabled == true))) | length),
+      routing: ($root.routing // {}),
+      envStatus: $env_status,
+      validation: {
+        envCheckEnabled: $env_check_enabled
+      }
+    }')
+fi
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$resolved_json"
+else
+  jq -c '.' <<<"$resolved_json"
+fi

--- a/tests/ops-manager-alert-sinks.bats
+++ b/tests/ops-manager-alert-sinks.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+write_enabled_webhook_config() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "schemaVersion": "v1",
+  "defaultMinSeverity": "warning",
+  "sinks": {
+    "webhook-a": {
+      "enabled": true,
+      "type": "webhook",
+      "urlEnv": "OPS_MANAGER_TEST_WEBHOOK_URL",
+      "timeoutSeconds": 5
+    }
+  },
+  "routing": {
+    "defaultSinks": [
+      "webhook-a"
+    ],
+    "categorySeverity": {
+      "health_degraded": "warning"
+    },
+    "routes": [
+      {
+        "category": "health_degraded",
+        "sinks": [
+          "webhook-a"
+        ],
+        "minSeverity": "warning",
+        "enabled": true
+      }
+    ]
+  }
+}
+JSON
+}
+
+@test "alert sink resolver lists default sink catalog entries" {
+  run "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh" --list-sinks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"webhook-default"* ]]
+  [[ "$output" == *"slack-default"* ]]
+  [[ "$output" == *"pagerduty-default"* ]]
+}
+
+@test "alert sink resolver returns default config summary" {
+  run "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh"
+  [ "$status" -eq 0 ]
+  local resolver_json="$output"
+
+  run jq -r '.defaultMinSeverity' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "warning" ]
+
+  run jq -r '.enabledSinkCount' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "alert sink resolver rejects severity without category" {
+  run "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh" --severity warning
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--severity requires --category"* ]]
+}
+
+@test "alert sink resolver fails closed when enabled sink secret env var is missing" {
+  local config_file="$TEMP_DIR/enabled-webhook.json"
+  write_enabled_webhook_config "$config_file"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh" --config-file "$config_file"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"enabled sink secret env var(s) are unset"* ]]
+}
+
+@test "alert sink resolver resolves route and dispatchable sinks when env var is set" {
+  local config_file="$TEMP_DIR/enabled-webhook.json"
+  write_enabled_webhook_config "$config_file"
+
+  run env OPS_MANAGER_TEST_WEBHOOK_URL="https://example.test/webhook" \
+    "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh" \
+    --config-file "$config_file" \
+    --category health_degraded \
+    --severity warning
+  [ "$status" -eq 0 ]
+  local route_json="$output"
+
+  run jq -r '.shouldDispatch' <<<"$route_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.dispatchableSinks | length' <<<"$route_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.dispatchableSinks[0].id' <<<"$route_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "webhook-a" ]
+}
+
+@test "alert sink resolver enforces min severity gate during category resolution" {
+  local config_file="$TEMP_DIR/enabled-webhook.json"
+  write_enabled_webhook_config "$config_file"
+
+  run env OPS_MANAGER_TEST_WEBHOOK_URL="https://example.test/webhook" \
+    "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh" \
+    --config-file "$config_file" \
+    --category health_degraded \
+    --severity info
+  [ "$status" -eq 0 ]
+  local route_json="$output"
+
+  run jq -r '.shouldDispatch' <<<"$route_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.dispatchableSinks | length' <<<"$route_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "alert sink resolver uses OPS_MANAGER_ALERT_SINKS_FILE when --config-file is omitted" {
+  local config_file="$TEMP_DIR/custom-config.json"
+  cat > "$config_file" <<'JSON'
+{
+  "schemaVersion": "v1",
+  "defaultMinSeverity": "critical",
+  "sinks": {
+    "webhook-a": {
+      "enabled": false,
+      "type": "webhook",
+      "urlEnv": "OPS_MANAGER_TEST_WEBHOOK_URL"
+    }
+  },
+  "routing": {
+    "defaultSinks": [
+      "webhook-a"
+    ],
+    "categorySeverity": {},
+    "routes": []
+  }
+}
+JSON
+
+  run env OPS_MANAGER_ALERT_SINKS_FILE="$config_file" \
+    "$PROJECT_ROOT/scripts/ops-manager-alert-sink-config.sh"
+  [ "$status" -eq 0 ]
+  local resolver_json="$output"
+
+  run jq -r '.sourceFile' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$config_file" ]
+
+  run jq -r '.defaultMinSeverity' <<<"$resolver_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "critical" ]
+}


### PR DESCRIPTION
## Summary
- add versioned alert sink config catalog at `config/ops-manager-alert-sinks.v1.json`
- add JSON schema reference at `schema/ops-manager-alert-sinks.config.schema.json`
- add fail-closed resolver `scripts/ops-manager-alert-sink-config.sh` with:
  - sink/routing shape validation
  - category+severity route resolution
  - env-secret reference validation for enabled sinks
  - config precedence (`--config-file`, `OPS_MANAGER_ALERT_SINKS_FILE`, repo default)
- add `tests/ops-manager-alert-sinks.bats` for resolver behavior and fail-closed checks
- update ops manager contract/runbook docs with defaults and override precedence
- mark P1.1 checklist completed in `feat/ops-manager-superloop-sprites/phase-6-alert-sinks/tasks/PHASE_1.MD`

## Validation
- `bash -n scripts/ops-manager-alert-sink-config.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-alert-sinks.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-threshold-tuning.bats`

Refs #54
