### PR TITLE
test(ops-manager): add rollout/governance transport parity regressions

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -27,7 +27,7 @@
 
 ## P2.5 Test Coverage
 1. [x] Extend `tests/ops-manager-fleet.bats` for rollout cohort gating, auto-pause behavior, governance validation, and incident drills.
-2. [ ] Add/extend parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for rollout/autopause/governance semantics.
+2. [x] Add/extend parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for rollout/autopause/governance semantics.
 3. [ ] Add regression tests for deterministic governance audit artifacts and reason-code stability under mixed success/ambiguity/failure runs.
 
 ## P2.6 Docs and Runbook


### PR DESCRIPTION
## Summary
- add a service-suite parity regression that validates fleet status governance/rollout/autopause projections remain stable between local and `sprite_service` loop transports
- add a visibility-suite parity regression that validates rollout/autopause/governance projections are stable across transports while preserving explicit transport-gated suppression semantics when sprite execution fails
- mark `P2.5.2` complete in the phase 2 task packet

## Validation
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-service.bats tests/ops-manager-visibility.bats`
