### PR TITLE
feat(ops-manager): phase-8 fleet orchestration baseline

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_1.MD
@@ -6,31 +6,31 @@
 3. [x] Link this phase packet from the issue and include prior PR context (`#68`, `#69`).
 
 ## P1.1 Fleet Registry Contract
-1. [ ] Define fleet registry artifact path/schema under `.superloop/ops-manager/fleet/`.
-2. [ ] Add validation/fail-closed behavior for malformed or incomplete fleet entries.
-3. [ ] Include transport mode and sprite assignment metadata per loop run.
+1. [x] Define fleet registry artifact path/schema under `.superloop/ops-manager/fleet/`.
+2. [x] Add validation/fail-closed behavior for malformed or incomplete fleet entries.
+3. [x] Include transport mode and sprite assignment metadata per loop run.
 
 ## P1.2 Fleet Reconcile Fan-Out
-1. [ ] Add fleet reconcile command that executes per-loop reconcile with bounded concurrency.
-2. [ ] Capture per-loop results (success/failure, reason code, trace linkage, duration) in fleet telemetry.
-3. [ ] Support deterministic replay mode for fleet reconcile ordering.
+1. [x] Add fleet reconcile command that executes per-loop reconcile with bounded concurrency.
+2. [x] Capture per-loop results (success/failure, reason code, trace linkage, duration) in fleet telemetry.
+3. [x] Support deterministic replay mode for fleet reconcile ordering.
 
 ## P1.3 Advisory Fleet Policy Evaluation
-1. [ ] Add fleet policy evaluator that consumes per-loop health/visibility outputs.
-2. [ ] Emit advisory action candidates with confidence and rationale (no automatic execution).
-3. [ ] Persist policy telemetry and suppression metadata for operator triage.
+1. [x] Add fleet policy evaluator that consumes per-loop health/visibility outputs.
+2. [x] Emit advisory action candidates with confidence and rationale (no automatic execution).
+3. [x] Persist policy telemetry and suppression metadata for operator triage.
 
 ## P1.4 Operator Fleet Surface
-1. [ ] Add fleet status projection summarizing fleet health posture and loop exception buckets.
-2. [ ] Surface trace-linked drill-down pointers to loop-level status/telemetry artifacts.
-3. [ ] Add reason-coded fleet degradation signals for partial-failure scenarios.
+1. [x] Add fleet status projection summarizing fleet health posture and loop exception buckets.
+2. [x] Surface trace-linked drill-down pointers to loop-level status/telemetry artifacts.
+3. [x] Add reason-coded fleet degradation signals for partial-failure scenarios.
 
 ## P1.5 Test Coverage
-1. [ ] Add `tests/ops-manager-fleet.bats` for registry validation, fan-out reconcile behavior, and policy/status outputs.
-2. [ ] Add/extend tests proving fleet parity across `local` and `sprite_service` transports.
-3. [ ] Add regression tests for fleet partial-failure and replay determinism behavior.
+1. [x] Add `tests/ops-manager-fleet.bats` for registry validation, fan-out reconcile behavior, and policy/status outputs.
+2. [x] Add/extend tests proving fleet parity across `local` and `sprite_service` transports.
+3. [x] Add regression tests for fleet partial-failure and replay determinism behavior.
 
 ## P1.V Validation
-1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
-2. [ ] All new/changed scripts pass `bash -n` syntax checks.
-3. [ ] Updated docs/runbook match implemented fleet artifacts, fields, and operator workflow.
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Updated docs/runbook match implemented fleet artifacts, fields, and operator workflow.

