### PR TITLE
feat(ops-manager): initiate phase-9 guarded autonomous remediation

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/PLAN.MD
@@ -1,0 +1,64 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 9 Guarded Autonomous Remediation)
+
+## Goal
+Enable optional, guardrailed autonomous fleet remediation that can execute a constrained subset of control intents safely while preserving deterministic state, auditability, and operator override.
+
+## Scope
+- Extend fleet policy contract to support `guarded_auto` mode while keeping `advisory` as default.
+- Introduce explicit auto-eligibility evaluation from policy candidates to execution intents.
+- Add safety controls for autonomous execution (allowlists, confidence/severity thresholds, action caps, cooldowns, kill switch).
+- Add autonomous execution telemetry/reason surfaces for fleet status and runbook triage.
+- Preserve behavior parity for `local` and `sprite_service` loop transports.
+
+## Non-Goals (this iteration)
+- Full autonomous execution across all control intents and categories.
+- Removal of existing explicit operator handoff workflows.
+- Multi-tenant authorization, billing, or organization-scoped control policy.
+- External orchestration services beyond existing file-first artifacts and scripts.
+
+## Primary References
+- `scripts/ops-manager-fleet-policy.sh` - fleet advisory candidate generation and suppression semantics.
+- `scripts/ops-manager-fleet-handoff.sh` - fleet intent mapping and control dispatch orchestration.
+- `scripts/ops-manager-control.sh` - loop-level control execution + confirmation behavior.
+- `scripts/ops-manager-fleet-status.sh` - operator fleet posture projection and reason surfaces.
+- `scripts/ops-manager-fleet-registry.sh` - fleet registry validation and policy contract normalization.
+- `docs/ops-manager-v0.md` - manager/runtime artifacts and reason-code contract.
+- `docs/ops-manager-runbook.md` - operator workflow and incident procedures.
+- `feat/ops-manager-superloop-sprites/phase-8-fleet-orchestration-initiation/tasks/PHASE_2.MD` - prior phase baseline and constraints.
+
+## Architecture
+Phase 9 adds an autonomous remediation layer on top of fleet advisory/handoff primitives:
+
+1. Eligibility plane:
+- Derive auto-executable intents from unsuppressed policy candidates using explicit allowlists, thresholds, and mode gates.
+
+2. Safety plane:
+- Enforce guardrails (caps, cooldowns, category restrictions, kill switch, deterministic fail behavior) before any control dispatch.
+
+3. Execution plane:
+- Execute only eligible intents through existing `ops-manager-control.sh` semantics with trace/idempotency propagation.
+
+4. Verification plane:
+- Persist execution outcomes and reason-coded fleet status surfaces so operators can audit, override, or fall back to manual handoff.
+
+## Decisions
+- Keep fleet `policy.mode=advisory` as default; autonomous execution is explicit opt-in.
+- Start with a constrained intent/category set (guarded subset) instead of broad automatic controls.
+- Preserve file-first append-only telemetry and deterministic reason-code outputs as release gates.
+- Keep operator override path first-class and available at all times.
+
+## Risks / Constraints
+- Misconfigured thresholds can over-trigger remediation and cause unnecessary loop cancellations.
+- Repeated auto-actions can create action churn without cooldown and cap enforcement.
+- Transport-specific error surfaces can diverge reason-code semantics if not validated for parity.
+- Autonomous execution increases governance expectations for audit trail completeness and operator rollback clarity.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Guarded auto-remediation contract, execution safety rails, autonomous dispatch, and operator surfaces.
+- **Phase 2**: Hardening and governance (advanced safety policies, rollout controls, and incident drill validation).

--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
@@ -1,0 +1,41 @@
+# Phase 1 - Guarded Autonomous Remediation Baseline
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/PLAN.MD` aligns with current repo state and phase-8 outcomes.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/80`).
+3. [x] Link this phase packet from the issue and include prior PR/issue context (`#79`, `#74`).
+
+## P1.1 Policy Mode and Contract Extension
+1. [ ] Extend fleet registry policy contract to support explicit autonomous remediation controls (`mode`, thresholds, caps, cooldowns, allowlists).
+2. [ ] Enforce fail-closed validation for unsupported auto categories/intents and invalid threshold/cap values.
+3. [ ] Update `docs/ops-manager-v0.md` contract notes for new policy fields and compatibility defaults.
+
+## P1.2 Auto-Eligibility Evaluation
+1. [ ] Extend fleet policy/handoff shaping to classify unsuppressed candidates as auto-eligible vs manual-only with explicit rejection reasons.
+2. [ ] Gate auto eligibility by category/intent allowlists plus severity/confidence thresholds.
+3. [ ] Persist auto-eligibility artifacts/telemetry so operators can audit why candidates were or were not auto-executed.
+
+## P1.3 Safety Rails and Circuit Breakers
+1. [ ] Enforce per-run and per-loop autonomous action caps before dispatch.
+2. [ ] Enforce cooldown windows to prevent repeated autonomous controls for the same loop/category.
+3. [ ] Add a global autonomous remediation kill switch that hard-disables auto dispatch without breaking advisory/manual flows.
+
+## P1.4 Autonomous Dispatch Workflow
+1. [ ] Add an autonomous execution path that dispatches only eligible intents via existing `ops-manager-control.sh` behavior.
+2. [ ] Preserve trace/idempotency propagation and deterministic execution status (`executed`, `ambiguous`, `failed`) across transports.
+3. [ ] Ensure autonomous dispatch failures are reason-coded and do not execute out-of-policy intents.
+
+## P1.5 Operator Visibility and Runbook
+1. [ ] Extend fleet status/reason surfaces for autonomous remediation outcomes and safety-gate decisions.
+2. [ ] Update `docs/ops-manager-runbook.md` with autonomous mode operating workflow, kill-switch usage, and fallback to explicit manual handoff.
+3. [ ] Document operator governance expectations for when autonomous mode should be enabled/disabled.
+
+## P1.6 Test Coverage
+1. [ ] Extend `tests/ops-manager-fleet.bats` for autonomous mode contract, eligibility gating, cap/cooldown rails, and kill-switch behavior.
+2. [ ] Add/extend transport parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for autonomous execution semantics.
+3. [ ] Add regressions for deterministic reason-code behavior under partial autonomous execution failures.
+
+## P1.V Validation
+1. [ ] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats` passes.
+2. [ ] All new/changed scripts pass `bash -n` syntax checks.
+3. [ ] Updated docs/runbook match implemented autonomous policy fields, execution semantics, and operator workflow.


### PR DESCRIPTION
## Summary
- add Phase 9 initiation blueprint for guarded autonomous fleet remediation
- add Phase 9 / Phase 1 task packet with scope, validation, and safety-focused execution plan
- link Phase 9 task authority to new tracking issue

## Files
- `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/PLAN.MD`
- `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD`

## Validation
- not run (initiation docs/tasks only)

Closes #80
