### PR TITLE
fix: harden boolean defaults to preserve explicit false

### DIFF
--- a/feat/boolean-default-hardening/initiation/PLAN.MD
+++ b/feat/boolean-default-hardening/initiation/PLAN.MD
@@ -1,0 +1,41 @@
+# Feature: Boolean Default Hardening
+
+## Goal
+Eliminate boolean default coercion bugs where explicit `false` values were treated as fallback defaults (especially `// true`).
+
+## Scope
+- Add a shared boolean normalizer helper in `src/00-header.sh`.
+- Replace vulnerable boolean reads in `src/60-commands.sh` and `src/56-validate-static.sh`.
+- Add regression tests in `tests/superloop.bats` and `tests/rlms.bats`.
+- Regenerate `superloop.sh` with `scripts/build.sh`.
+
+## Non-Goals (this iteration)
+- Changing lifecycle audit policy thresholds or cleanup behavior.
+- Refactoring all config reads to shared typed accessors.
+
+## Primary References
+- `src/00-header.sh` - shared utility helpers.
+- `src/56-validate-static.sh` - static lifecycle gate validation path.
+- `src/60-commands.sh` - runtime state/lifecycle/rlms boolean decisions.
+- `tests/superloop.bats` - run and validation regressions.
+- `tests/rlms.bats` - RLMS role toggle regression.
+
+## Architecture
+Use a single helper (`bool_or_default`) to normalize raw boolean reads (`true`/`false`) while only applying defaults for missing/invalid values.
+
+## Decisions
+- Keep defaulting behavior intact for missing values, but preserve explicit `false`.
+- Replace all runtime/static `// true` boolean reads in source to remove this bug class.
+- Assert behavior with both config-level and runtime-level regressions.
+
+## Risks / Constraints
+- Large shell test suite runtime; use targeted bats filters for fast confidence.
+- Generated `superloop.sh` must be rebuilt after source edits.
+
+## Gate Baseline
+- Tests mode: `disabled` in added run-path test loops.
+- Validation require on completion: unchanged from existing test fixtures.
+- Validation checklist mapping file: `N/A`.
+
+## Phases
+- **Phase 1**: implement helper, patch callsites, add regressions, and validate with targeted bats runs.

--- a/feat/boolean-default-hardening/initiation/tasks/PHASE_1.MD
+++ b/feat/boolean-default-hardening/initiation/tasks/PHASE_1.MD
@@ -1,0 +1,23 @@
+# Phase 1 - Boolean Default Hardening
+
+## P1.1 Shared Bool Parsing
+1. [x] Add `bool_or_default` helper in `src/00-header.sh`.
+
+## P1.2 Runtime Callsite Hardening
+1. [x] Replace `state.active` parsing in `src/60-commands.sh` with helper-based parsing.
+2. [x] Replace lifecycle booleans in `src/60-commands.sh` (`enabled`, `require_on_completion`, `strict`, `block_on_failure`).
+3. [x] Replace `usage_check.enabled` parsing in `src/60-commands.sh`.
+4. [x] Replace RLMS booleans in `src/60-commands.sh` (`output.require_citations`, `rlms.roles[$role]`).
+
+## P1.3 Static Validation Hardening
+1. [x] Replace lifecycle boolean parsing in `src/56-validate-static.sh`.
+
+## P1.4 Regressions
+1. [x] Add superloop regression: explicit `active=false` state does not trigger reentrant block.
+2. [x] Add superloop regression: explicit `lifecycle.enabled=false` is rejected in run path.
+3. [x] Add static validation regression: explicit `lifecycle.enabled=false` fails validation.
+4. [x] Add RLMS regression: `rlms.roles.reviewer=false` disables reviewer RLMS execution.
+
+## P1.V Validation
+1. [x] `bats tests/superloop.bats --filter 'validate --static fails when lifecycle.enabled is explicitly false|run blocks reentrant invocation for the same active loop id|run does not treat state.active=false as active|run rejects explicit lifecycle.enabled=false in loop config|run --dry-run resolves lifecycle main ref to HEAD on detached checkout'`
+2. [x] `bats tests/rlms.bats --filter 'rlms requested mode does not run when keyword is absent|rlms role override false skips reviewer execution|rlms hybrid mode auto-triggers on large context'`