--- a/schema/ops-manager-fleet.registry.schema.json
+++ b/schema/ops-manager-fleet.registry.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ops Manager Fleet Registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "loops"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "v1"
+    },
+    "fleetId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "loops": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "loopId"
+        ],
+        "properties": {
+          "loopId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "transport": {
+            "type": "string",
+            "enum": [
+              "local",
+              "sprite_service"
+            ]
+          },
+          "sprite": {
+            "type": "object"
+          },
+          "service": {
+            "type": "object"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "advisory"
+          ]
+        },
+        "suppressions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/ops-manager-fleet-policy.sh
+++ b/scripts/ops-manager-fleet-policy.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-fleet-policy.sh --repo <path> [options]
+
+Options:
+  --registry-file <path>        Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --fleet-state-file <path>     Fleet state JSON path. Default: <repo>/.superloop/ops-manager/fleet/state.json
+  --policy-state-file <path>    Policy state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/policy-state.json
+  --policy-telemetry-file <path> Policy telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/policy.jsonl
+  --trace-id <id>               Policy trace id override. Default: fleet state trace id or generated.
+  --pretty                      Pretty-print output JSON.
+  --help                        Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'trace-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+repo=""
+registry_file=""
+fleet_state_file=""
+policy_state_file=""
+policy_telemetry_file=""
+trace_id=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --registry-file)
+      registry_file="${2:-}"
+      shift 2
+      ;;
+    --fleet-state-file)
+      fleet_state_file="${2:-}"
+      shift 2
+      ;;
+    --policy-state-file)
+      policy_state_file="${2:-}"
+      shift 2
+      ;;
+    --policy-telemetry-file)
+      policy_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+registry_script="${OPS_MANAGER_FLEET_REGISTRY_SCRIPT:-$script_dir/ops-manager-fleet-registry.sh}"
+
+if [[ -z "$registry_file" ]]; then
+  registry_file="$repo/.superloop/ops-manager/fleet/registry.v1.json"
+fi
+if [[ -z "$fleet_state_file" ]]; then
+  fleet_state_file="$repo/.superloop/ops-manager/fleet/state.json"
+fi
+if [[ -z "$policy_state_file" ]]; then
+  policy_state_file="$repo/.superloop/ops-manager/fleet/policy-state.json"
+fi
+if [[ -z "$policy_telemetry_file" ]]; then
+  policy_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/policy.jsonl"
+fi
+
+if [[ ! -f "$fleet_state_file" ]]; then
+  die "fleet state file not found: $fleet_state_file"
+fi
+
+registry_json=$("$registry_script" --repo "$repo" --registry-file "$registry_file")
+fleet_state_json=$(jq -c '.' "$fleet_state_file" 2>/dev/null) || die "invalid fleet state JSON: $fleet_state_file"
+
+if [[ -z "$trace_id" ]]; then
+  trace_id="$(jq -r '.traceId // empty' <<<"$fleet_state_json")"
+fi
+if [[ -z "$trace_id" && -n "${OPS_MANAGER_TRACE_ID:-}" ]]; then
+  trace_id="$OPS_MANAGER_TRACE_ID"
+fi
+if [[ -z "$trace_id" ]]; then
+  trace_id="$(generate_trace_id)"
+fi
+
+mkdir -p "$(dirname "$policy_state_file")"
+mkdir -p "$(dirname "$policy_telemetry_file")"
+
+policy_mode="$(jq -r '.policy.mode // "advisory"' <<<"$registry_json")"
+if [[ "$policy_mode" != "advisory" ]]; then
+  die "unsupported policy mode in phase 8 baseline: $policy_mode"
+fi
+
+suppressions_json="$(jq -c '.policy.suppressions // {}' <<<"$registry_json")"
+
+candidates_json=$(jq -cn \
+  --argjson results "$(jq -c '.results // []' <<<"$fleet_state_json")" \
+  --argjson suppressions "$suppressions_json" \
+  '
+  def suppression_matches($loop_id; $category):
+    ((($suppressions[$loop_id] // []) + ($suppressions["*"] // [])) | index($category)) != null;
+
+  [
+    $results[] as $r
+    | [
+        (if ($r.status // "") == "failed" then {
+          loopId: $r.loopId,
+          category: "reconcile_failed",
+          severity: "critical",
+          confidence: "high",
+          rationale: "Loop reconcile failed in fleet fan-out",
+          recommendedIntent: null,
+          traceId: ($r.traceId // null)
+        } else empty end),
+        (if ($r.healthStatus // "") == "critical" then {
+          loopId: $r.loopId,
+          category: "health_critical",
+          severity: "critical",
+          confidence: "high",
+          rationale: "Loop health is critical",
+          recommendedIntent: null,
+          traceId: ($r.traceId // null)
+        } else empty end),
+        (if ($r.healthStatus // "") == "degraded" then {
+          loopId: $r.loopId,
+          category: "health_degraded",
+          severity: "warning",
+          confidence: "medium",
+          rationale: "Loop health is degraded",
+          recommendedIntent: null,
+          traceId: ($r.traceId // null)
+        } else empty end)
+      ]
+      | .[]
+      | . as $candidate
+      | . + {
+          suppressed: suppression_matches($candidate.loopId; $candidate.category),
+          suppressionReason: (
+            if suppression_matches($candidate.loopId; $candidate.category) then
+              "registry_policy_suppression"
+            else
+              null
+            end
+          )
+        }
+  ]
+  ')
+
+policy_state_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg updated_at "$(timestamp)" \
+  --arg fleet_id "$(jq -r '.fleetId // "default"' <<<"$fleet_state_json")" \
+  --arg trace_id "$trace_id" \
+  --arg mode "$policy_mode" \
+  --arg fleet_status "$(jq -r '.status // "unknown"' <<<"$fleet_state_json")" \
+  --arg fleet_state_file "$fleet_state_file" \
+  --arg registry_file "$registry_file" \
+  --argjson evaluated_loop_count "$(jq -r '.results | length' <<<"$fleet_state_json")" \
+  --argjson candidates "$candidates_json" \
+  --argjson suppressions "$suppressions_json" \
+  '
+  {
+    schemaVersion: $schema_version,
+    updatedAt: $updated_at,
+    fleetId: $fleet_id,
+    traceId: $trace_id,
+    mode: $mode,
+    fleetStatus: $fleet_status,
+    source: {
+      fleetStateFile: $fleet_state_file,
+      registryFile: $registry_file
+    },
+    evaluatedLoopCount: $evaluated_loop_count,
+    candidateCount: ($candidates | length),
+    unsuppressedCount: ([ $candidates[] | select((.suppressed // false) == false) ] | length),
+    suppressedCount: ([ $candidates[] | select((.suppressed // false) == true) ] | length),
+    candidates: $candidates,
+    summary: {
+      bySeverity: {
+        critical: ([ $candidates[] | select(.severity == "critical") ] | length),
+        warning: ([ $candidates[] | select(.severity == "warning") ] | length),
+        info: ([ $candidates[] | select(.severity == "info") ] | length)
+      },
+      byCategory: (
+        reduce $candidates[] as $candidate ({}; .[$candidate.category] = ((.[$candidate.category] // 0) + 1))
+      )
+    },
+    suppressionState: {
+      suppressions: $suppressions
+    }
+  }
+  | .reasonCodes = (
+      [
+        (if .unsuppressedCount > 0 then "fleet_action_required" else "no_action_required" end),
+        (if .suppressedCount > 0 then "fleet_actions_suppressed" else empty end)
+      ]
+      | unique
+    )
+  ')
+
+jq -c '.' <<<"$policy_state_json" > "$policy_state_file"
+
+jq -cn \
+  --arg timestamp "$(timestamp)" \
+  --arg fleet_id "$(jq -r '.fleetId // "default"' <<<"$fleet_state_json")" \
+  --arg trace_id "$trace_id" \
+  --arg mode "$policy_mode" \
+  --argjson summary "$(jq -c '{candidateCount, unsuppressedCount, suppressedCount, reasonCodes, summary}' <<<"$policy_state_json")" \
+  '{
+    timestamp: $timestamp,
+    category: "fleet_policy",
+    fleetId: $fleet_id,
+    traceId: $trace_id,
+    mode: $mode,
+    summary: $summary
+  }' >> "$policy_telemetry_file"
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$policy_state_json"
+else
+  jq -c '.' <<<"$policy_state_json"
+fi

--- a/scripts/ops-manager-fleet-reconcile.sh
+++ b/scripts/ops-manager-fleet-reconcile.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-fleet-reconcile.sh --repo <path> [options]
+
+Options:
+  --registry-file <path>        Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --fleet-state-file <path>     Fleet state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/state.json
+  --fleet-telemetry-file <path> Fleet reconcile telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl
+  --max-parallel <n>            Max concurrent loop reconciles (default: 2)
+  --deterministic-order          Sort loops by loopId before fan-out.
+  --max-events <n>              Max events per loop reconcile pass-through.
+  --from-start                  Replay from start for each loop reconcile pass.
+  --trace-id <id>               Fleet reconcile trace id (generated when omitted).
+  --pretty                      Pretty-print output JSON.
+  --help                        Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'trace-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+classify_failure_code() {
+  local msg="$1"
+  local lower
+  lower="$(tr '[:upper:]' '[:lower:]' <<<"$msg")"
+
+  if [[ "$lower" == *"missing required artifact"* || "$lower" == *"events artifact"* ]]; then
+    echo "missing_runtime_artifacts"
+    return 0
+  fi
+  if [[ "$lower" == *"service request failed"* || "$lower" == *"transport_unreachable"* || "$lower" == *"connection refused"* ]]; then
+    echo "transport_unreachable"
+    return 0
+  fi
+  if [[ "$lower" == *"invalid"*"json"* || "$lower" == *"invalid payload"* ]]; then
+    echo "invalid_payload"
+    return 0
+  fi
+
+  echo "reconcile_failed"
+}
+
+repo=""
+registry_file=""
+fleet_state_file=""
+fleet_telemetry_file=""
+max_parallel="2"
+deterministic_order="0"
+max_events=""
+from_start="0"
+trace_id=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --registry-file)
+      registry_file="${2:-}"
+      shift 2
+      ;;
+    --fleet-state-file)
+      fleet_state_file="${2:-}"
+      shift 2
+      ;;
+    --fleet-telemetry-file)
+      fleet_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --max-parallel)
+      max_parallel="${2:-}"
+      shift 2
+      ;;
+    --deterministic-order)
+      deterministic_order="1"
+      shift
+      ;;
+    --max-events)
+      max_events="${2:-}"
+      shift 2
+      ;;
+    --from-start)
+      from_start="1"
+      shift
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+need_cmd mktemp
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ ! "$max_parallel" =~ ^[0-9]+$ || "$max_parallel" -lt 1 ]]; then
+  die "--max-parallel must be an integer >= 1"
+fi
+if [[ -n "$max_events" && (! "$max_events" =~ ^[0-9]+$) ]]; then
+  die "--max-events must be a non-negative integer"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+registry_script="${OPS_MANAGER_FLEET_REGISTRY_SCRIPT:-$script_dir/ops-manager-fleet-registry.sh}"
+reconcile_script="${OPS_MANAGER_RECONCILE_SCRIPT:-$script_dir/ops-manager-reconcile.sh}"
+
+if [[ -z "$registry_file" ]]; then
+  registry_file="$repo/.superloop/ops-manager/fleet/registry.v1.json"
+fi
+if [[ -z "$fleet_state_file" ]]; then
+  fleet_state_file="$repo/.superloop/ops-manager/fleet/state.json"
+fi
+if [[ -z "$fleet_telemetry_file" ]]; then
+  fleet_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl"
+fi
+if [[ -z "$trace_id" && -n "${OPS_MANAGER_TRACE_ID:-}" ]]; then
+  trace_id="$OPS_MANAGER_TRACE_ID"
+fi
+if [[ -z "$trace_id" ]]; then
+  trace_id="$(generate_trace_id)"
+fi
+
+mkdir -p "$(dirname "$fleet_state_file")"
+mkdir -p "$(dirname "$fleet_telemetry_file")"
+
+registry_json=$("$registry_script" --repo "$repo" --registry-file "$registry_file")
+fleet_id="$(jq -r '.fleetId // "default"' <<<"$registry_json")"
+
+if [[ "$deterministic_order" == "1" ]]; then
+  loops_json=$(jq -c '.loops | sort_by(.loopId)' <<<"$registry_json")
+else
+  loops_json=$(jq -c '.loops' <<<"$registry_json")
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+run_single_loop() {
+  local loop_json="$1"
+  local result_file="$2"
+
+  local loop_id transport enabled service_base_url service_token_env retry_attempts retry_backoff
+  local sprite_json metadata_json
+  loop_id="$(jq -r '.loopId' <<<"$loop_json")"
+  transport="$(jq -r '.transport // "local"' <<<"$loop_json")"
+  enabled="$(jq -r 'if (.enabled // true) then "true" else "false" end' <<<"$loop_json")"
+  service_base_url="$(jq -r '.service.baseUrl // empty' <<<"$loop_json")"
+  service_token_env="$(jq -r '.service.tokenEnv // empty' <<<"$loop_json")"
+  retry_attempts="$(jq -r '.service.retryAttempts // 3' <<<"$loop_json")"
+  retry_backoff="$(jq -r '.service.retryBackoffSeconds // 1' <<<"$loop_json")"
+  sprite_json="$(jq -c '.sprite // {}' <<<"$loop_json")"
+  metadata_json="$(jq -c '.metadata // {}' <<<"$loop_json")"
+
+  local loop_trace_id
+  loop_trace_id="${trace_id}-${loop_id//[^a-zA-Z0-9._-]/-}"
+
+  local started_at ended_at start_epoch end_epoch duration_seconds
+  started_at="$(timestamp)"
+  start_epoch="$(date -u +%s)"
+
+  local status="success"
+  local reason_code=""
+  local reconcile_output=""
+  local reconcile_status="success"
+  local health_status="unknown"
+  local health_reason_codes='[]'
+  local transition_state=""
+
+  local state_file="$repo/.superloop/ops-manager/$loop_id/state.json"
+  local health_file="$repo/.superloop/ops-manager/$loop_id/health.json"
+  local cursor_file="$repo/.superloop/ops-manager/$loop_id/cursor.json"
+  local reconcile_telemetry_file="$repo/.superloop/ops-manager/$loop_id/telemetry/reconcile.jsonl"
+
+  if [[ "$enabled" != "true" ]]; then
+    status="skipped"
+    reason_code="loop_disabled"
+    reconcile_status="skipped"
+  elif [[ "$transport" == "sprite_service" && -z "$service_base_url" ]]; then
+    status="failed"
+    reason_code="missing_service_base_url"
+    reconcile_status="failed"
+  elif [[ -n "$service_token_env" && -z "${!service_token_env:-}" ]]; then
+    status="failed"
+    reason_code="missing_service_token_env"
+    reconcile_status="failed"
+  else
+    local -a cmd
+    cmd=("$reconcile_script" --repo "$repo" --loop "$loop_id" --transport "$transport" --trace-id "$loop_trace_id")
+    if [[ -n "$max_events" ]]; then
+      cmd+=(--max-events "$max_events")
+    fi
+    if [[ "$from_start" == "1" ]]; then
+      cmd+=(--from-start)
+    fi
+    if [[ "$transport" == "sprite_service" ]]; then
+      cmd+=(--service-base-url "$service_base_url" --retry-attempts "$retry_attempts" --retry-backoff-seconds "$retry_backoff")
+      if [[ -n "$service_token_env" ]]; then
+        cmd+=(--service-token "${!service_token_env}")
+      fi
+    fi
+
+    if reconcile_output="$("${cmd[@]}" 2>&1)"; then
+      local reconcile_json
+      reconcile_json="$(jq -c '.' <<<"$reconcile_output" 2>/dev/null || echo 'null')"
+      health_status="$(jq -r '.health.status // "unknown"' <<<"$reconcile_json" 2>/dev/null || echo "unknown")"
+      health_reason_codes="$(jq -c '.health.reasonCodes // []' <<<"$reconcile_json" 2>/dev/null || echo '[]')"
+      transition_state="$(jq -r '.transition.currentState // empty' <<<"$reconcile_json" 2>/dev/null || true)"
+    else
+      status="failed"
+      reconcile_status="failed"
+      reason_code="$(classify_failure_code "$reconcile_output")"
+    fi
+  fi
+
+  ended_at="$(timestamp)"
+  end_epoch="$(date -u +%s)"
+  duration_seconds=$(( ${end_epoch:-0} - ${start_epoch:-0} ))
+  if (( duration_seconds < 0 )); then
+    duration_seconds=0
+  fi
+
+  local output_excerpt=""
+  if [[ "$status" != "success" ]]; then
+    output_excerpt="$(tr '\n' ' ' <<<"$reconcile_output" | sed 's/[[:space:]]\+/ /g' | cut -c1-600)"
+  fi
+
+  jq -cn \
+    --arg timestamp "$ended_at" \
+    --arg started_at "$started_at" \
+    --arg loop_id "$loop_id" \
+    --arg transport "$transport" \
+    --arg enabled "$enabled" \
+    --arg status "$status" \
+    --arg reason_code "$reason_code" \
+    --arg reconcile_status "$reconcile_status" \
+    --arg health_status "$health_status" \
+    --arg transition_state "$transition_state" \
+    --arg trace_id "$loop_trace_id" \
+    --arg output_excerpt "$output_excerpt" \
+    --arg state_file "$state_file" \
+    --arg health_file "$health_file" \
+    --arg cursor_file "$cursor_file" \
+    --arg reconcile_telemetry_file "$reconcile_telemetry_file" \
+    --argjson sprite "$sprite_json" \
+    --argjson metadata "$metadata_json" \
+    --argjson duration_seconds "$duration_seconds" \
+    --argjson health_reason_codes "$health_reason_codes" \
+    '{
+      timestamp: $timestamp,
+      startedAt: $started_at,
+      loopId: $loop_id,
+      transport: $transport,
+      enabled: ($enabled == "true"),
+      status: $status,
+      reasonCode: (if ($reason_code | length) > 0 then $reason_code else null end),
+      reconcileStatus: $reconcile_status,
+      healthStatus: $health_status,
+      healthReasonCodes: $health_reason_codes,
+      transitionState: (if ($transition_state | length) > 0 then $transition_state else null end),
+      durationSeconds: $duration_seconds,
+      traceId: $trace_id,
+      outputExcerpt: (if ($output_excerpt | length) > 0 then $output_excerpt else null end),
+      sprite: $sprite,
+      metadata: $metadata,
+      files: {
+        stateFile: $state_file,
+        healthFile: $health_file,
+        cursorFile: $cursor_file,
+        reconcileTelemetryFile: $reconcile_telemetry_file
+      }
+    } | with_entries(select(.value != null))' > "$result_file"
+}
+
+started_at="$(timestamp)"
+start_epoch="$(date -u +%s)"
+
+pids=()
+active_result_files=()
+completed_result_files=()
+
+launch_loop() {
+  local loop_json="$1"
+  local result_file
+  result_file="$(mktemp "$tmp_dir/loop-result.XXXXXX.json")"
+  run_single_loop "$loop_json" "$result_file" &
+  pids+=("$!")
+  active_result_files+=("$result_file")
+}
+
+reap_first() {
+  local pid="${pids[0]}"
+  local result_file="${active_result_files[0]}"
+  wait "$pid" || true
+  completed_result_files+=("$result_file")
+
+  if (( ${#pids[@]} > 1 )); then
+    pids=("${pids[@]:1}")
+    active_result_files=("${active_result_files[@]:1}")
+  else
+    pids=()
+    active_result_files=()
+  fi
+}
+
+while IFS= read -r loop_line; do
+  [[ -z "$loop_line" ]] && continue
+  launch_loop "$loop_line"
+  if (( ${#pids[@]} >= max_parallel )); then
+    reap_first
+  fi
+done < <(jq -c '.[]' <<<"$loops_json")
+
+while (( ${#pids[@]} > 0 )); do
+  reap_first
+done
+
+if (( ${#completed_result_files[@]} == 0 )); then
+  die "fleet reconcile produced no loop results"
+fi
+
+results_json="$(jq -cs '.' "${completed_result_files[@]}")"
+
+loop_count="$(jq -r 'length' <<<"$results_json")"
+success_count="$(jq -r '[.[] | select(.status == "success")] | length' <<<"$results_json")"
+failed_count="$(jq -r '[.[] | select(.status == "failed")] | length' <<<"$results_json")"
+skipped_count="$(jq -r '[.[] | select(.status == "skipped")] | length' <<<"$results_json")"
+
+fleet_status="success"
+if (( failed_count > 0 && success_count > 0 )); then
+  fleet_status="partial_failure"
+elif (( failed_count > 0 && success_count == 0 )); then
+  fleet_status="failed"
+fi
+
+reason_codes_json="$(jq -cn \
+  --argjson results "$results_json" \
+  --argjson success_count "$success_count" \
+  --argjson failed_count "$failed_count" \
+  --argjson skipped_count "$skipped_count" \
+  '
+  [
+    (if $failed_count > 0 and $success_count > 0 then "fleet_partial_failure" else empty end),
+    (if $failed_count > 0 and $success_count == 0 then "fleet_reconcile_failed" else empty end),
+    (if ([ $results[] | select(.healthStatus == "critical") ] | length) > 0 then "fleet_health_critical"
+     elif ([ $results[] | select(.healthStatus == "degraded") ] | length) > 0 then "fleet_health_degraded"
+     else empty end),
+    (if $skipped_count > 0 then "fleet_loop_skipped" else empty end)
+  ] | unique
+  ')"
+
+ended_at="$(timestamp)"
+end_epoch="$(date -u +%s)"
+duration_seconds=$(( ${end_epoch:-0} - ${start_epoch:-0} ))
+if (( duration_seconds < 0 )); then
+  duration_seconds=0
+fi
+
+fleet_state_json="$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$ended_at" \
+  --arg started_at "$started_at" \
+  --arg fleet_id "$fleet_id" \
+  --arg trace_id "$trace_id" \
+  --arg status "$fleet_status" \
+  --arg deterministic_order "$deterministic_order" \
+  --argjson max_parallel "$max_parallel" \
+  --argjson from_start "$from_start" \
+  --argjson max_events "${max_events:-0}" \
+  --argjson loop_count "$loop_count" \
+  --argjson success_count "$success_count" \
+  --argjson failed_count "$failed_count" \
+  --argjson skipped_count "$skipped_count" \
+  --argjson duration_seconds "$duration_seconds" \
+  --argjson reason_codes "$reason_codes_json" \
+  --argjson results "$results_json" \
+  '{
+    schemaVersion: $schema_version,
+    updatedAt: $timestamp,
+    startedAt: $started_at,
+    fleetId: $fleet_id,
+    traceId: $trace_id,
+    status: $status,
+    reasonCodes: $reason_codes,
+    loopCount: $loop_count,
+    successCount: $success_count,
+    failedCount: $failed_count,
+    skippedCount: $skipped_count,
+    durationSeconds: $duration_seconds,
+    execution: {
+      maxParallel: $max_parallel,
+      deterministicOrder: ($deterministic_order == "1"),
+      fromStart: ($from_start == 1),
+      maxEvents: $max_events
+    },
+    results: $results
+  }')"
+
+jq -c '.' <<<"$fleet_state_json" > "$fleet_state_file"
+
+jq -cn \
+  --arg timestamp "$ended_at" \
+  --arg fleet_id "$fleet_id" \
+  --arg trace_id "$trace_id" \
+  --arg status "$fleet_status" \
+  --argjson loop_count "$loop_count" \
+  --argjson success_count "$success_count" \
+  --argjson failed_count "$failed_count" \
+  --argjson skipped_count "$skipped_count" \
+  --argjson duration_seconds "$duration_seconds" \
+  --argjson reason_codes "$reason_codes_json" \
+  --argjson results "$results_json" \
+  '{
+    timestamp: $timestamp,
+    category: "fleet_reconcile",
+    fleetId: $fleet_id,
+    traceId: $trace_id,
+    status: $status,
+    reasonCodes: $reason_codes,
+    loopCount: $loop_count,
+    successCount: $success_count,
+    failedCount: $failed_count,
+    skippedCount: $skipped_count,
+    durationSeconds: $duration_seconds,
+    results: $results
+  }' >> "$fleet_telemetry_file"
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$fleet_state_json"
+else
+  jq -c '.' <<<"$fleet_state_json"
+fi

--- a/scripts/ops-manager-fleet-registry.sh
+++ b/scripts/ops-manager-fleet-registry.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-fleet-registry.sh --repo <path> [options]
+
+Options:
+  --registry-file <path>  Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --loop <id>             Filter output to a single loop id.
+  --pretty                Pretty-print output JSON.
+  --help                  Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+repo=""
+registry_file=""
+loop_id=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --registry-file)
+      registry_file="${2:-}"
+      shift 2
+      ;;
+    --loop)
+      loop_id="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+if [[ -z "$registry_file" ]]; then
+  registry_file="$repo/.superloop/ops-manager/fleet/registry.v1.json"
+fi
+
+if [[ ! -f "$registry_file" ]]; then
+  die "fleet registry file not found: $registry_file"
+fi
+
+registry_raw=$(jq -c '.' "$registry_file" 2>/dev/null) || die "invalid fleet registry JSON: $registry_file"
+
+validation_errors=$(jq -r '
+  def is_non_empty_string: (type == "string" and (.|length) > 0);
+  def loop_error($idx; $msg): "loops[\($idx)]: \($msg)";
+
+  (
+    if (.schemaVersion // "") != "v1" then ["schemaVersion must be \"v1\""] else [] end
+  )
+  + (
+    if ((.fleetId // "default") | type) != "string" then ["fleetId must be a string when present"] else [] end
+  )
+  + (
+    if (.loops | type) != "array" then ["loops must be an array"] else [] end
+  )
+  + (
+    if (.loops | type) == "array" and (.loops | length) == 0 then ["loops must include at least one loop entry"] else [] end
+  )
+  + (
+    if (.loops | type) != "array" then []
+    else
+      [.loops[]?] as $loops
+      | ( [ $loops[] | .loopId // null ] | map(select(type == "string")) ) as $loop_ids
+      | (
+          if (($loop_ids | length) != (($loop_ids | unique) | length)) then
+            ["loopId values must be unique"]
+          else
+            []
+          end
+        )
+      + (
+          [ range(0; $loops|length) as $i
+            | ($loops[$i]) as $loop
+            | (
+                if ($loop | type) != "object" then
+                  [loop_error($i; "entry must be an object")]
+                else
+                  []
+                end
+              )
+            + (
+                if (($loop.loopId // null) | is_non_empty_string) then []
+                else [loop_error($i; "loopId must be a non-empty string")]
+                end
+              )
+            + (
+                if ($loop.enabled == null or ($loop.enabled | type) == "boolean") then []
+                else [loop_error($i; "enabled must be boolean when present")]
+                end
+              )
+            + (
+                ($loop.transport // "local") as $transport
+                | if ($transport == "local" or $transport == "sprite_service") then []
+                  else [loop_error($i; "transport must be local or sprite_service")]
+                  end
+              )
+            + (
+                if (($loop.sprite // null) == null or ($loop.sprite | type) == "object") then []
+                else [loop_error($i; "sprite must be an object when present")]
+                end
+              )
+            + (
+                if (($loop.sprite.id // null) == null or (($loop.sprite.id // null) | is_non_empty_string)) then []
+                else [loop_error($i; "sprite.id must be a non-empty string when present")]
+                end
+              )
+            + (
+                if (($loop.service // null) == null or ($loop.service | type) == "object") then []
+                else [loop_error($i; "service must be an object when present")]
+                end
+              )
+            + (
+                if (($loop.service.tokenEnv // null) == null or (($loop.service.tokenEnv // null) | is_non_empty_string)) then []
+                else [loop_error($i; "service.tokenEnv must be a non-empty string when present")]
+                end
+              )
+            + (
+                if (($loop.service.retryAttempts // null) == null or ((($loop.service.retryAttempts // null) | type) == "number" and ($loop.service.retryAttempts >= 1))) then []
+                else [loop_error($i; "service.retryAttempts must be >= 1 when present")]
+                end
+              )
+            + (
+                if (($loop.service.retryBackoffSeconds // null) == null or ((($loop.service.retryBackoffSeconds // null) | type) == "number" and ($loop.service.retryBackoffSeconds >= 0))) then []
+                else [loop_error($i; "service.retryBackoffSeconds must be >= 0 when present")]
+                end
+              )
+            + (
+                ($loop.transport // "local") as $transport
+                | if $transport != "sprite_service" then []
+                  else
+                    ($loop.service.baseUrl // $loop.sprite.serviceBaseUrl // "") as $base_url
+                    | if ($base_url | is_non_empty_string) then []
+                      else [loop_error($i; "sprite_service loops require service.baseUrl or sprite.serviceBaseUrl")]
+                      end
+                  end
+              )
+            + (
+                if (($loop.metadata // null) == null or ($loop.metadata | type) == "object") then []
+                else [loop_error($i; "metadata must be an object when present")]
+                end
+              )
+          ] | add
+        )
+    end
+  )
+  + (
+    if ((.policy // null) == null or (.policy | type) == "object") then []
+    else ["policy must be an object when present"]
+    end
+  )
+  + (
+    if ((.policy.mode // "advisory") == "advisory") then []
+    else ["policy.mode must be \"advisory\" in phase 8 baseline"]
+    end
+  )
+  + (
+    if ((.policy.suppressions // {}) | type) != "object" then
+      ["policy.suppressions must be an object mapping loopId to category arrays"]
+    else
+      [ (.policy.suppressions // {}) | to_entries[]?
+        | if (.value | type) != "array" then
+            "policy.suppressions.\(.key) must be an array"
+          elif ([.value[] | type] | all(. == "string")) then
+            empty
+          else
+            "policy.suppressions.\(.key) entries must be strings"
+          end
+      ]
+    end
+  )
+  | .[]
+' <<<"$registry_raw")
+
+if [[ -n "$validation_errors" ]]; then
+  printf 'error: invalid fleet registry: %s\n' "$registry_file" >&2
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    printf ' - %s\n' "$line" >&2
+  done <<<"$validation_errors"
+  exit 1
+fi
+
+normalized_json=$(jq -cn \
+  --arg source_file "$registry_file" \
+  --argjson registry "$registry_raw" \
+  --arg loop_filter "$loop_id" \
+  '
+  ($registry.loops // []) as $raw_loops
+  | {
+      schemaVersion: "v1",
+      sourceFile: $source_file,
+      fleetId: ($registry.fleetId // "default"),
+      loops: (
+        $raw_loops
+        | map({
+            loopId: .loopId,
+            enabled: (.enabled // true),
+            transport: (.transport // "local"),
+            sprite: ({
+              id: (.sprite.id // null),
+              assignment: (.sprite.assignment // null),
+              serviceBaseUrl: (.sprite.serviceBaseUrl // .service.baseUrl // null)
+            } | with_entries(select(.value != null))),
+            service: ({
+              baseUrl: (.service.baseUrl // .sprite.serviceBaseUrl // null),
+              tokenEnv: (.service.tokenEnv // null),
+              retryAttempts: (.service.retryAttempts // 3),
+              retryBackoffSeconds: (.service.retryBackoffSeconds // 1)
+            } | with_entries(select(.value != null))),
+            metadata: (.metadata // {})
+          })
+        | if ($loop_filter | length) > 0 then map(select(.loopId == $loop_filter)) else . end
+      ),
+      policy: {
+        mode: ($registry.policy.mode // "advisory"),
+        suppressions: ($registry.policy.suppressions // {})
+      }
+    }
+  | .loopCount = (.loops | length)
+  | if ($loop_filter | length) > 0 and .loopCount == 0 then
+      error("loop not found in registry: " + $loop_filter)
+    else
+      .
+    end
+  ')
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$normalized_json"
+else
+  jq -c '.' <<<"$normalized_json"
+fi

--- a/scripts/ops-manager-fleet-status.sh
+++ b/scripts/ops-manager-fleet-status.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-fleet-status.sh --repo <path> [options]
+
+Options:
+  --registry-file <path>         Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --fleet-state-file <path>      Fleet state JSON path. Default: <repo>/.superloop/ops-manager/fleet/state.json
+  --policy-state-file <path>     Fleet policy state JSON path. Default: <repo>/.superloop/ops-manager/fleet/policy-state.json
+  --fleet-telemetry-file <path>  Fleet reconcile telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl
+  --pretty                       Pretty-print output JSON.
+  --help                         Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+repo=""
+registry_file=""
+fleet_state_file=""
+policy_state_file=""
+fleet_telemetry_file=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --registry-file)
+      registry_file="${2:-}"
+      shift 2
+      ;;
+    --fleet-state-file)
+      fleet_state_file="${2:-}"
+      shift 2
+      ;;
+    --policy-state-file)
+      policy_state_file="${2:-}"
+      shift 2
+      ;;
+    --fleet-telemetry-file)
+      fleet_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+registry_script="${OPS_MANAGER_FLEET_REGISTRY_SCRIPT:-$script_dir/ops-manager-fleet-registry.sh}"
+
+if [[ -z "$registry_file" ]]; then
+  registry_file="$repo/.superloop/ops-manager/fleet/registry.v1.json"
+fi
+if [[ -z "$fleet_state_file" ]]; then
+  fleet_state_file="$repo/.superloop/ops-manager/fleet/state.json"
+fi
+if [[ -z "$policy_state_file" ]]; then
+  policy_state_file="$repo/.superloop/ops-manager/fleet/policy-state.json"
+fi
+if [[ -z "$fleet_telemetry_file" ]]; then
+  fleet_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl"
+fi
+
+if [[ ! -f "$fleet_state_file" ]]; then
+  die "fleet state file not found: $fleet_state_file"
+fi
+
+registry_json=$("$registry_script" --repo "$repo" --registry-file "$registry_file")
+fleet_state_json=$(jq -c '.' "$fleet_state_file" 2>/dev/null) || die "invalid fleet state JSON: $fleet_state_file"
+
+policy_state_json='null'
+if [[ -f "$policy_state_file" ]]; then
+  policy_state_json=$(jq -c '.' "$policy_state_file" 2>/dev/null) || die "invalid policy state JSON: $policy_state_file"
+fi
+
+latest_fleet_telemetry='null'
+if [[ -f "$fleet_telemetry_file" ]]; then
+  if line=$(tail -n 1 "$fleet_telemetry_file" 2>/dev/null); then
+    if [[ -n "$line" ]]; then
+      latest_fleet_telemetry=$(jq -c '.' <<<"$line" 2>/dev/null || echo 'null')
+    fi
+  fi
+fi
+
+status_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg generated_at "$(timestamp)" \
+  --arg repo_path "$repo" \
+  --arg registry_file "$registry_file" \
+  --arg fleet_state_file "$fleet_state_file" \
+  --arg policy_state_file "$policy_state_file" \
+  --arg fleet_telemetry_file "$fleet_telemetry_file" \
+  --argjson registry "$registry_json" \
+  --argjson fleet "$fleet_state_json" \
+  --argjson policy "$policy_state_json" \
+  --argjson last_telemetry "$latest_fleet_telemetry" \
+  '
+  ($fleet.results // []) as $results
+  | {
+      schemaVersion: $schema_version,
+      generatedAt: $generated_at,
+      source: {
+        repoPath: $repo_path,
+        fleetId: ($fleet.fleetId // $registry.fleetId // "default")
+      },
+      fleet: {
+        status: ($fleet.status // "unknown"),
+        reasonCodes: ($fleet.reasonCodes // []),
+        loopCount: ($fleet.loopCount // ($results | length)),
+        successCount: ($fleet.successCount // ([ $results[] | select(.status == "success") ] | length)),
+        failedCount: ($fleet.failedCount // ([ $results[] | select(.status == "failed") ] | length)),
+        skippedCount: ($fleet.skippedCount // ([ $results[] | select(.status == "skipped") ] | length)),
+        startedAt: ($fleet.startedAt // null),
+        updatedAt: ($fleet.updatedAt // null),
+        durationSeconds: ($fleet.durationSeconds // null),
+        traceId: ($fleet.traceId // null),
+        partialFailure: (
+          (($fleet.failedCount // 0) > 0) and (($fleet.successCount // 0) > 0)
+        )
+      },
+      healthRollup: {
+        healthy: ([ $results[] | select((.healthStatus // "unknown") == "healthy") ] | length),
+        degraded: ([ $results[] | select((.healthStatus // "unknown") == "degraded") ] | length),
+        critical: ([ $results[] | select((.healthStatus // "unknown") == "critical") ] | length),
+        unknown: ([ $results[] | select((.healthStatus // "unknown") == "unknown") ] | length)
+      },
+      exceptions: {
+        reconcileFailures: ([ $results[] | select(.status == "failed") | .loopId ] | unique),
+        criticalLoops: ([ $results[] | select(.healthStatus == "critical") | .loopId ] | unique),
+        degradedLoops: ([ $results[] | select(.healthStatus == "degraded") | .loopId ] | unique),
+        skippedLoops: ([ $results[] | select(.status == "skipped") | .loopId ] | unique)
+      },
+      policy: (
+        if $policy == null then null
+        else {
+          mode: ($policy.mode // "advisory"),
+          candidateCount: ($policy.candidateCount // 0),
+          unsuppressedCount: ($policy.unsuppressedCount // 0),
+          suppressedCount: ($policy.suppressedCount // 0),
+          reasonCodes: ($policy.reasonCodes // []),
+          topCandidates: (
+            ($policy.candidates // [])
+            | sort_by(
+                if .severity == "critical" then 0
+                elif .severity == "warning" then 1
+                else 2
+                end
+              )
+            | .[0:5]
+          ),
+          traceId: ($policy.traceId // null),
+          updatedAt: ($policy.updatedAt // null)
+        } | with_entries(select(.value != null))
+        end
+      ),
+      loops: (
+        $results
+        | map({
+            loopId: .loopId,
+            status: (.status // "unknown"),
+            reasonCode: (.reasonCode // null),
+            reconcileStatus: (.reconcileStatus // null),
+            healthStatus: (.healthStatus // "unknown"),
+            healthReasonCodes: (.healthReasonCodes // []),
+            transitionState: (.transitionState // null),
+            durationSeconds: (.durationSeconds // null),
+            traceId: (.traceId // null),
+            transport: (.transport // "local"),
+            sprite: (.sprite // {}),
+            artifacts: {
+              stateFile: (.files.stateFile // null),
+              healthFile: (.files.healthFile // null),
+              cursorFile: (.files.cursorFile // null),
+              reconcileTelemetryFile: (.files.reconcileTelemetryFile // null)
+            }
+          } | with_entries(select(.value != null)))
+      ),
+      traceLinkage: {
+        fleetTraceId: ($fleet.traceId // null),
+        policyTraceId: ($policy.traceId // null),
+        loopTraceIds: ([ $results[] | .traceId // empty ] | unique),
+        sharedTraceId: (
+          [ $results[] | .traceId // empty ]
+          | unique as $ids
+          | if ($ids | length) == 1 and ($ids[0] // "") != "" and (($fleet.traceId // "") == "" or $ids[0] == ($fleet.traceId // "")) then
+              $ids[0]
+            else
+              null
+            end
+        )
+      },
+      latestTelemetry: (
+        if $last_telemetry == null then null
+        else {
+          timestamp: ($last_telemetry.timestamp // null),
+          status: ($last_telemetry.status // null),
+          reasonCodes: ($last_telemetry.reasonCodes // [])
+        } | with_entries(select(.value != null))
+        end
+      ),
+      files: {
+        registryFile: $registry_file,
+        fleetStateFile: $fleet_state_file,
+        policyStateFile: $policy_state_file,
+        fleetTelemetryFile: $fleet_telemetry_file
+      }
+    }
+  | .fleet.reasonCodes = (
+      (
+        .fleet.reasonCodes
+        + (if .fleet.failedCount > 0 and .fleet.successCount > 0 then ["fleet_partial_failure"] else [] end)
+        + (if .healthRollup.critical > 0 then ["fleet_health_critical"]
+           elif .healthRollup.degraded > 0 then ["fleet_health_degraded"]
+           else [] end)
+      )
+      | unique
+    )
+  ')
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$status_json"
+else
+  jq -c '.' <<<"$status_json"
+fi

--- a/tests/ops-manager-fleet.bats
+++ b/tests/ops-manager-fleet.bats
@@ -1,0 +1,288 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  SERVICE_PID=""
+  SERVICE_PORT=""
+  SERVICE_URL=""
+  SERVICE_TOKEN="fleet-test-token"
+}
+
+teardown() {
+  if [[ -n "$SERVICE_PID" ]] && kill -0 "$SERVICE_PID" 2>/dev/null; then
+    kill "$SERVICE_PID" 2>/dev/null || true
+    wait "$SERVICE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TEMP_DIR"
+}
+
+get_free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+write_runtime_artifacts() {
+  local repo="$1"
+  local loop_id="$2"
+  local event_ts="$3"
+
+  mkdir -p "$repo/.superloop/loops/$loop_id"
+
+  cat > "$repo/.superloop/state.json" <<JSON
+{"active":true,"loop_index":0,"iteration":2,"current_loop_id":"$loop_id","updated_at":"$event_ts"}
+JSON
+
+  cat > "$repo/.superloop/loops/$loop_id/run-summary.json" <<JSON
+{"version":1,"loop_id":"$loop_id","updated_at":"$event_ts","entries":[{"run_id":"run-$loop_id","iteration":1,"gates":{"tests":"ok","validation":"ok","prerequisites":"ok","checklist":"ok","evidence":"skipped","approval":"none"},"stuck":{"streak":0,"threshold":3},"completion_ok":false,"ended_at":"$event_ts"}]}
+JSON
+
+  cat > "$repo/.superloop/loops/$loop_id/events.jsonl" <<JSONL
+{"timestamp":"$event_ts","event":"loop_start","loop_id":"$loop_id","run_id":"run-$loop_id","iteration":1,"data":{"max_iterations":5}}
+{"timestamp":"$event_ts","event":"iteration_start","loop_id":"$loop_id","run_id":"run-$loop_id","iteration":2,"data":{"started_at":"$event_ts"}}
+JSONL
+}
+
+start_service() {
+  local repo="$1"
+  local token="$2"
+
+  SERVICE_PORT="$(get_free_port)"
+  SERVICE_URL="http://127.0.0.1:$SERVICE_PORT"
+
+  OPS_MANAGER_SERVICE_TOKEN="$token" \
+    "$PROJECT_ROOT/scripts/ops-manager-sprite-service.py" \
+    --repo "$repo" --host 127.0.0.1 --port "$SERVICE_PORT" --token "$token" \
+    >"$TEMP_DIR/service.log" 2>&1 &
+
+  SERVICE_PID=$!
+
+  local ready=0
+  for _ in $(seq 1 60); do
+    if curl -sS -H "X-Ops-Token: $token" "$SERVICE_URL/healthz" >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    sleep 0.1
+  done
+
+  [ "$ready" -eq 1 ]
+}
+
+@test "fleet registry fails closed when sprite_service loop omits service base URL" {
+  local repo="$TEMP_DIR/registry-invalid"
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<'JSON'
+{"schemaVersion":"v1","fleetId":"demo","loops":[{"loopId":"loop-a","transport":"sprite_service"}]}
+JSON
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-registry.sh" --repo "$repo"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sprite_service loops require service.baseUrl or sprite.serviceBaseUrl"* ]]
+}
+
+@test "fleet reconcile captures partial failure with deterministic ordering and trace linkage" {
+  local repo="$TEMP_DIR/fleet-partial"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  write_runtime_artifacts "$repo" "loop-b" "$now_ts"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<'JSON'
+{"schemaVersion":"v1","fleetId":"fleet-partial","loops":[{"loopId":"loop-b","transport":"local"},{"loopId":"loop-a","transport":"local"}]}
+JSON
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-reconcile.sh" \
+    --repo "$repo" \
+    --deterministic-order \
+    --max-parallel 2 \
+    --trace-id "trace-fleet-partial-1"
+  [ "$status" -eq 0 ]
+  local fleet_json="$output"
+
+  run jq -r '.status' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "partial_failure" ]
+
+  run jq -r '.results | map(.loopId) | join(",")' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop-a,loop-b" ]
+
+  run jq -r '.failedCount' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.successCount' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -e '.reasonCodes | index("fleet_partial_failure") != null' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.results[] | select(.loopId == "loop-a") | .status' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "failed" ]
+
+  run jq -r '.results[] | select(.loopId == "loop-a") | .reasonCode' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [[ -n "$output" && "$output" != "null" ]]
+
+  local telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl"
+  [ -f "$telemetry_file" ]
+
+  run bash -lc "tail -n 1 '$telemetry_file' | jq -r '.traceId'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-fleet-partial-1" ]
+}
+
+@test "fleet reconcile deterministic replay keeps stable loop ordering across runs" {
+  local repo="$TEMP_DIR/fleet-deterministic"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  write_runtime_artifacts "$repo" "loop-c" "$now_ts"
+  write_runtime_artifacts "$repo" "loop-a" "$now_ts"
+  write_runtime_artifacts "$repo" "loop-b" "$now_ts"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<'JSON'
+{"schemaVersion":"v1","fleetId":"fleet-deterministic","loops":[{"loopId":"loop-c"},{"loopId":"loop-a"},{"loopId":"loop-b"}]}
+JSON
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-reconcile.sh" \
+    --repo "$repo" \
+    --deterministic-order \
+    --max-parallel 3 \
+    --trace-id "trace-fleet-order-1"
+  [ "$status" -eq 0 ]
+  local first_run="$output"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-reconcile.sh" \
+    --repo "$repo" \
+    --deterministic-order \
+    --max-parallel 3 \
+    --trace-id "trace-fleet-order-2"
+  [ "$status" -eq 0 ]
+  local second_run="$output"
+
+  run jq -r '.results | map(.loopId) | join(",")' <<<"$first_run"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop-a,loop-b,loop-c" ]
+
+  run jq -r '.results | map(.loopId) | join(",")' <<<"$second_run"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop-a,loop-b,loop-c" ]
+}
+
+@test "fleet reconcile preserves parity across local and sprite_service transports" {
+  local repo="$TEMP_DIR/fleet-parity"
+  local now_ts
+  now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  write_runtime_artifacts "$repo" "loop-local" "$now_ts"
+  write_runtime_artifacts "$repo" "loop-service" "$now_ts"
+  start_service "$repo" "$SERVICE_TOKEN"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<JSON
+{"schemaVersion":"v1","fleetId":"fleet-parity","loops":[{"loopId":"loop-local","transport":"local"},{"loopId":"loop-service","transport":"sprite_service","service":{"baseUrl":"$SERVICE_URL","tokenEnv":"OPS_MANAGER_TEST_SERVICE_TOKEN"}}]}
+JSON
+
+  run env OPS_MANAGER_TEST_SERVICE_TOKEN="$SERVICE_TOKEN" \
+    "$PROJECT_ROOT/scripts/ops-manager-fleet-reconcile.sh" \
+    --repo "$repo" \
+    --deterministic-order \
+    --max-parallel 2 \
+    --trace-id "trace-fleet-parity-1"
+  [ "$status" -eq 0 ]
+  local fleet_json="$output"
+
+  run jq -r '.status' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "success" ]
+
+  run jq -r '.successCount' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run jq -r '.failedCount' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+
+  run jq -r '.results | map(.transport) | sort | join(",")' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "local,sprite_service" ]
+
+  run jq -r '.results[] | select(.loopId == "loop-service") | .status' <<<"$fleet_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "success" ]
+}
+
+@test "fleet policy and status project suppressions, exception buckets, and advisory actions" {
+  local repo="$TEMP_DIR/fleet-policy"
+  mkdir -p "$repo/.superloop/ops-manager/fleet/telemetry"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<'JSON'
+{"schemaVersion":"v1","fleetId":"fleet-policy","loops":[{"loopId":"loop-red"},{"loopId":"loop-blue"}],"policy":{"mode":"advisory","suppressions":{"loop-red":["reconcile_failed"],"*":["health_degraded"]}}}
+JSON
+
+  cat > "$repo/.superloop/ops-manager/fleet/state.json" <<'JSON'
+{"schemaVersion":"v1","updatedAt":"2026-02-22T18:00:00Z","startedAt":"2026-02-22T17:59:40Z","fleetId":"fleet-policy","traceId":"trace-fleet-policy-1","status":"partial_failure","reasonCodes":["fleet_partial_failure","fleet_health_critical"],"loopCount":2,"successCount":1,"failedCount":1,"skippedCount":0,"durationSeconds":20,"execution":{"maxParallel":2,"deterministicOrder":true,"fromStart":false,"maxEvents":0},"results":[{"timestamp":"2026-02-22T18:00:00Z","startedAt":"2026-02-22T17:59:45Z","loopId":"loop-red","transport":"local","enabled":true,"status":"failed","reasonCode":"reconcile_failed","reconcileStatus":"failed","healthStatus":"critical","healthReasonCodes":["transport_unreachable"],"durationSeconds":5,"traceId":"trace-fleet-policy-1-loop-red","files":{"stateFile":"/tmp/loop-red/state.json","healthFile":"/tmp/loop-red/health.json","cursorFile":"/tmp/loop-red/cursor.json","reconcileTelemetryFile":"/tmp/loop-red/reconcile.jsonl"}},{"timestamp":"2026-02-22T18:00:00Z","startedAt":"2026-02-22T17:59:50Z","loopId":"loop-blue","transport":"local","enabled":true,"status":"success","reconcileStatus":"success","healthStatus":"degraded","healthReasonCodes":["ingest_stale"],"durationSeconds":4,"traceId":"trace-fleet-policy-1-loop-blue","files":{"stateFile":"/tmp/loop-blue/state.json","healthFile":"/tmp/loop-blue/health.json","cursorFile":"/tmp/loop-blue/cursor.json","reconcileTelemetryFile":"/tmp/loop-blue/reconcile.jsonl"}}]}
+JSON
+
+  cat > "$repo/.superloop/ops-manager/fleet/telemetry/reconcile.jsonl" <<'JSONL'
+{"timestamp":"2026-02-22T18:00:00Z","category":"fleet_reconcile","fleetId":"fleet-policy","traceId":"trace-fleet-policy-1","status":"partial_failure","reasonCodes":["fleet_partial_failure","fleet_health_critical"]}
+JSONL
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-policy.sh" \
+    --repo "$repo" \
+    --trace-id "trace-fleet-policy-1"
+  [ "$status" -eq 0 ]
+  local policy_json="$output"
+
+  run jq -r '.candidateCount' <<<"$policy_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+
+  run jq -r '.unsuppressedCount' <<<"$policy_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.suppressedCount' <<<"$policy_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run jq -e '.reasonCodes | index("fleet_action_required") != null' <<<"$policy_json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '.reasonCodes | index("fleet_actions_suppressed") != null' <<<"$policy_json"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-fleet-status.sh" --repo "$repo"
+  [ "$status" -eq 0 ]
+  local status_json="$output"
+
+  run jq -r '.policy.unsuppressedCount' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.exceptions.reconcileFailures | join(",")' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop-red" ]
+
+  run jq -r '.fleet.partialFailure' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.loops[] | select(.loopId == "loop-red") | .artifacts.stateFile' <<<"$status_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/loop-red/state.json" ]
+}


### PR DESCRIPTION
## Summary
- add Phase 8 fleet registry contract and schema for loop-run fleet membership, transport metadata, and advisory suppression metadata
- add fleet reconcile fan-out command with bounded concurrency, deterministic ordering option, fleet state output, and fleet telemetry output
- add advisory fleet policy evaluator and fleet status projection with exception buckets and trace-linked loop drill-down surfaces
- add fleet Bats coverage for registry fail-closed behavior, partial-failure rollups, replay determinism, transport parity, and policy/status outputs
- update ops manager contract/runbook docs and mark Phase 8 Phase 1 checklist complete

## Validation
- `bash -n scripts/ops-manager-fleet-registry.sh scripts/ops-manager-fleet-reconcile.sh scripts/ops-manager-fleet-policy.sh scripts/ops-manager-fleet-status.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`

Closes #70
