### PR TITLE
feat(ops-manager): harden fleet policy suppressions and dedupe

### DIFF
--- a/docs/ops-manager-runbook.md
+++ b/docs/ops-manager-runbook.md
@@ -30,6 +30,7 @@ Operational procedures for manager core behavior across local and sprite-service
 - fleet policy state: `.superloop/ops-manager/fleet/policy-state.json`
 - fleet reconcile telemetry: `.superloop/ops-manager/fleet/telemetry/reconcile.jsonl`
 - fleet policy telemetry: `.superloop/ops-manager/fleet/telemetry/policy.jsonl`
+- fleet policy history: `.superloop/ops-manager/fleet/telemetry/policy-history.jsonl`
 - threshold profiles: `config/ops-manager-threshold-profiles.v1.json`
 - alert sinks config: `config/ops-manager-alert-sinks.v1.json`
 - runtime events: `.superloop/loops/<loop>/events.jsonl`
@@ -76,6 +77,11 @@ scripts/ops-manager-fleet-reconcile.sh \
 scripts/ops-manager-fleet-policy.sh --repo /path/to/repo --pretty
 ```
 
+Optional noise-control override:
+```bash
+scripts/ops-manager-fleet-policy.sh --repo /path/to/repo --dedupe-window-seconds 300 --pretty
+```
+
 4. Read operator fleet surface:
 ```bash
 scripts/ops-manager-fleet-status.sh --repo /path/to/repo --pretty
@@ -85,6 +91,8 @@ Expected fleet outputs:
 - fleet rollup status + reason codes (`success|partial_failure|failed`)
 - per-loop exception buckets (`reconcileFailures`, `criticalLoops`, `degradedLoops`, `skippedLoops`)
 - advisory candidate summary with suppression counts
+- suppression precedence (`loop` over global `*`) and suppression source details
+- advisory cooldown suppression behavior (`advisory_cooldown_active`) for repeated candidates
 - trace-linked pointers to loop-level state/health/cursor/telemetry artifacts
 
 ## Fleet Partial-Failure Triage

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -267,13 +267,15 @@ Purpose:
 scripts/ops-manager-fleet-policy.sh \
   --repo /path/to/repo \
   --trace-id fleet-trace-001 \
+  --dedupe-window-seconds 300 \
   --pretty
 ```
 
 Purpose:
 - Evaluates fleet reconcile output and emits advisory candidates only.
 - Produces reason-coded candidates for `reconcile_failed`, `health_critical`, and `health_degraded`.
-- Applies registry suppression metadata and records suppressed vs unsuppressed actions.
+- Applies suppression precedence (`loop` over global `*`) and records suppression scope/source.
+- Supports advisory cooldown dedupe using policy history (no automatic control execution).
 
 ### Fleet Status
 ```bash
@@ -328,6 +330,7 @@ Transport mode switch:
 - `.superloop/ops-manager/fleet/policy-state.json` - latest advisory policy candidates + suppression state.
 - `.superloop/ops-manager/fleet/telemetry/reconcile.jsonl` - fleet reconcile attempt history.
 - `.superloop/ops-manager/fleet/telemetry/policy.jsonl` - fleet policy evaluation history.
+- `.superloop/ops-manager/fleet/telemetry/policy-history.jsonl` - fleet policy candidate suppression/dedupe history.
 - `config/ops-manager-threshold-profiles.v1.json` - threshold profile catalog (repo-level, versioned).
 - `config/ops-manager-alert-sinks.v1.json` - alert sink routing/catalog config (repo-level, versioned).
 - `schema/ops-manager-alert-sinks.config.schema.json` - JSON schema reference for alert sink config.
@@ -354,6 +357,8 @@ Fleet state/policy/status artifacts may include:
 - `fleet_loop_skipped`
 - `fleet_action_required`
 - `fleet_actions_suppressed`
+- `fleet_actions_policy_suppressed`
+- `fleet_actions_deduped`
 
 ## Alert Dispatch Reason Codes
 Current alert dispatch telemetry/state may include:

--- a/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_2.MD
@@ -6,9 +6,9 @@
 3. [x] Link this phase packet from the issue and include prior PR/issue context (`#73`, `#70`).
 
 ## P2.1 Fleet Policy Hardening
