### PR TITLE
feat(ops-manager): extend fleet guarded_auto policy contract

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
@@ -6,9 +6,9 @@
 3. [x] Link this phase packet from the issue and include prior PR/issue context (`#79`, `#74`).
 
 ## P1.1 Policy Mode and Contract Extension
-1. [ ] Extend fleet registry policy contract to support explicit autonomous remediation controls (`mode`, thresholds, caps, cooldowns, allowlists).
-2. [ ] Enforce fail-closed validation for unsupported auto categories/intents and invalid threshold/cap values.
-3. [ ] Update `docs/ops-manager-v0.md` contract notes for new policy fields and compatibility defaults.
+1. [x] Extend fleet registry policy contract to support explicit autonomous remediation controls (`mode`, thresholds, caps, cooldowns, allowlists).
+2. [x] Enforce fail-closed validation for unsupported auto categories/intents and invalid threshold/cap values.
+3. [x] Update `docs/ops-manager-v0.md` contract notes for new policy fields and compatibility defaults.
 
 ## P1.2 Auto-Eligibility Evaluation
 1. [ ] Extend fleet policy/handoff shaping to classify unsuppressed candidates as auto-eligible vs manual-only with explicit rejection reasons.

--- a/schema/ops-manager-fleet.registry.schema.json
+++ b/schema/ops-manager-fleet.registry.schema.json
@@ -58,7 +58,8 @@
         "mode": {
           "type": "string",
           "enum": [
-            "advisory"
+            "advisory",
+            "guarded_auto"
           ]
         },
         "suppressions": {
@@ -82,6 +83,81 @@
             "dedupeWindowSeconds": {
               "type": "integer",
               "minimum": 0
+            }
+          }
+        },
+        "autonomous": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "reconcile_failed",
+                      "health_critical",
+                      "health_degraded"
+                    ]
+                  }
+                },
+                "intents": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "cancel"
+                    ]
+                  }
+                }
+              }
+            },
+            "thresholds": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minSeverity": {
+                  "type": "string",
+                  "enum": [
+                    "critical",
+                    "warning",
+                    "info"
+                  ]
+                },
+                "minConfidence": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "medium",
+                    "low"
+                  ]
+                }
+              }
+            },
+            "safety": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "maxActionsPerRun": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxActionsPerLoop": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "cooldownSeconds": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "killSwitch": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         }

--- a/scripts/ops-manager-fleet-handoff.sh
+++ b/scripts/ops-manager-fleet-handoff.sh
@@ -214,8 +214,8 @@ registry_json=$("$registry_script" --repo "$repo" --registry-file "$registry_fil
 policy_state_json=$(jq -c '.' "$policy_state_file" 2>/dev/null) || die "invalid policy state JSON: $policy_state_file"
 
 policy_mode="$(jq -r '.mode // "advisory"' <<<"$policy_state_json")"
-if [[ "$policy_mode" != "advisory" ]]; then
-  die "unsupported policy mode in phase 8 baseline: $policy_mode"
+if [[ "$policy_mode" != "advisory" && "$policy_mode" != "guarded_auto" ]]; then
+  die "unsupported policy mode: $policy_mode"
 fi
 
 if [[ -z "$trace_id" ]]; then

--- a/scripts/ops-manager-fleet-policy.sh
+++ b/scripts/ops-manager-fleet-policy.sh
@@ -156,8 +156,8 @@ if [[ -z "$trace_id" ]]; then
 fi
 
 policy_mode="$(jq -r '.policy.mode // "advisory"' <<<"$registry_json")"
-if [[ "$policy_mode" != "advisory" ]]; then
-  die "unsupported policy mode in phase 8 baseline: $policy_mode"
+if [[ "$policy_mode" != "advisory" && "$policy_mode" != "guarded_auto" ]]; then
+  die "unsupported policy mode: $policy_mode"
 fi
 
 if [[ "$flag_dedupe_window_seconds" != "1" ]]; then


### PR DESCRIPTION
## Summary
- extend fleet registry contract to support `policy.mode=guarded_auto` with explicit autonomous control fields
- enforce fail-closed validation for unsupported autonomous categories/intents and invalid threshold/safety values
- normalize autonomous policy defaults in registry output for downstream scripts
- allow fleet policy/handoff scripts to accept both `advisory` and `guarded_auto` modes
- update ops manager docs and phase task packet to reflect Phase 9 P1.1 completion

## Files
- `schema/ops-manager-fleet.registry.schema.json`
- `scripts/ops-manager-fleet-registry.sh`
- `scripts/ops-manager-fleet-policy.sh`
- `scripts/ops-manager-fleet-handoff.sh`
- `tests/ops-manager-fleet.bats`
- `docs/ops-manager-v0.md`
- `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD`

## Validation
- `bash -n scripts/ops-manager-fleet-registry.sh`
- `bash -n scripts/ops-manager-fleet-policy.sh`
- `bash -n scripts/ops-manager-fleet-handoff.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`

Refs #80
