### PR TITLE
feat(ops-manager): initiate Phase 8 fleet orchestration

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/PLAN.MD
@@ -1,0 +1,63 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 8 Fleet Orchestration)
+
+## Goal
+Enable the ops manager to coordinate and observe multiple loop runs across sprites as a fleet with deterministic, policy-aware orchestration.
+
+## Scope
+- Add a fleet registry artifact that tracks loop run membership, sprite assignment, transport mode, and latest per-loop health/status pointers.
+- Add fleet reconcile fan-out that executes per-loop reconcile safely with bounded concurrency and records fleet-level outcomes.
+- Add advisory fleet policy evaluation that summarizes candidate actions without auto-execution.
+- Add fleet operator status surfaces for fleet health rollups, per-loop exceptions, and trace-linked drill-down.
+- Preserve local and `sprite_service` transport parity for fleet-level orchestration semantics.
+
+## Non-Goals (this iteration)
+- Autonomous remediation that executes control actions without explicit operator approval.
+- Multi-tenant authorization, billing, or organization-scoped control planes.
+- Cross-repo orchestration; this phase is single-repo fleet coordination.
+- External tracing/APM vendor coupling beyond existing file-first telemetry artifacts.
+
+## Primary References
+- `scripts/ops-manager-reconcile.sh` - per-loop reconciliation primitive used by fleet fan-out.
+- `scripts/ops-manager-control.sh` - per-loop control primitive used by advisory policy handoff.
+- `scripts/ops-manager-status.sh` - per-loop visibility projection used for fleet rollups.
+- `scripts/ops-manager-sprite-service.py` - service transport parity contract for sprite execution.
+- `docs/ops-manager-v0.md` - manager/runtime contract and persistence paths.
+- `docs/ops-manager-runbook.md` - operational triage and fallback workflow baseline.
+- `feat/ops-manager-superloop-sprites/phase-7-total-visibility/PLAN.MD` - prior-phase visibility assumptions carried forward.
+
+## Architecture
+Phase 8 introduces a fleet orchestration layer above existing loop-scoped manager artifacts:
+
+1. Fleet registry plane:
+- File-first registry under `.superloop/ops-manager/fleet/` declaring managed loops, sprite assignments, transport preferences, and policy metadata.
+
+2. Fleet execution plane:
+- Fleet reconcile entrypoint orchestrates loop-level reconcile passes with bounded parallelism, deterministic ordering options, and per-loop result capture.
+
+3. Fleet policy plane:
+- Advisory evaluator consumes loop health/visibility outputs to produce ranked, trace-linked action recommendations.
+
+4. Fleet operator plane:
+- Fleet status/reporting surface summarizes overall fleet posture and identifies loops needing manual intervention.
+
+## Decisions
+- Keep `Loop Run` as the primary managed unit; fleet is an orchestration wrapper across loop units.
+- Keep phase output file-first and append-only where possible for replay/debug value.
+- Start with advisory policy mode only; no automatic control dispatch in Phase 8 initiation.
+- Maintain transport parity as a release gate, not a best-effort follow-up.
+
+## Risks / Constraints
+- Fleet fan-out can increase I/O and process contention if concurrency is not bounded.
+- Partial failures across loops can produce inconsistent fleet snapshots without strict aggregation semantics.
+- Policy recommendations may drift/noise without clear confidence and suppression controls.
+- Trace correlation across many loops may become ambiguous without explicit fleet/session IDs.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Fleet registry contract + fan-out reconcile baseline + advisory policy/status surfaces.
+- **Phase 2**: Fleet policy hardening, operator controls, runbook workflows, and parity hardening.

--- a/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_1.MD
@@ -1,0 +1,36 @@
+# Phase 1 - Fleet Orchestration Baseline
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/PLAN.MD` aligns with current repo state and prior phase outcomes.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/70`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#68`, `#69`).
+
+## P1.1 Fleet Registry Contract
+1. [ ] Define fleet registry artifact path/schema under `.superloop/ops-manager/fleet/`.
+2. [ ] Add validation/fail-closed behavior for malformed or incomplete fleet entries.
+3. [ ] Include transport mode and sprite assignment metadata per loop run.
+
+## P1.2 Fleet Reconcile Fan-Out
+1. [ ] Add fleet reconcile command that executes per-loop reconcile with bounded concurrency.
+2. [ ] Capture per-loop results (success/failure, reason code, trace linkage, duration) in fleet telemetry.
+3. [ ] Support deterministic replay mode for fleet reconcile ordering.
+
+## P1.3 Advisory Fleet Policy Evaluation
+1. [ ] Add fleet policy evaluator that consumes per-loop health/visibility outputs.
+2. [ ] Emit advisory action candidates with confidence and rationale (no automatic execution).
+3. [ ] Persist policy telemetry and suppression metadata for operator triage.
+
+## P1.4 Operator Fleet Surface
+1. [ ] Add fleet status projection summarizing fleet health posture and loop exception buckets.
+2. [ ] Surface trace-linked drill-down pointers to loop-level status/telemetry artifacts.
+3. [ ] Add reason-coded fleet degradation signals for partial-failure scenarios.
+
+## P1.5 Test Coverage
+1. [ ] Add `tests/ops-manager-fleet.bats` for registry validation, fan-out reconcile behavior, and policy/status outputs.
+2. [ ] Add/extend tests proving fleet parity across `local` and `sprite_service` transports.
+3. [ ] Add regression tests for fleet partial-failure and replay determinism behavior.
+
+## P1.V Validation
+1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
+2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+3. [ ] Updated docs/runbook match implemented fleet artifacts, fields, and operator workflow.


### PR DESCRIPTION
## Summary
- add Phase 8 initiation packet for ops-manager fleet orchestration
- define Phase 8 goal/scope/non-goals, architecture, decisions, risks, and gate baseline
- add Phase 8 Phase-1 task decomposition with explicit validation criteria
- attach issue scope authority and prior PR context references

## Feature Packet
- `feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/PLAN.MD`
- `feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_1.MD`

## Issue
Refs #70