-1. [ ] Harden advisory candidate taxonomy and severity/confidence normalization for fleet policy output.
-2. [ ] Enforce suppression precedence and validation semantics (`loopId`-specific over global `*`, unknown categories fail closed).
-3. [ ] Add advisory-noise controls (dedupe/cooldown windows) without introducing automatic control execution.
+1. [x] Harden advisory candidate taxonomy and severity/confidence normalization for fleet policy output.
+2. [x] Enforce suppression precedence and validation semantics (`loopId`-specific over global `*`, unknown categories fail closed).
+3. [x] Add advisory-noise controls (dedupe/cooldown windows) without introducing automatic control execution.
 
 ## P2.2 Fleet Operator Control Handoff
 1. [ ] Add a fleet handoff artifact that maps unsuppressed policy candidates into explicit per-loop control intents.
@@ -26,11 +26,11 @@
 3. [ ] Harden failure classification behavior to keep fleet status semantics deterministic across transports.
 
 ## P2.5 Test Coverage
-1. [ ] Extend `tests/ops-manager-fleet.bats` for policy hardening and operator handoff flows.
+1. [x] Extend `tests/ops-manager-fleet.bats` for policy hardening and operator handoff flows.
 2. [ ] Add/extend transport parity regressions across `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` where relevant.
-3. [ ] Add regression tests for suppression precedence and advisory-noise controls.
+3. [x] Add regression tests for suppression precedence and advisory-noise controls.
 
 ## P2.V Validation
-1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
-2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
 3. [ ] Updated docs/runbook match implemented fleet policy/handoff/parity artifacts and operator workflow.

--- a/schema/ops-manager-fleet.registry.schema.json
+++ b/schema/ops-manager-fleet.registry.schema.json
@@ -66,7 +66,22 @@
           "additionalProperties": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "reconcile_failed",
+                "health_critical",
+                "health_degraded"
+              ]
+            }
+          }
+        },
+        "noiseControls": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dedupeWindowSeconds": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         }

--- a/scripts/ops-manager-fleet-policy.sh
+++ b/scripts/ops-manager-fleet-policy.sh
@@ -7,13 +7,15 @@ Usage:
   scripts/ops-manager-fleet-policy.sh --repo <path> [options]
 
 Options:
-  --registry-file <path>        Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
-  --fleet-state-file <path>     Fleet state JSON path. Default: <repo>/.superloop/ops-manager/fleet/state.json
-  --policy-state-file <path>    Policy state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/policy-state.json
+  --registry-file <path>         Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --fleet-state-file <path>      Fleet state JSON path. Default: <repo>/.superloop/ops-manager/fleet/state.json
+  --policy-state-file <path>     Policy state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/policy-state.json
   --policy-telemetry-file <path> Policy telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/policy.jsonl
-  --trace-id <id>               Policy trace id override. Default: fleet state trace id or generated.
-  --pretty                      Pretty-print output JSON.
-  --help                        Show this help message.
+  --policy-history-file <path>   Candidate history JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/policy-history.jsonl
+  --dedupe-window-seconds <n>    Advisory cooldown window for duplicate candidates. Default: registry policy.noiseControls.dedupeWindowSeconds (or 300)
+  --trace-id <id>                Policy trace id override. Default: fleet state trace id or generated.
+  --pretty                       Pretty-print output JSON.
+  --help                         Show this help message.
 USAGE
 }
 
@@ -54,8 +56,11 @@ registry_file=""
 fleet_state_file=""
 policy_state_file=""
 policy_telemetry_file=""
+policy_history_file=""
+dedupe_window_seconds=""
 trace_id=""
 pretty="0"
+flag_dedupe_window_seconds="0"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -77,6 +82,15 @@ while [[ $# -gt 0 ]]; do
       ;;
     --policy-telemetry-file)
       policy_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --policy-history-file)
+      policy_history_file="${2:-}"
+      shift 2
+      ;;
+    --dedupe-window-seconds)
+      dedupe_window_seconds="${2:-}"
+      flag_dedupe_window_seconds="1"
       shift 2
       ;;
     --trace-id)
@@ -120,6 +134,9 @@ fi
 if [[ -z "$policy_telemetry_file" ]]; then
   policy_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/policy.jsonl"
 fi
+if [[ -z "$policy_history_file" ]]; then
+  policy_history_file="$repo/.superloop/ops-manager/fleet/telemetry/policy-history.jsonl"
+fi
 
 if [[ ! -f "$fleet_state_file" ]]; then
   die "fleet state file not found: $fleet_state_file"
@@ -138,78 +155,144 @@ if [[ -z "$trace_id" ]]; then
   trace_id="$(generate_trace_id)"
 fi
 
