### PR TITLE
test(ops-manager): harden governance and mixed-outcome regressions

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -28,7 +28,7 @@
 ## P2.5 Test Coverage
 1. [x] Extend `tests/ops-manager-fleet.bats` for rollout cohort gating, auto-pause behavior, governance validation, and incident drills.
 2. [x] Add/extend parity regressions in `tests/ops-manager-service.bats` and `tests/ops-manager-visibility.bats` for rollout/autopause/governance semantics.
-3. [ ] Add regression tests for deterministic governance audit artifacts and reason-code stability under mixed success/ambiguity/failure runs.
+3. [x] Add regression tests for deterministic governance audit artifacts and reason-code stability under mixed success/ambiguity/failure runs.
 
 ## P2.6 Docs and Runbook
 1. [x] Update `docs/ops-manager-v0.md` with rollout/governance contract fields and compatibility defaults.


### PR DESCRIPTION
## Summary
- add a deterministic governance-audit regression that verifies immutable snapshot lineage (`previousGovernance`, `previousControls`) and no-op rerun stability
- add a mixed autonomous outcome regression that verifies reason-code projection stability for identical success/ambiguous/failed runs
- mark `P2.5.3` complete in the phase task packet

## Validation
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-fleet.bats`
