### PR TITLE
feat(ops-manager): harden guarded-auto incident drills and retry storms

### DIFF
--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -360,6 +360,7 @@ Purpose:
 - Maps unsuppressed advisory candidates into explicit per-loop control intents.
 - Enforces explicit operator confirmation gate (`--execute` requires `--confirm`).
 - Supports guarded autonomous dispatch (`--autonomous-execute`) for only `autonomous.eligible` intents when policy mode is `guarded_auto`.
+- Applies autonomous retry guard after ambiguous/failed autonomous outcomes, forcing explicit manual confirmation before repeat attempts.
 - Propagates fleet trace/idempotency into loop-level control telemetry and invocation audit.
 - Persists handoff plan/execution artifacts and telemetry.
 - Preserves policy autonomous eligibility classification on generated intents (`autoEligibleIntentCount`, `manualOnlyIntentCount`).
@@ -450,6 +451,7 @@ Fleet state/policy/status artifacts may include:
 - `fleet_handoff_confirmation_pending`
 - `fleet_handoff_partial_mapping`
 - `fleet_handoff_unmapped_candidates`
+- `fleet_handoff_retry_guarded`
 - `fleet_handoff_auto_eligible_intents`
 - `fleet_handoff_executed`
 - `fleet_handoff_execution_ambiguous`

--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -16,9 +16,9 @@
 3. [x] Enforce fail-closed behavior when guarded autonomous mode is requested without required governance metadata/authority context.
 
 ## P2.3 Incident Drill Hardening
-1. [ ] Add executable kill-switch drill coverage proving immediate autonomous halt and deterministic fallback to explicit manual handoff.
-2. [ ] Add sprite-service outage drill coverage proving autonomous auto-pause and reason-coded operator fallback behavior.
-3. [ ] Add ambiguous-outcome drill coverage preventing retry storms and preserving deterministic escalation/reason semantics.
+1. [x] Add executable kill-switch drill coverage proving immediate autonomous halt and deterministic fallback to explicit manual handoff.
+2. [x] Add sprite-service outage drill coverage proving autonomous auto-pause and reason-coded operator fallback behavior.
+3. [x] Add ambiguous-outcome drill coverage preventing retry storms and preserving deterministic escalation/reason semantics.
 
 ## P2.4 Operator Visibility and SLO Surfaces
 1. [ ] Extend fleet status projection with rollout/autopause state and governance posture surfaces (`who changed`, `when`, `why`, `until`).
@@ -26,13 +26,13 @@
 3. [ ] Ensure reason-code surfaces distinguish policy-gated, rollout-gated, governance-gated, and transport-gated autonomous suppression paths.
 
 ## P2.5 Test Coverage
-1. [ ] Extend `tests/ops-manager-fleet.bats` for rollout cohort gating, auto-pause behavior, governance validation, and incident drills.
+1. [x] Extend `tests/ops-manager-fleet.bats` for rollout cohort gating, auto-pause behavior, governance validation, and incident drills.
 2. [ ] Add/extend parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for rollout/autopause/governance semantics.
 3. [ ] Add regression tests for deterministic governance audit artifacts and reason-code stability under mixed success/ambiguity/failure runs.
 
 ## P2.6 Docs and Runbook
-1. [ ] Update `docs/ops-manager-v0.md` with rollout/governance contract fields and compatibility defaults.
-2. [ ] Update `docs/ops-manager-runbook.md` with autonomous rollout operations, pause/unpause procedures, and incident drill workflows.
+1. [x] Update `docs/ops-manager-v0.md` with rollout/governance contract fields and compatibility defaults.
+2. [x] Update `docs/ops-manager-runbook.md` with autonomous rollout operations, pause/unpause procedures, and incident drill workflows.
 3. [ ] Document dogfood promotion gates (required metrics/evidence) for moving from guarded internal mode toward broader beta exposure.
 
 ## P2.V Validation


### PR DESCRIPTION
## Summary
- add executable Phase 2.3 incident drill coverage for guarded autonomous mode:
  - kill-switch immediate autonomous halt + deterministic fallback to explicit manual handoff
  - sprite-service outage auto-pause + reason-coded manual fallback behavior
  - ambiguous autonomous outcome retry-storm prevention + deterministic escalation semantics
- harden `ops-manager-fleet-handoff.sh` with autonomous retry guard:
  - carries prior handoff outcome context
  - marks previously ambiguous/failed autonomous intents as manual-only with retry-guard reasons
  - emits `fleet_handoff_retry_guarded` reason code
- fix intent/loop execution filter selection in handoff execution target shaping when `--intent-id` / `--loop` filters are supplied
- update contract/runbook docs for retry-guard semantics and incident drill procedures
- update phase checklist status for P2.3, P2.5.1, and P2.6.1/.2

## Files
- `scripts/ops-manager-fleet-handoff.sh`
- `tests/ops-manager-fleet.bats`
- `docs/ops-manager-v0.md`
- `docs/ops-manager-runbook.md`
- `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD`

## Validation
- `bash -n scripts/ops-manager-fleet-handoff.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats tests/usage-tracking.bats`

## Tracking
- phase packet: `feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD`
- scope issue: https://github.com/Supergent/superloop/issues/80