-mkdir -p "$(dirname "$policy_state_file")"
-mkdir -p "$(dirname "$policy_telemetry_file")"
-
 policy_mode="$(jq -r '.policy.mode // "advisory"' <<<"$registry_json")"
 if [[ "$policy_mode" != "advisory" ]]; then
   die "unsupported policy mode in phase 8 baseline: $policy_mode"
 fi
 
+if [[ "$flag_dedupe_window_seconds" != "1" ]]; then
+  dedupe_window_seconds="$(jq -r '.policy.noiseControls.dedupeWindowSeconds // 300' <<<"$registry_json")"
+fi
+if [[ ! "$dedupe_window_seconds" =~ ^[0-9]+$ ]]; then
+  die "--dedupe-window-seconds must be a non-negative integer"
+fi
+
+mkdir -p "$(dirname "$policy_state_file")"
+mkdir -p "$(dirname "$policy_telemetry_file")"
+mkdir -p "$(dirname "$policy_history_file")"
+
 suppressions_json="$(jq -c '.policy.suppressions // {}' <<<"$registry_json")"
+results_json="$(jq -c '.results // []' <<<"$fleet_state_json")"
+
+history_json='[]'
+if [[ -f "$policy_history_file" ]]; then
+  history_json=$(jq -cs '.' "$policy_history_file" 2>/dev/null) || die "invalid policy history JSONL: $policy_history_file"
+fi
+
+current_timestamp="$(timestamp)"
 
 candidates_json=$(jq -cn \
-  --argjson results "$(jq -c '.results // []' <<<"$fleet_state_json")" \
+  --argjson results "$results_json" \
   --argjson suppressions "$suppressions_json" \
+  --argjson history "$history_json" \
+  --argjson dedupe_window "$dedupe_window_seconds" \
+  --arg now "$current_timestamp" \
   '
-  def suppression_matches($loop_id; $category):
-    ((($suppressions[$loop_id] // []) + ($suppressions["*"] // [])) | index($category)) != null;
+  def category_profile($category):
+    if $category == "reconcile_failed" then
+      {severity: "critical", confidence: "high", rationale: "Loop reconcile failed in fleet fan-out"}
+    elif $category == "health_critical" then
+      {severity: "critical", confidence: "high", rationale: "Loop health is critical"}
+    elif $category == "health_degraded" then
+      {severity: "warning", confidence: "medium", rationale: "Loop health is degraded"}
+    else
+      error("unknown policy category: " + $category)
+    end;
 
-  [
-    $results[] as $r
-    | [
-        (if ($r.status // "") == "failed" then {
-          loopId: $r.loopId,
-          category: "reconcile_failed",
-          severity: "critical",
-          confidence: "high",
-          rationale: "Loop reconcile failed in fleet fan-out",
-          recommendedIntent: null,
-          traceId: ($r.traceId // null)
-        } else empty end),
-        (if ($r.healthStatus // "") == "critical" then {
-          loopId: $r.loopId,
-          category: "health_critical",
-          severity: "critical",
-          confidence: "high",
-          rationale: "Loop health is critical",
-          recommendedIntent: null,
-          traceId: ($r.traceId // null)
-        } else empty end),
-        (if ($r.healthStatus // "") == "degraded" then {
-          loopId: $r.loopId,
-          category: "health_degraded",
-          severity: "warning",
-          confidence: "medium",
-          rationale: "Loop health is degraded",
-          recommendedIntent: null,
-          traceId: ($r.traceId // null)
-        } else empty end)
-      ]
+  def suppression_scope($loop_id; $category):
+    if (($suppressions[$loop_id] // []) | index($category)) != null then "loop"
+    elif (($suppressions["*"] // []) | index($category)) != null then "global"
+    else null
+    end;
+
+  def last_unsuppressed_epoch($candidate_id):
+    ([ $history[]?
+       | select((.candidateId // "") == $candidate_id)
+       | select((.suppressed // false) == false)
+       | (.timestamp // empty)
+       | fromdateiso8601?
+     ] | max // null);
+
+  ($now | fromdateiso8601) as $now_epoch
+  | [
+      $results[] as $r
+      | [
+          (if ($r.status // "") == "failed" then {
+            loopId: $r.loopId,
+            category: "reconcile_failed",
+            signal: "status_failed",
+            traceId: ($r.traceId // null)
+          } else empty end),
+          (if ($r.healthStatus // "") == "critical" then {
+            loopId: $r.loopId,
+            category: "health_critical",
+            signal: "health_critical",
+            traceId: ($r.traceId // null)
+          } else empty end),
+          (if ($r.healthStatus // "") == "degraded" then {
+            loopId: $r.loopId,
+            category: "health_degraded",
+            signal: "health_degraded",
+            traceId: ($r.traceId // null)
+          } else empty end)
+        ]
       | .[]
-      | . as $candidate
-      | . + {
-          suppressed: suppression_matches($candidate.loopId; $candidate.category),
-          suppressionReason: (
-            if suppression_matches($candidate.loopId; $candidate.category) then
-              "registry_policy_suppression"
-            else
-              null
-            end
-          )
-        }
-  ]
+      | .candidateId = (.loopId + ":" + .category)
+      | . + category_profile(.category)
+      | .taxonomyVersion = "v1"
+      | .recommendedIntent = null
+      | .suppressionScope = suppression_scope(.loopId; .category)
+      | .suppressed = (.suppressionScope != null)
+      | .suppressionReason = (if .suppressionScope == null then null else "registry_policy_suppression" end)
+      | .suppressionSource = (
+          if .suppressionScope == "loop" then "policy.suppressions.<loopId>"
+          elif .suppressionScope == "global" then "policy.suppressions.*"
+          else null
+          end
+        )
+      | .cooldown = (
+          if $dedupe_window <= 0 then {
+            enabled: false,
+            windowSeconds: $dedupe_window,
+            active: false,
+            remainingSeconds: 0,
+            lastUnsuppressedAt: null
+          } else
+            (last_unsuppressed_epoch(.candidateId)) as $last_epoch
+            | (if $last_epoch == null then null else ($now_epoch - $last_epoch) end) as $age
+            | {
+                enabled: true,
+                windowSeconds: $dedupe_window,
+                active: ($last_epoch != null and $age < $dedupe_window),
+                remainingSeconds: (if $last_epoch != null and $age < $dedupe_window then ($dedupe_window - $age) else 0 end),
+                lastUnsuppressedAt: (if $last_epoch == null then null else ($last_epoch | todateiso8601) end)
+              }
+          end
+        )
+      | if (.suppressed == false and (.cooldown.active // false)) then
+          .suppressed = true
+          | .suppressionScope = "cooldown"
+          | .suppressionReason = "advisory_cooldown_active"
+          | .suppressionSource = "policy.noiseControls.dedupeWindowSeconds"
+        else
+          .
+        end
+    ]
+  | sort_by(.loopId, .category)
+  | unique_by(.candidateId)
   ')
 
 policy_state_json=$(jq -cn \
   --arg schema_version "v1" \
-  --arg updated_at "$(timestamp)" \
+  --arg updated_at "$current_timestamp" \
   --arg fleet_id "$(jq -r '.fleetId // "default"' <<<"$fleet_state_json")" \
   --arg trace_id "$trace_id" \
   --arg mode "$policy_mode" \
   --arg fleet_status "$(jq -r '.status // "unknown"' <<<"$fleet_state_json")" \
   --arg fleet_state_file "$fleet_state_file" \
   --arg registry_file "$registry_file" \
+  --arg policy_history_file "$policy_history_file" \
+  --argjson dedupe_window "$dedupe_window_seconds" \
   --argjson evaluated_loop_count "$(jq -r '.results | length' <<<"$fleet_state_json")" \
   --argjson candidates "$candidates_json" \
   --argjson suppressions "$suppressions_json" \
@@ -225,10 +308,23 @@ policy_state_json=$(jq -cn \
       fleetStateFile: $fleet_state_file,
       registryFile: $registry_file
     },
+    taxonomy: {
+      version: "v1",
+      categories: [
+        {category: "reconcile_failed", severity: "critical", confidence: "high"},
+        {category: "health_critical", severity: "critical", confidence: "high"},
+        {category: "health_degraded", severity: "warning", confidence: "medium"}
+      ]
+    },
+    noiseControls: {
+      dedupeWindowSeconds: $dedupe_window,
+      policyHistoryFile: $policy_history_file
+    },
     evaluatedLoopCount: $evaluated_loop_count,
     candidateCount: ($candidates | length),
     unsuppressedCount: ([ $candidates[] | select((.suppressed // false) == false) ] | length),
     suppressedCount: ([ $candidates[] | select((.suppressed // false) == true) ] | length),
+    cooldownSuppressedCount: ([ $candidates[] | select((.suppressionReason // "") == "advisory_cooldown_active") ] | length),
     candidates: $candidates,
     summary: {
       bySeverity: {
@@ -236,18 +332,36 @@ policy_state_json=$(jq -cn \
         warning: ([ $candidates[] | select(.severity == "warning") ] | length),
         info: ([ $candidates[] | select(.severity == "info") ] | length)
       },
+      byConfidence: {
+        high: ([ $candidates[] | select(.confidence == "high") ] | length),
+        medium: ([ $candidates[] | select(.confidence == "medium") ] | length),
+        low: ([ $candidates[] | select(.confidence == "low") ] | length)
+      },
       byCategory: (
         reduce $candidates[] as $candidate ({}; .[$candidate.category] = ((.[$candidate.category] // 0) + 1))
+      ),
+      bySuppressionReason: (
+        reduce $candidates[] as $candidate ({};
+          if ($candidate.suppressionReason // null) == null then
+            .
+          else
+            .[$candidate.suppressionReason] = ((.[$candidate.suppressionReason] // 0) + 1)
+          end
+        )
       )
     },
     suppressionState: {
-      suppressions: $suppressions
+      suppressions: $suppressions,
+      precedence: ["loop", "global", "cooldown"],
+      allowedCategories: ["reconcile_failed", "health_critical", "health_degraded"]
     }
   }
   | .reasonCodes = (
       [
         (if .unsuppressedCount > 0 then "fleet_action_required" else "no_action_required" end),
-        (if .suppressedCount > 0 then "fleet_actions_suppressed" else empty end)
+        (if .suppressedCount > 0 then "fleet_actions_suppressed" else empty end),
+        (if .summary.bySuppressionReason.registry_policy_suppression // 0 > 0 then "fleet_actions_policy_suppressed" else empty end),
+        (if .summary.bySuppressionReason.advisory_cooldown_active // 0 > 0 then "fleet_actions_deduped" else empty end)
       ]
       | unique
     )
@@ -255,12 +369,43 @@ policy_state_json=$(jq -cn \
 
 jq -c '.' <<<"$policy_state_json" > "$policy_state_file"
 
-jq -cn \
-  --arg timestamp "$(timestamp)" \
+history_entries_json=$(jq -cn \
+  --arg timestamp "$current_timestamp" \
   --arg fleet_id "$(jq -r '.fleetId // "default"' <<<"$fleet_state_json")" \
   --arg trace_id "$trace_id" \
   --arg mode "$policy_mode" \
-  --argjson summary "$(jq -c '{candidateCount, unsuppressedCount, suppressedCount, reasonCodes, summary}' <<<"$policy_state_json")" \
+  --argjson candidates "$candidates_json" \
+  '
+  [
+    $candidates[]?
+    | {
+        timestamp: $timestamp,
+        category: "fleet_policy_candidate",
+        fleetId: $fleet_id,
+        traceId: $trace_id,
+        mode: $mode,
+        candidateId: .candidateId,
+        loopId: .loopId,
+        candidateCategory: .category,
+        severity: .severity,
+        confidence: .confidence,
+        suppressed: (.suppressed // false),
+        suppressionReason: (.suppressionReason // null),
+        suppressionScope: (.suppressionScope // null),
+        suppressionSource: (.suppressionSource // null)
+      }
+      | with_entries(select(.value != null))
+  ]
+  ')
+
+jq -c '.[]' <<<"$history_entries_json" >> "$policy_history_file"
+
+jq -cn \
+  --arg timestamp "$current_timestamp" \
+  --arg fleet_id "$(jq -r '.fleetId // "default"' <<<"$fleet_state_json")" \
+  --arg trace_id "$trace_id" \
+  --arg mode "$policy_mode" \
+  --argjson summary "$(jq -c '{candidateCount, unsuppressedCount, suppressedCount, cooldownSuppressedCount, reasonCodes, summary, noiseControls}' <<<"$policy_state_json")" \
   '{
     timestamp: $timestamp,
     category: "fleet_policy",


### PR DESCRIPTION
## Summary
- harden fleet policy candidate taxonomy with normalized category/severity/confidence metadata and deterministic candidate IDs
- enforce suppression semantics: declared loopId/* key validation, known-category validation, and explicit suppression precedence (`loop` > `global`)
- add advisory cooldown/dedupe controls with policy history tracking (`policy-history.jsonl`) and reason-coded outputs (`fleet_actions_policy_suppressed`, `fleet_actions_deduped`)
- extend fleet registry schema/normalization for policy noise controls and stricter suppression category constraints
- expand `tests/ops-manager-fleet.bats` with suppression validation and cooldown/precedence regression coverage
- update phase packet progress for completed P2.1 and related validation items

## Validation
- `bash -n scripts/ops-manager-fleet-registry.sh scripts/ops-manager-fleet-policy.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`

Refs #74
