### PR TITLE
feat(ops-manager): enforce fleet autonomous safety rails

### DIFF
--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -291,6 +291,7 @@ Purpose:
 - Supports both `advisory` and `guarded_auto` policy modes at the contract layer.
 - Supports advisory cooldown dedupe using policy history.
 - Classifies unsuppressed candidates as `autonomous.eligible` vs `autonomous.manualOnly` with explicit rejection reasons from allowlist/threshold gates.
+- Enforces autonomous safety rails before eligibility (`killSwitch`, `maxActionsPerRun`, `maxActionsPerLoop`, `cooldownSeconds`).
 - Persists autonomous eligibility state into policy artifacts and policy history telemetry.
 
 ### Fleet Status
@@ -405,6 +406,8 @@ Fleet state/policy/status artifacts may include:
 - `fleet_actions_deduped`
 - `fleet_auto_candidates_eligible`
 - `fleet_auto_candidates_blocked`
+- `fleet_auto_kill_switch_enabled`
+- `fleet_auto_candidates_safety_blocked`
 - `fleet_handoff_action_required`
 - `fleet_handoff_no_action`
 - `fleet_handoff_confirmation_pending`

--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD
@@ -16,9 +16,9 @@
 3. [x] Persist auto-eligibility artifacts/telemetry so operators can audit why candidates were or were not auto-executed.
 
 ## P1.3 Safety Rails and Circuit Breakers
-1. [ ] Enforce per-run and per-loop autonomous action caps before dispatch.
-2. [ ] Enforce cooldown windows to prevent repeated autonomous controls for the same loop/category.
-3. [ ] Add a global autonomous remediation kill switch that hard-disables auto dispatch without breaking advisory/manual flows.
+1. [x] Enforce per-run and per-loop autonomous action caps before dispatch.
+2. [x] Enforce cooldown windows to prevent repeated autonomous controls for the same loop/category.
+3. [x] Add a global autonomous remediation kill switch that hard-disables auto dispatch without breaking advisory/manual flows.
 
 ## P1.4 Autonomous Dispatch Workflow
 1. [ ] Add an autonomous execution path that dispatches only eligible intents via existing `ops-manager-control.sh` behavior.
@@ -31,7 +31,7 @@
 3. [ ] Document operator governance expectations for when autonomous mode should be enabled/disabled.
 
 ## P1.6 Test Coverage
-1. [ ] Extend `tests/ops-manager-fleet.bats` for autonomous mode contract, eligibility gating, cap/cooldown rails, and kill-switch behavior.
+1. [x] Extend `tests/ops-manager-fleet.bats` for autonomous mode contract, eligibility gating, cap/cooldown rails, and kill-switch behavior.
 2. [ ] Add/extend transport parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for autonomous execution semantics.
 3. [ ] Add regressions for deterministic reason-code behavior under partial autonomous execution failures.
 


### PR DESCRIPTION
## Summary
- enforce autonomous safety rails before candidate eligibility finalization in fleet policy shaping
- add deterministic gating for `killSwitch`, `maxActionsPerRun`, `maxActionsPerLoop`, and `cooldownSeconds`
- persist safety-gate outcomes and reason codes in policy state/history for auditability
- extend fleet policy regression suite for kill-switch, cap, and cooldown behavior
- update Phase 9 task packet and docs with safety-rail reason surfaces

## Files
- `scripts/ops-manager-fleet-policy.sh`
- `tests/ops-manager-fleet.bats`
- `docs/ops-manager-v0.md`
- `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_1.MD`

## Validation
- `bash -n scripts/ops-manager-fleet-policy.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats`

Refs #80