--- a/src/00-header.sh
+++ b/src/00-header.sh
@@ -149,6 +149,24 @@ json_or_default() {
   echo "$fallback"
 }
 
+bool_or_default() {
+  local raw="${1:-}"
+  local fallback="${2:-false}"
+
+  if [[ "$fallback" != "true" && "$fallback" != "false" ]]; then
+    fallback="false"
+  fi
+
+  case "$raw" in
+    true|false)
+      echo "$raw"
+      ;;
+    *)
+      echo "$fallback"
+      ;;
+  esac
+}
+
 file_mtime() {
   local file="$1"
   if [[ ! -e "$file" ]]; then

--- a/src/56-validate-static.sh
+++ b/src/56-validate-static.sh
@@ -458,11 +458,11 @@ check_lifecycle_gate_config() {
   local location_prefix="$2"
 
   local enabled
-  enabled=$(jq -r '.lifecycle.enabled // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  enabled=$(bool_or_default "$(jq -r '.lifecycle.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
   local require_on_completion
-  require_on_completion=$(jq -r '.lifecycle.require_on_completion // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  require_on_completion=$(bool_or_default "$(jq -r '.lifecycle.require_on_completion' <<<"$loop_json" 2>/dev/null || true)" "true")
   local strict
-  strict=$(jq -r '.lifecycle.strict // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  strict=$(bool_or_default "$(jq -r '.lifecycle.strict' <<<"$loop_json" 2>/dev/null || true)" "true")
   local feature_prefix
   feature_prefix=$(jq -r '.lifecycle.feature_prefix // "feat/"' <<<"$loop_json" 2>/dev/null || echo "feat/")
   local main_ref

--- a/src/60-commands.sh
+++ b/src/60-commands.sh
@@ -1541,7 +1541,7 @@ run_cmd() {
     loop_index=$(jq -r '.loop_index // 0' "$state_file")
     iteration=$(jq -r '.iteration // 1' "$state_file")
     local active
-    active=$(jq -r '.active // true' "$state_file")
+    active=$(bool_or_default "$(jq -r '.active' "$state_file" 2>/dev/null || true)" "true")
     if [[ "$active" == "true" ]]; then
       was_active="true"
       active_loop_id=$(jq -r '.current_loop_id // ""' "$state_file")
@@ -1875,13 +1875,13 @@ run_cmd() {
     evidence_require=$(jq -r '.evidence.require_on_completion // false' <<<"$loop_json")
 
     local lifecycle_enabled
-    lifecycle_enabled=$(jq -r '.lifecycle.enabled // true' <<<"$loop_json")
+    lifecycle_enabled=$(bool_or_default "$(jq -r '.lifecycle.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_require
-    lifecycle_require=$(jq -r '.lifecycle.require_on_completion // true' <<<"$loop_json")
+    lifecycle_require=$(bool_or_default "$(jq -r '.lifecycle.require_on_completion' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_strict
-    lifecycle_strict=$(jq -r '.lifecycle.strict // true' <<<"$loop_json")
+    lifecycle_strict=$(bool_or_default "$(jq -r '.lifecycle.strict' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_block_on_failure
-    lifecycle_block_on_failure=$(jq -r '.lifecycle.block_on_failure // true' <<<"$loop_json")
+    lifecycle_block_on_failure=$(bool_or_default "$(jq -r '.lifecycle.block_on_failure' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_feature_prefix
     lifecycle_feature_prefix=$(jq -r '.lifecycle.feature_prefix // "feat/"' <<<"$loop_json")
     local lifecycle_main_ref
@@ -1926,7 +1926,7 @@ run_cmd() {
 
     # Usage check settings (enabled by default - gracefully degrades if no credentials)
     local usage_check_enabled
-    usage_check_enabled=$(jq -r '.usage_check.enabled // true' <<<"$loop_json")
+    usage_check_enabled=$(bool_or_default "$(jq -r '.usage_check.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
     local usage_warn_threshold
     usage_warn_threshold=$(jq -r '.usage_check.warn_threshold // 70' <<<"$loop_json")
     local usage_block_threshold
@@ -2035,7 +2035,7 @@ run_cmd() {
     local rlms_output_format
     rlms_output_format=$(jq -r '.rlms.output.format // "json"' <<<"$loop_json")
     local rlms_output_require_citations
-    rlms_output_require_citations=$(jq -r '.rlms.output.require_citations // true' <<<"$loop_json")
+    rlms_output_require_citations=$(bool_or_default "$(jq -r '.rlms.output.require_citations' <<<"$loop_json" 2>/dev/null || true)" "true")
     local rlms_policy_force_on
     rlms_policy_force_on=$(jq -r '.rlms.policy.force_on // false' <<<"$loop_json")
     local rlms_policy_force_off
@@ -4776,8 +4776,7 @@ EOF
 
         if [[ "$rlms_enabled" == "true" ]]; then
           local role_rlms_enabled
-          role_rlms_enabled=$(jq -r --arg role "$role" '.rlms.roles[$role] // true' <<<"$loop_json")
-          role_rlms_enabled="${role_rlms_enabled:-true}"
+          role_rlms_enabled=$(bool_or_default "$(jq -r --arg role "$role" '.rlms.roles[$role]' <<<"$loop_json" 2>/dev/null || true)" "true")
 
           local role_rlms_dir="$rlms_root_dir/iter-$iteration/$role"
           local role_rlms_context_file="$role_rlms_dir/context-files.txt"

--- a/superloop.sh
+++ b/superloop.sh
@@ -149,6 +149,24 @@ json_or_default() {
   echo "$fallback"
 }
 
+bool_or_default() {
+  local raw="${1:-}"
+  local fallback="${2:-false}"
+
+  if [[ "$fallback" != "true" && "$fallback" != "false" ]]; then
+    fallback="false"
+  fi
+
+  case "$raw" in
+    true|false)
+      echo "$raw"
+      ;;
+    *)
+      echo "$fallback"
+      ;;
+  esac
+}
+
 file_mtime() {
   local file="$1"
   if [[ ! -e "$file" ]]; then
@@ -6736,11 +6754,11 @@ check_lifecycle_gate_config() {
   local location_prefix="$2"
 
   local enabled
-  enabled=$(jq -r '.lifecycle.enabled // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  enabled=$(bool_or_default "$(jq -r '.lifecycle.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
   local require_on_completion
-  require_on_completion=$(jq -r '.lifecycle.require_on_completion // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  require_on_completion=$(bool_or_default "$(jq -r '.lifecycle.require_on_completion' <<<"$loop_json" 2>/dev/null || true)" "true")
   local strict
-  strict=$(jq -r '.lifecycle.strict // true' <<<"$loop_json" 2>/dev/null || echo "true")
+  strict=$(bool_or_default "$(jq -r '.lifecycle.strict' <<<"$loop_json" 2>/dev/null || true)" "true")
   local feature_prefix
   feature_prefix=$(jq -r '.lifecycle.feature_prefix // "feat/"' <<<"$loop_json" 2>/dev/null || echo "feat/")
   local main_ref
@@ -9242,7 +9260,7 @@ run_cmd() {
     loop_index=$(jq -r '.loop_index // 0' "$state_file")
     iteration=$(jq -r '.iteration // 1' "$state_file")
     local active
-    active=$(jq -r '.active // true' "$state_file")
+    active=$(bool_or_default "$(jq -r '.active' "$state_file" 2>/dev/null || true)" "true")
     if [[ "$active" == "true" ]]; then
       was_active="true"
       active_loop_id=$(jq -r '.current_loop_id // ""' "$state_file")
@@ -9576,13 +9594,13 @@ run_cmd() {
     evidence_require=$(jq -r '.evidence.require_on_completion // false' <<<"$loop_json")
 
     local lifecycle_enabled
-    lifecycle_enabled=$(jq -r '.lifecycle.enabled // true' <<<"$loop_json")
+    lifecycle_enabled=$(bool_or_default "$(jq -r '.lifecycle.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_require
-    lifecycle_require=$(jq -r '.lifecycle.require_on_completion // true' <<<"$loop_json")
+    lifecycle_require=$(bool_or_default "$(jq -r '.lifecycle.require_on_completion' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_strict
-    lifecycle_strict=$(jq -r '.lifecycle.strict // true' <<<"$loop_json")
+    lifecycle_strict=$(bool_or_default "$(jq -r '.lifecycle.strict' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_block_on_failure
-    lifecycle_block_on_failure=$(jq -r '.lifecycle.block_on_failure // true' <<<"$loop_json")
+    lifecycle_block_on_failure=$(bool_or_default "$(jq -r '.lifecycle.block_on_failure' <<<"$loop_json" 2>/dev/null || true)" "true")
     local lifecycle_feature_prefix
     lifecycle_feature_prefix=$(jq -r '.lifecycle.feature_prefix // "feat/"' <<<"$loop_json")
     local lifecycle_main_ref
@@ -9627,7 +9645,7 @@ run_cmd() {
 
     # Usage check settings (enabled by default - gracefully degrades if no credentials)
     local usage_check_enabled
-    usage_check_enabled=$(jq -r '.usage_check.enabled // true' <<<"$loop_json")
+    usage_check_enabled=$(bool_or_default "$(jq -r '.usage_check.enabled' <<<"$loop_json" 2>/dev/null || true)" "true")
     local usage_warn_threshold
     usage_warn_threshold=$(jq -r '.usage_check.warn_threshold // 70' <<<"$loop_json")
     local usage_block_threshold
@@ -9736,7 +9754,7 @@ run_cmd() {
     local rlms_output_format
     rlms_output_format=$(jq -r '.rlms.output.format // "json"' <<<"$loop_json")
     local rlms_output_require_citations
-    rlms_output_require_citations=$(jq -r '.rlms.output.require_citations // true' <<<"$loop_json")
+    rlms_output_require_citations=$(bool_or_default "$(jq -r '.rlms.output.require_citations' <<<"$loop_json" 2>/dev/null || true)" "true")
     local rlms_policy_force_on
     rlms_policy_force_on=$(jq -r '.rlms.policy.force_on // false' <<<"$loop_json")
     local rlms_policy_force_off
@@ -12477,8 +12495,7 @@ EOF
 
         if [[ "$rlms_enabled" == "true" ]]; then
           local role_rlms_enabled
-          role_rlms_enabled=$(jq -r --arg role "$role" '.rlms.roles[$role] // true' <<<"$loop_json")
-          role_rlms_enabled="${role_rlms_enabled:-true}"
+          role_rlms_enabled=$(bool_or_default "$(jq -r --arg role "$role" '.rlms.roles[$role]' <<<"$loop_json" 2>/dev/null || true)" "true")
 
           local role_rlms_dir="$rlms_root_dir/iter-$iteration/$role"
           local role_rlms_context_file="$role_rlms_dir/context-files.txt"


### PR DESCRIPTION
## Summary
- add `bool_or_default` helper to preserve explicit `false` values while defaulting only missing/invalid booleans
- replace vulnerable runtime boolean reads that previously used `// true` in `run_cmd`
- replace vulnerable lifecycle static-validation boolean reads in `check_lifecycle_gate_config`
- regenerate `superloop.sh` from source
- add regressions for `state.active=false`, lifecycle explicit-false handling, and RLMS role disable override
- include feature initiation artifacts for traceability

## Root Cause
`jq` `//` treats both `null` and `false` as fallback candidates. Patterns like `.active // true` therefore coerced explicit `false` to `true`, causing incorrect reentrant blocks and other boolean-gating misbehavior.

## Behavior After Fix
- `state.active=false` is respected (no false reentrant block)
- explicit `lifecycle.enabled=false` is respected and rejected by mandatory lifecycle enforcement
- `rlms.roles.<role>=false` is respected and yields `role_disabled`
- defaults still apply when fields are missing or invalid

## Validation
- `bats tests/superloop.bats --filter 'validate --static fails when lifecycle.enabled is explicitly false|run blocks reentrant invocation for the same active loop id|run does not treat state.active=false as active|run rejects explicit lifecycle.enabled=false in loop config|run --dry-run resolves lifecycle main ref to HEAD on detached checkout'`
- `bats tests/rlms.bats --filter 'rlms requested mode does not run when keyword is absent|rlms role override false skips reviewer execution|rlms hybrid mode auto-triggers on large context'`
