### PR TITLE
feat(ops-manager): propagate trace ids across visibility plane

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
@@ -21,9 +21,9 @@
 3. [x] Persist ordering diagnostics for operator triage.
 
 ## P1.4 Trace ID Propagation
-1. [ ] Generate/propagate trace IDs across reconcile, control, runtime effects, and escalation/alert telemetry.
-2. [ ] Surface trace linkage fields in status output for latest control/reconcile/alert actions.
-3. [ ] Preserve backward compatibility with null-safe trace fields for existing artifacts.
+1. [x] Generate/propagate trace IDs across reconcile, control, runtime effects, and escalation/alert telemetry.
+2. [x] Surface trace linkage fields in status output for latest control/reconcile/alert actions.
+3. [x] Preserve backward compatibility with null-safe trace fields for existing artifacts.
 
 ## P1.5 Operator Surface + Runbook
 1. [ ] Extend `scripts/ops-manager-status.sh` with heartbeat, sequence, and trace visibility summary fields.

--- a/schema/ops-manager.contract.schema.json
+++ b/schema/ops-manager.contract.schema.json
@@ -266,6 +266,12 @@
           "type": "string",
           "format": "date-time"
         },
+        "traceId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "$ref": "#/$defs/source"
         },
@@ -462,6 +468,12 @@
         "emittedAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "traceId": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "source": {
           "$ref": "#/$defs/source"

--- a/scripts/ops-manager-health.sh
+++ b/scripts/ops-manager-health.sh
@@ -12,6 +12,7 @@ Options:
   --sequence-state-file <path>                Optional sequence diagnostics JSON file.
   --transport-health-file <path>              Optional transport health JSON file.
   --intents-file <path>                       Optional intents JSONL file.
+  --trace-id <id>                             Optional trace id for this health projection.
   --transport <local|sprite_service>          Transport mode label (default: local)
   --threshold-profile <name>                  Optional applied threshold profile label.
   --ingest-status <success|failed>            Reconcile ingest result (default: success)
@@ -49,6 +50,7 @@ heartbeat_state_file=""
 sequence_state_file=""
 transport_health_file=""
 intents_file=""
+trace_id=""
 transport="local"
 threshold_profile=""
 ingest_status="success"
@@ -82,6 +84,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --intents-file)
       intents_file="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
       shift 2
       ;;
     --transport)
