### PR TITLE
feat(ops-manager): harden fleet transport parity semantics

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_2.MD
@@ -21,13 +21,13 @@
 3. [x] Document suppression governance workflow (add/remove suppression + audit trail expectations).
 
 ## P2.4 Local vs Sprite Service Parity Hardening
-1. [ ] Extend fleet parity coverage for mixed `local` and `sprite_service` loop sets under degraded/critical/failure conditions.
-2. [ ] Verify fleet rollup and reason-code parity across transports for equivalent runtime states.
-3. [ ] Harden failure classification behavior to keep fleet status semantics deterministic across transports.
+1. [x] Extend fleet parity coverage for mixed `local` and `sprite_service` loop sets under degraded/critical/failure conditions.
+2. [x] Verify fleet rollup and reason-code parity across transports for equivalent runtime states.
+3. [x] Harden failure classification behavior to keep fleet status semantics deterministic across transports.
 
 ## P2.5 Test Coverage
 1. [x] Extend `tests/ops-manager-fleet.bats` for policy hardening and operator handoff flows.
-2. [ ] Add/extend transport parity regressions across `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` where relevant.
+2. [x] Add/extend transport parity regressions across `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` where relevant.
 3. [x] Add regression tests for suppression precedence and advisory-noise controls.
 
 ## P2.V Validation


### PR DESCRIPTION
## Summary
- harden `scripts/ops-manager-fleet-reconcile.sh` failure classification to derive deterministic fleet `reasonCode` semantics from reconcile JSON health/transport outputs before stderr fallback
- normalize fallback invalid payload classification to `invalid_transport_payload`
- propagate health status/reason codes from failed reconcile outputs into fleet loop results for both local and `sprite_service` transports
- extend fleet parity coverage with mixed transport degraded/critical/failure scenarios
- add equivalent local vs service fleet rollup/reason-surface parity regression
- add transport parity failure regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats`
- mark P2.4 and P2.5.2 checklist items complete in `PHASE_2.MD`

## Validation
- `bash -n scripts/ops-manager-fleet-reconcile.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-service.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`
