### PR TITLE
feat(ops-manager): add control invocation audit telemetry

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
@@ -11,9 +11,9 @@
 3. [x] Project heartbeat freshness into health/status with reason-coded degradation behavior.
 
 ## P1.2 Control Invocation Audit Log
-1. [ ] Add structured invocation log entries for manager-issued control actions.
-2. [ ] Capture transport, idempotency key, intent, execution result, and confirmation outcome.
-3. [ ] Ensure append-only audit trails under `.superloop/ops-manager/<loop>/telemetry/`.
+1. [x] Add structured invocation log entries for manager-issued control actions.
+2. [x] Capture transport, idempotency key, intent, execution result, and confirmation outcome.
+3. [x] Ensure append-only audit trails under `.superloop/ops-manager/<loop>/telemetry/`.
 
 ## P1.3 Envelope Sequence Diagnostics
 1. [ ] Add sequence identifiers for snapshot/event envelopes (local + sprite_service).

--- a/tests/ops-manager-core.bats
+++ b/tests/ops-manager-core.bats
@@ -288,9 +288,23 @@ EOF
   [ "$output" = "cancel" ]
 
   local control_telemetry="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry/control.jsonl"
+  local invocation_telemetry="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry/control-invocations.jsonl"
   [ -f "$control_telemetry" ]
+  [ -f "$invocation_telemetry" ]
 
   run bash -lc "tail -n 1 '$control_telemetry' | jq -r '.status'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "confirmed" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.execution.status'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "succeeded" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.confirmation.status'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "confirmed" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.outcome.status'"
   [ "$status" -eq 0 ]
   [ "$output" = "confirmed" ]
 }
@@ -321,4 +335,15 @@ JSON
   run jq -r '.status' "$TEMP_DIR/.superloop/loops/$loop_id/approval.json"
   [ "$status" -eq 0 ]
   [ "$output" = "approved" ]
+
+  local invocation_telemetry="$TEMP_DIR/.superloop/ops-manager/$loop_id/telemetry/control-invocations.jsonl"
+  [ -f "$invocation_telemetry" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.intent'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "approve" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.confirmation.status'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "confirmed" ]
 }

--- a/tests/ops-manager-service.bats
+++ b/tests/ops-manager-service.bats
@@ -305,6 +305,25 @@ start_service() {
   run bash -lc "jq -r 'has(\"idem-1\")' '$TEMP_DIR/.superloop/ops-manager/demo-loop/service-idempotency.json'"
   [ "$status" -eq 0 ]
   [ "$output" = "true" ]
+
+  local invocation_telemetry="$TEMP_DIR/.superloop/ops-manager/demo-loop/telemetry/control-invocations.jsonl"
+  [ -f "$invocation_telemetry" ]
+
+  run bash -lc "wc -l < '$invocation_telemetry' | tr -d ' '"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 2 ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.transport'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "sprite_service" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.idempotencyKey'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "idem-1" ]
+
+  run bash -lc "tail -n 1 '$invocation_telemetry' | jq -r '.execution.replayed'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
 }
 
 @test "control fails closed with wrong sprite_service token" {


### PR DESCRIPTION
## Summary
- add append-only invocation audit telemetry at `.superloop/ops-manager/<loop>/telemetry/control-invocations.jsonl`
- record structured request/execution/confirmation/outcome sections for each manager-issued control action
- include transport, idempotency key, intent, execution status, confirmation status, and replay marker
- preserve existing `intents.jsonl` and `telemetry/control.jsonl` behavior
- extend core/service tests to validate invocation telemetry fields and append-only behavior
- mark Phase 7 P1.2 checklist items complete

## Testing
- `bash -n scripts/ops-manager-control.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-core.bats tests/ops-manager-service.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/`

Refs #59
