### PR TITLE
chore(ops-manager): scaffold phase 7 total visibility packet

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-7-total-visibility/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-7-total-visibility/PLAN.MD
@@ -1,0 +1,71 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 7 Total Visibility)
+
+## Goal
+Deliver total visibility across manager and sprite runtime boundaries so operators can trace intent, execution, and escalation end-to-end with deterministic telemetry.
+
+## Scope
+- Add runtime heartbeat telemetry and manager ingestion for liveness/process context.
+- Add explicit command invocation audit logs for manager-issued control actions.
+- Add envelope sequence IDs and monotonic ordering diagnostics for snapshot/event streams.
+- Propagate correlation/trace IDs from manager intent through runtime effects and alert dispatch.
+- Surface visibility signals in status and runbook flows with transport parity (`local`, `sprite_service`).
+
+## Non-Goals (this iteration)
+- Full distributed tracing vendor integration (OTel collectors, SaaS APM coupling).
+- Multi-tenant authz, billing, or org-scoped telemetry controls.
+- Autonomous remediation policies; this phase is observability-first.
+- Replacing existing v1 envelope contracts with breaking schema changes.
+
+## Primary References
+- `docs/ops-manager-sprite-integration.md`
+- `docs/ops-manager-v0.md`
+- `docs/ops-manager-runbook.md`
+- `scripts/ops-manager-reconcile.sh`
+- `scripts/ops-manager-status.sh`
+- `scripts/ops-manager-sprite-service.py`
+- `tests/ops-manager-service.bats`
+- `tests/ops-manager-observability.bats`
+
+## Architecture
+Phase 7 adds a visibility plane across runtime, transport, and manager artifacts:
+
+1. Runtime heartbeat channel:
+- Emit periodic heartbeat envelopes with process/runtime metadata.
+- Persist heartbeat artifacts under loop-scoped telemetry paths.
+- Project heartbeat freshness into manager health/status context.
+
+2. Invocation audit channel:
+- Capture structured records for manager-issued control command execution.
+- Include command intent, idempotency key, transport mode, and observed outcome.
+- Ensure append-only audit logs with stable envelope fields.
+
+3. Ordering and traceability:
+- Add per-envelope sequence identifiers for ordering diagnostics.
+- Enforce monotonic checks and reason-coded ordering regressions.
+- Introduce trace IDs spanning manager intent -> runtime effect -> escalation/dispatch telemetry.
+
+4. Operator surfaces:
+- Extend status output with heartbeat freshness, ordering diagnostics, and recent trace links.
+- Update runbook procedures for diagnosing partial visibility and transport gaps.
+- Keep local and sprite service visibility semantics equivalent.
+
+## Decisions
+- Keep all new visibility artifacts file-first and schema-versioned (`v1` additive fields only).
+- Treat visibility failures as reason-coded degradations, not silent best-effort drops.
+- Maintain fail-open reconcile semantics for non-critical telemetry writes.
+- Use deterministic IDs/offsets where possible to preserve replay/debug value.
+
+## Risks / Constraints
+- Heartbeat frequency too high can cause noisy telemetry and I/O overhead.
+- Sequence enforcement must not falsely flag benign replay/restart scenarios.
+- Trace propagation drift across adapters can break cross-artifact correlation.
+- Service and local transport implementations must stay behaviorally aligned.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Heartbeat + invocation audit + sequence/trace propagation + operator surfaces + parity tests.

--- a/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
@@ -1,0 +1,41 @@
+# Phase 1 - Total Visibility Plane
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-7-total-visibility/PLAN.MD` aligns with prior phases and current repo state.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/59`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#40`, `#42`, `#44`, `#46`, `#48`, `#50`, `#53`, `#55`, `#56`, `#57`, `#58`).
+
+## P1.1 Runtime Heartbeat Telemetry
+1. [ ] Add heartbeat envelope artifact path and schema shape for loop runtime/service adapters.
+2. [ ] Ingest heartbeat signals in manager reconcile and persist loop-scoped heartbeat telemetry.
+3. [ ] Project heartbeat freshness into health/status with reason-coded degradation behavior.
+
+## P1.2 Control Invocation Audit Log
+1. [ ] Add structured invocation log entries for manager-issued control actions.
+2. [ ] Capture transport, idempotency key, intent, execution result, and confirmation outcome.
+3. [ ] Ensure append-only audit trails under `.superloop/ops-manager/<loop>/telemetry/`.
+
+## P1.3 Envelope Sequence Diagnostics
+1. [ ] Add sequence identifiers for snapshot/event envelopes (local + sprite_service).
+2. [ ] Add monotonic sequence validation and reason-coded ordering drift signals.
+3. [ ] Persist ordering diagnostics for operator triage.
+
+## P1.4 Trace ID Propagation
+1. [ ] Generate/propagate trace IDs across reconcile, control, runtime effects, and escalation/alert telemetry.
+2. [ ] Surface trace linkage fields in status output for latest control/reconcile/alert actions.
+3. [ ] Preserve backward compatibility with null-safe trace fields for existing artifacts.
+
+## P1.5 Operator Surface + Runbook
+1. [ ] Extend `scripts/ops-manager-status.sh` with heartbeat, sequence, and trace visibility summary fields.
+2. [ ] Update `docs/ops-manager-v0.md` with visibility artifact contract and field definitions.
+3. [ ] Update `docs/ops-manager-runbook.md` with total-visibility triage workflows and fallback behavior.
+
+## P1.6 Test Coverage
+1. [ ] Add `tests/ops-manager-visibility.bats` for heartbeat, invocation audit, sequence checks, and trace propagation.
+2. [ ] Add/extend tests proving status output includes new visibility fields.
+3. [ ] Verify local vs sprite_service parity for visibility artifacts and reason codes.
+
+## P1.V Validation
+1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats` passes.
+2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+3. [ ] Updated docs match implemented visibility artifacts, fields, and operator flow.


### PR DESCRIPTION
## Summary
- scaffold the Phase 7 packet for Ops Manager + Sprites total visibility mode
- add `PLAN.MD` covering heartbeat telemetry, invocation audit, sequence diagnostics, and trace propagation
- add `tasks/PHASE_1.MD` checklist with issue linkage and implementation/validation gates

## Context
- Follow-on issue: #59
- Parent roadmap: #51

## Testing
- Not run (docs/task scaffold only)

Refs #59