@@ -382,6 +388,7 @@ fi
 health_json=$(jq -cn \
   --arg schema_version "v1" \
   --arg updated_at "$now_iso" \
+  --arg trace_id "$trace_id" \
   --arg status "$health_status" \
   --arg transport "$transport" \
   --arg threshold_profile "$threshold_profile" \
@@ -408,6 +415,7 @@ health_json=$(jq -cn \
   '{
     schemaVersion: $schema_version,
     updatedAt: $updated_at,
+    traceId: (if ($trace_id | length) > 0 then $trace_id else null end),
     status: $status,
     reasonCodes: $reason_codes,
     reasons: $reasons,

--- a/scripts/ops-manager-loop-run-snapshot.sh
+++ b/scripts/ops-manager-loop-run-snapshot.sh
@@ -8,6 +8,7 @@ Usage:
 
 Options:
   --run-id <id>   Override inferred run id in emitted snapshot.
+  --trace-id <id> Optional trace id propagated by ops manager transport.
   --pretty        Pretty-print JSON output.
   --help          Show this help message.
 USAGE
@@ -121,6 +122,7 @@ json_or_null_file() {
 repo=""
 loop_id=""
 requested_run_id=""
+trace_id=""
 pretty="0"
 
 while [[ $# -gt 0 ]]; do
@@ -135,6 +137,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --run-id)
       requested_run_id="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
       shift 2
       ;;
     --pretty)
@@ -257,6 +263,7 @@ heartbeat_ref=$(file_ref_json "$repo" "$heartbeat_file")
 snapshot_json=$(jq -cn \
   --arg schema_version "v1" \
   --arg emitted_at "$(timestamp)" \
+  --arg trace_id "$trace_id" \
   --arg repo_path "$repo" \
   --arg loop_id "$loop_id" \
   --arg run_id "$resolved_run_id" \
@@ -285,6 +292,7 @@ snapshot_json=$(jq -cn \
     schemaVersion: $schema_version,
     envelopeType: "loop_run_snapshot",
     emittedAt: $emitted_at,
+    traceId: (if ($trace_id | length) > 0 then $trace_id else null end),
     source: {
       repoPath: $repo_path,
       loopId: $loop_id

--- a/scripts/ops-manager-poll-events.sh
+++ b/scripts/ops-manager-poll-events.sh
@@ -10,6 +10,7 @@ Options:
   --cursor-file <path>  Cursor JSON path. Default: <repo>/.superloop/loops/<loop>/ops-manager.cursor.json
   --from-start          Ignore existing cursor and emit from first line.
   --max-events <n>      Emit at most n events in this call (n > 0).
+  --trace-id <id>       Optional trace id propagated by ops manager transport.
   --help                Show this help message.
 USAGE
 }
@@ -35,6 +36,7 @@ loop_id=""
 cursor_file=""
 from_start="0"
 max_events="0"
+trace_id=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,6 +58,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-events)
       max_events="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
       shift 2
       ;;
     --help|-h)
@@ -149,6 +155,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   jq -cn \
     --arg schema_version "v1" \
     --arg emitted_at "$(timestamp)" \
+    --arg trace_id "$trace_id" \
     --arg repo_path "$repo" \
     --arg loop_id "$loop_id" \
     --argjson line_offset "$line_no" \
@@ -167,6 +174,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
       schemaVersion: $schema_version,
       envelopeType: "loop_run_event",
       emittedAt: $emitted_at,
+      traceId: (if ($trace_id | length) > 0 then $trace_id else null end),
       source: {
         repoPath: $repo_path,
         loopId: $loop_id

--- a/scripts/ops-manager-service-client.sh
+++ b/scripts/ops-manager-service-client.sh
@@ -8,6 +8,7 @@ Usage:
 
 Options:
   --token <token>                Optional auth token (sent as Bearer and X-Ops-Token)
+  --trace-id <id>                Optional trace id header (X-Trace-Id)
   --body-file <path>             JSON request body file for POST
   --retry-attempts <n>           Retry attempts on transient failures (default: 3)
   --retry-backoff-seconds <n>    Base backoff seconds between retries (default: 1)
@@ -33,6 +34,7 @@ method=""
 base_url=""
 path=""
 header_value=""
+trace_id=""
 body_file=""
 retry_attempts="3"
 retry_backoff_seconds="1"
@@ -55,6 +57,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --token)
       header_value="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
       shift 2
       ;;
     --body-file)
@@ -152,6 +158,9 @@ while (( attempt <= retry_attempts )); do
       -H "Authorization: Bearer $header_value"
       -H "X-Ops-Token: $header_value"
     )
+  fi
+  if [[ -n "$trace_id" ]]; then
+    curl_args+=(-H "X-Trace-Id: $trace_id")
   fi
 
   if [[ "$method" == "POST" ]]; then

--- a/tests/ops-manager-alert-sinks.bats
+++ b/tests/ops-manager-alert-sinks.bats
@@ -336,6 +336,7 @@ JSONL
   run "$PROJECT_ROOT/scripts/ops-manager-alert-dispatch.sh" \
     --repo "$repo" \
     --loop "$loop_id" \
+    --trace-id "trace-alert-dispatch-1" \
     --alert-config-file "$config_file"
   [ "$status" -eq 0 ]
   local first_json="$output"
@@ -374,6 +375,10 @@ JSONL
   [ "$status" -eq 0 ]
   [ "$output" = "2" ]
 
+  run bash -lc "head -n 1 '$telemetry_file' | jq -r '.traceId'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-dispatch-1" ]
+
   local dispatch_state_file="$ops_dir/alert-dispatch-state.json"
   [ -f "$dispatch_state_file" ]
   run jq -r '.escalationsLineOffset' "$dispatch_state_file"
@@ -392,6 +397,7 @@ JSONL
   run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
     --repo "$repo" \
     --loop "$loop_id" \
+    --trace-id "trace-alert-status-1" \
     --alerts-enabled true \
     --alert-config-file "$config_file" \
     --degraded-ingest-lag-seconds 1 \
@@ -419,6 +425,7 @@ JSONL
   run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
     --repo "$repo" \
     --loop "$loop_id" \
+    --trace-id "trace-alert-status-1" \
     --alerts-enabled true \
     --alert-config-file "$config_file" \
     --degraded-ingest-lag-seconds 1 \
