### PR TITLE
feat(ops-manager): add P1.5 status visibility and runbook workflows

### DIFF
--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -150,6 +150,13 @@ Purpose:
 - Includes tuning guidance fields from telemetry summaries (`recommendedProfile`, `confidence`, `rationale`).
 - Includes profile-drift state/action fields when drift artifacts are present.
 - Includes alert delivery summary fields from dispatch artifacts (`alerts.dispatch`, `alerts.lastDelivery`).
+- Includes visibility summaries for heartbeat, sequence diagnostics, invocation audit, and trace linkage (`visibility.*`).
+
+Visibility summary fields:
+- `visibility.heartbeat`: `freshnessStatus`, `reasonCode`, `lastHeartbeatAt`, `heartbeatLagSeconds`, `updatedAt`, `transport`, `traceId`.
+- `visibility.sequence`: `status`, `reasonCode`, `driftActive`, `violations`, `snapshotCurrent`, `eventsLast`, `updatedAt`, `transport`, `traceId`.
+- `visibility.invocationAudit`: latest control invocation audit record summary (`intent`, `transport`, `idempotencyKey`, execution/confirmation/outcome status, `traceId`).
+- `visibility.trace`: latest trace surface across control/reconcile/heartbeat/sequence/alert artifacts and `sharedTraceId` when all present traces agree.
 
 ### Threshold Profile Resolver
 ```bash
@@ -245,12 +252,17 @@ Transport mode switch:
 - `.superloop/ops-manager/<loop>/state.json` - projected lifecycle state.
 - `.superloop/ops-manager/<loop>/cursor.json` - incremental event cursor.
 - `.superloop/ops-manager/<loop>/health.json` - latest health status + reason codes.
+- `.superloop/ops-manager/<loop>/heartbeat.json` - latest runtime heartbeat freshness projection.
+- `.superloop/ops-manager/<loop>/sequence-state.json` - latest envelope sequence diagnostics state.
 - `.superloop/ops-manager/<loop>/intents.jsonl` - control intent execution log.
 - `.superloop/ops-manager/<loop>/escalations.jsonl` - divergence/escalation records.
 - `.superloop/ops-manager/<loop>/profile-drift.json` - current profile drift state.
 - `.superloop/ops-manager/<loop>/alert-dispatch-state.json` - latest alert dispatch summary and cursor offsets.
 - `.superloop/ops-manager/<loop>/telemetry/reconcile.jsonl` - reconcile attempt telemetry.
 - `.superloop/ops-manager/<loop>/telemetry/control.jsonl` - control attempt telemetry.
+- `.superloop/ops-manager/<loop>/telemetry/control-invocations.jsonl` - detailed control invocation audit trail.
+- `.superloop/ops-manager/<loop>/telemetry/heartbeat.jsonl` - heartbeat ingestion/freshness telemetry history.
+- `.superloop/ops-manager/<loop>/telemetry/sequence.jsonl` - sequence diagnostic telemetry history.
 - `.superloop/ops-manager/<loop>/telemetry/profile-drift.jsonl` - profile drift history.
 - `.superloop/ops-manager/<loop>/telemetry/alerts.jsonl` - alert delivery attempts/outcomes and reason codes.
 - `.superloop/ops-manager/<loop>/telemetry/transport-health.json` - rolling transport failure streak state.

--- a/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-7-total-visibility/tasks/PHASE_1.MD
@@ -26,13 +26,13 @@
 3. [x] Preserve backward compatibility with null-safe trace fields for existing artifacts.
 
 ## P1.5 Operator Surface + Runbook
-1. [ ] Extend `scripts/ops-manager-status.sh` with heartbeat, sequence, and trace visibility summary fields.
-2. [ ] Update `docs/ops-manager-v0.md` with visibility artifact contract and field definitions.
-3. [ ] Update `docs/ops-manager-runbook.md` with total-visibility triage workflows and fallback behavior.
+1. [x] Extend `scripts/ops-manager-status.sh` with heartbeat, sequence, and trace visibility summary fields.
+2. [x] Update `docs/ops-manager-v0.md` with visibility artifact contract and field definitions.
+3. [x] Update `docs/ops-manager-runbook.md` with total-visibility triage workflows and fallback behavior.
 
 ## P1.6 Test Coverage
 1. [ ] Add `tests/ops-manager-visibility.bats` for heartbeat, invocation audit, sequence checks, and trace propagation.
-2. [ ] Add/extend tests proving status output includes new visibility fields.
+2. [x] Add/extend tests proving status output includes new visibility fields.
 3. [ ] Verify local vs sprite_service parity for visibility artifacts and reason codes.
 
 ## P1.V Validation

--- a/tests/ops-manager-alert-sinks.bats
+++ b/tests/ops-manager-alert-sinks.bats
@@ -450,6 +450,7 @@ JSONL
   local config_file="$PROJECT_ROOT/config/ops-manager-alert-sinks.v1.json"
   local dispatch_state_file="$repo/.superloop/ops-manager/$loop_id/alert-dispatch-state.json"
   local dispatch_telemetry_file="$repo/.superloop/ops-manager/$loop_id/telemetry/alerts.jsonl"
+  local sequence_state_file="$repo/.superloop/ops-manager/$loop_id/sequence-state.json"
 
   run "$PROJECT_ROOT/scripts/ops-manager-reconcile.sh" \
     --repo "$repo" \
@@ -496,6 +497,18 @@ JSONL
   [ "$status" -eq 0 ]
   [ "$output" = "trace-alert-status-1" ]
 
+  run jq -r '.visibility.sequence.status' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+
+  run jq -r '.visibility.trace.alertTraceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
+
+  run jq -r '.visibility.trace.sharedTraceId' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-alert-status-1" ]
+
   run jq -r '.files.alertDispatchStateFile' <<<"$status_json"
   [ "$status" -eq 0 ]
   [ "$output" = "$dispatch_state_file" ]
@@ -503,6 +516,10 @@ JSONL
   run jq -r '.files.alertDispatchTelemetryFile' <<<"$status_json"
   [ "$status" -eq 0 ]
   [ "$output" = "$dispatch_telemetry_file" ]
+
+  run jq -r '.files.sequenceStateFile' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$sequence_state_file" ]
 }
 
 @test "alert dispatch is transport-parity across local and sprite_service reconciles" {


### PR DESCRIPTION
## Summary
- extend `ops-manager-status.sh` with explicit visibility summaries for heartbeat, sequence diagnostics, invocation audit, and trace linkage
- add file-path options and artifact surfacing for heartbeat/sequence/control-invocation telemetry in status output
- update `docs/ops-manager-v0.md` and `docs/ops-manager-runbook.md` with visibility field definitions, total-visibility triage, and partial-visibility fallback
- update Phase 7 task tracker to mark P1.5 complete and P1.6.2 complete
- extend observability/alert-sink tests to assert new status `visibility.*` fields

## Validation
- `bash -n scripts/ops-manager-status.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-observability.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-threshold-tuning.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats`

## Issue
- progresses #59
