### PR TITLE
feat(ops-manager): rollout cohort gating and autonomous auto-pause (phase 9 p2.1)

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -6,9 +6,9 @@
 3. [ ] Link this phase packet from the issue and include prior PR context (`#85`, `#84`, `#83`, `#82`, `#81`).
 
 ## P2.1 Rollout Controls and Blast-Radius Containment
-1. [ ] Extend fleet policy contract with rollout controls for guarded autonomous mode (canary scope/percentage, pause flags, and deterministic cohort selection).
-2. [ ] Implement rollout gating in policy/handoff shaping so auto-dispatch applies only to in-scope cohorts while out-of-scope intents remain manual pending.
-3. [ ] Add fail-safe auto-pause triggers for ambiguity/failure spikes and ensure advisory/manual flows continue when auto execution is paused.
+1. [x] Extend fleet policy contract with rollout controls for guarded autonomous mode (canary scope/percentage, pause flags, and deterministic cohort selection).
+2. [x] Implement rollout gating in policy/handoff shaping so auto-dispatch applies only to in-scope cohorts while out-of-scope intents remain manual pending.
+3. [x] Add fail-safe auto-pause triggers for ambiguity/failure spikes and ensure advisory/manual flows continue when auto execution is paused.
 
 ## P2.2 Governance and Policy-Change Authority
 1. [ ] Define and validate governance metadata for autonomous policy changes (actor identity, approval reference, rationale, and expiry/review window).

--- a/schema/ops-manager-fleet.registry.schema.json
+++ b/schema/ops-manager-fleet.registry.schema.json
@@ -158,6 +158,76 @@
                   "type": "boolean"
                 }
               }
+            },
+            "rollout": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "canaryPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "scope": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "loopIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                },
+                "selector": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "salt": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "pause": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "manual": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "autoPause": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "lookbackExecutions": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "minSampleSize": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "ambiguityRateThreshold": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "failureRateThreshold": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- deliver Phase 9 / Phase 2 (P2.1) rollout controls and blast-radius containment for guarded autonomous remediation
- extend fleet registry contract + schema with validated rollout controls:
  - deterministic cohorting (`canaryPercent`, `scope.loopIds`, `selector.salt`)
  - manual pause (`pause.manual`)
  - telemetry-driven auto-pause (`autoPause.*` thresholds/window)
- implement rollout gating + pause gating in `ops-manager-fleet-policy.sh` so out-of-cohort or paused candidates remain manual-only while still generating handoff intents
- add telemetry-derived auto-pause trigger logic from recent autonomous handoff executions (`fleet/telemetry/handoff.jsonl`) for ambiguity/failure spikes
- extend policy/state/status reason surfaces with rollout/autopause-specific codes and rollout posture in `autonomous.rollout.*`
- update runbook + v0 contract docs and mark P2.1 checklist items complete in `PHASE_2.MD`

## Reason Codes Added
- `autonomous_rollout_scope_excluded`
- `autonomous_rollout_canary_excluded`
- `autonomous_rollout_paused_manual`
- `autonomous_rollout_paused_auto`
- `autonomous_autopause_ambiguous_spike`
- `autonomous_autopause_failure_spike`
- `fleet_auto_candidates_rollout_gated`
- `fleet_auto_candidates_paused`
- `fleet_auto_candidates_autopause_triggered`

## Validation
- `bash -n scripts/ops-manager-fleet-registry.sh`
- `bash -n scripts/ops-manager-fleet-policy.sh`
- `bash -n scripts/ops-manager-fleet-status.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-service.bats tests/ops-manager-visibility.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats tests/usage-tracking.bats`

## Scope Tracking
- closes P2.1 checklist items in:
  - `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD`
- refs: #80
