### PR TITLE
feat(ops-manager): add autonomous operator visibility rollups

### DIFF
--- a/docs/ops-manager-runbook.md
+++ b/docs/ops-manager-runbook.md
@@ -132,6 +132,9 @@ Expected fleet outputs:
 - advisory cooldown suppression behavior (`advisory_cooldown_active`) for repeated candidates
 - deterministic rollout cohort gating surfaces (`autonomous.rollout.candidateBuckets.*`) for canary/scope posture
 - rollout pause posture and spike metrics (`autonomous.rollout.pause.*`) for manual and auto-pause state
+- governance posture surfaces (`autonomous.governance.*`) with who changed policy, when, why, and review-until deadline
+- autonomous outcome rollups (`autonomous.outcomeRollup`, `handoff.summary.autonomousOutcomeRollup`, `latestHandoffTelemetry.autonomousOutcomeRollup`) for attempted/executed/ambiguous/failed/manual backlog tracking
+- suppression-path classification surfaces (`autonomous.safetyGateDecisions.byPath.*`) for policy, rollout, governance, and transport gating
 - handoff summary of pending/confirmed/failed operator intents
 - explicit confirmation gate for manual execution (`--execute` requires `--confirm`)
 - guarded autonomous outcomes and safety-gate decisions from `scripts/ops-manager-fleet-status.sh` (`autonomous.*`, `handoff.*`)

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -327,6 +327,9 @@ Purpose:
 - Surfaces policy summary and top advisory candidates.
 - Surfaces handoff execution outcomes plus autonomous safety-gate decisions/reason counts.
 - Surfaces rollout posture (`autonomous.rollout.*`) including cohort buckets and pause/auto-pause metrics.
+- Surfaces governance posture (`autonomous.governance.*`) including who changed policy (`changedBy`), when (`changedAt`), why (`why`), and until when (`until`).
+- Adds autonomous outcome rollups (`attempted`, `executed`, `ambiguous`, `failed`, `manual_backlog`) across status and latest handoff telemetry summaries.
+- Distinguishes suppression-path buckets (`policyGated`, `rolloutGated`, `governanceGated`, `transportGated`) under `autonomous.safetyGateDecisions.byPath` plus normalized `suppressionReasonCodes`.
 - Includes trace linkage and per-loop drill-down pointers to loop-level artifacts.
 
 ### Fleet Handoff (Operator Control Planning/Execution)

--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -21,9 +21,9 @@
 3. [x] Add ambiguous-outcome drill coverage preventing retry storms and preserving deterministic escalation/reason semantics.
 
 ## P2.4 Operator Visibility and SLO Surfaces
-1. [ ] Extend fleet status projection with rollout/autopause state and governance posture surfaces (`who changed`, `when`, `why`, `until`).
-2. [ ] Add autonomous outcome rollups (`attempted`, `executed`, `ambiguous`, `failed`, `manual_backlog`) to fleet status and telemetry summaries.
-3. [ ] Ensure reason-code surfaces distinguish policy-gated, rollout-gated, governance-gated, and transport-gated autonomous suppression paths.
+1. [x] Extend fleet status projection with rollout/autopause state and governance posture surfaces (`who changed`, `when`, `why`, `until`).
+2. [x] Add autonomous outcome rollups (`attempted`, `executed`, `ambiguous`, `failed`, `manual_backlog`) to fleet status and telemetry summaries.
+3. [x] Ensure reason-code surfaces distinguish policy-gated, rollout-gated, governance-gated, and transport-gated autonomous suppression paths.
 
 ## P2.5 Test Coverage
 1. [x] Extend `tests/ops-manager-fleet.bats` for rollout cohort gating, auto-pause behavior, governance validation, and incident drills.


### PR DESCRIPTION
## Summary
- extend fleet status projection with governance posture surfaces (`changedBy`, `changedAt`, `why`, `until`) and rollout/autopause posture details
- add autonomous outcome rollups (`attempted`, `executed`, `ambiguous`, `failed`, `manual_backlog`) across status, handoff summary, and latest handoff telemetry projection
- add suppression-path classification buckets for policy, rollout, governance, and transport gates under `autonomous.safetyGateDecisions.byPath`
- add focused fleet regression coverage for the new P2.4 status surfaces and mark P2.4 checklist items complete
- document new status/runbook surfaces in ops manager docs

## Validation
- `bash -n scripts/ops-manager-fleet-status.sh tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-fleet.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-service.bats tests/ops-manager-visibility.bats`