@@ -447,6 +454,7 @@ JSONL
   run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
     --repo "$repo" \
     --loop "$loop_id" \
+    --trace-id "trace-alert-status-1" \
     --alerts-enabled true \
     --alert-config-file "$config_file" \
     --degraded-ingest-lag-seconds 1 \
@@ -461,6 +469,10 @@ JSONL
   [ "$status" -eq 0 ]
   [ "$output" = "success" ]
 
+  run jq -r '.alerts.dispatch.lastTraceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
+
   run jq -e '.alerts.dispatch.processedCount >= 1' <<<"$status_json"
   [ "$status" -eq 0 ]
 
@@ -471,6 +483,18 @@ JSONL
   run jq -r '.alerts.lastDelivery.reasonCode' <<<"$status_json"
   [ "$status" -eq 0 ]
   [ "$output" = "no_dispatchable_sinks" ]
+
+  run jq -r '.alerts.lastDelivery.traceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
+
+  run jq -r '.traceLinkage.reconcileTraceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
+
+  run jq -r '.traceLinkage.alertTraceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
 
   run jq -r '.files.alertDispatchStateFile' <<<"$status_json"
   [ "$status" -eq 0 ]

--- a/tests/ops-manager-contract.bats
+++ b/tests/ops-manager-contract.bats
@@ -64,7 +64,7 @@ JSONL
 @test "ops manager snapshot emits loop_run_snapshot envelope" {
   write_base_runtime_artifacts
 
-  run "$PROJECT_ROOT/scripts/ops-manager-loop-run-snapshot.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID"
+  run "$PROJECT_ROOT/scripts/ops-manager-loop-run-snapshot.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --trace-id "trace-snapshot-1"
   [ "$status" -eq 0 ]
 
   output_file="$TEMP_DIR/snapshot.json"
@@ -85,6 +85,10 @@ JSONL
   run jq -r '.run.runId' "$output_file"
   [ "$status" -eq 0 ]
   [ "$output" = "run-123" ]
+
+  run jq -r '.traceId' "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-snapshot-1" ]
 
   run jq -r '.sequence.source' "$output_file"
   [ "$status" -eq 0 ]
@@ -127,7 +131,7 @@ JSON
 
   cursor_file="$TEMP_DIR/cursor.json"
 
-  run "$PROJECT_ROOT/scripts/ops-manager-poll-events.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --cursor-file "$cursor_file"
+  run "$PROJECT_ROOT/scripts/ops-manager-poll-events.sh" --repo "$TEMP_DIR" --loop "$LOOP_ID" --cursor-file "$cursor_file" --trace-id "trace-events-1"
   [ "$status" -eq 0 ]
 
   line_count=$(printf '%s\n' "$output" | sed '/^$/d' | wc -l | tr -d ' ')
@@ -144,6 +148,10 @@ JSON
   run bash -lc "head -n 1 '$TEMP_DIR/events.ndjson' | jq -r '.sequence.value'"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
+
+  run bash -lc "head -n 1 '$TEMP_DIR/events.ndjson' | jq -r '.traceId'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-events-1" ]
 
   run jq -r '.eventLineOffset' "$cursor_file"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- add optional `--trace-id` plumbing to ops-manager scripts and service client, with generated trace IDs when omitted for reconcile/control/alert-dispatch operations
- propagate trace IDs through local and `sprite_service` ingest/control paths (including `X-Trace-Id` forwarding in sprite service)
- include null-safe `traceId` fields on snapshot/event envelopes and update contract schema accordingly
- propagate trace context into reconcile/control/heartbeat/sequence/health/escalation/alert-dispatch artifacts
- extend `ops-manager-status.sh` with trace linkage fields for latest control/reconcile/alert actions
- mark Phase 7 P1.4 checklist complete in `feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD`

## Validation
- `bash -n scripts/ops-manager-service-client.sh`
- `bash -n scripts/ops-manager-loop-run-snapshot.sh`
- `bash -n scripts/ops-manager-poll-events.sh`
- `bash -n scripts/ops-manager-health.sh`
- `bash -n scripts/ops-manager-control.sh`
- `bash -n scripts/ops-manager-reconcile.sh`
- `bash -n scripts/ops-manager-alert-dispatch.sh`
- `bash -n scripts/ops-manager-status.sh`
- `python3 -m py_compile scripts/ops-manager-sprite-service.py`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-alert-sinks.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/`

Part of #59.
