### PR TITLE
docs(ops-manager): define guarded-auto dogfood promotion gates

### DIFF
--- a/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-9-guarded-autonomous-remediation-initiation/tasks/PHASE_2.MD
@@ -33,9 +33,9 @@
 ## P2.6 Docs and Runbook
 1. [x] Update `docs/ops-manager-v0.md` with rollout/governance contract fields and compatibility defaults.
 2. [x] Update `docs/ops-manager-runbook.md` with autonomous rollout operations, pause/unpause procedures, and incident drill workflows.
-3. [ ] Document dogfood promotion gates (required metrics/evidence) for moving from guarded internal mode toward broader beta exposure.
+3. [x] Document dogfood promotion gates (required metrics/evidence) for moving from guarded internal mode toward broader beta exposure.
 
 ## P2.V Validation
 1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-contract.bats tests/ops-manager-core.bats tests/ops-manager-service.bats tests/ops-manager-observability.bats tests/ops-manager-threshold-tuning.bats tests/ops-manager-profile-drift.bats tests/ops-manager-alert-sinks.bats tests/ops-manager-visibility.bats tests/ops-manager-fleet.bats tests/usage-tracking.bats` passes.
 2. [x] All new/changed scripts pass `bash -n` syntax checks.
-3. [ ] Updated docs/runbook match implemented rollout/governance/drill semantics and operator workflow.
+3. [x] Updated docs/runbook match implemented rollout/governance/drill semantics and operator workflow.


### PR DESCRIPTION
## Summary
- document explicit dogfood promotion gates for guarded autonomous rollout in `docs/ops-manager-v0.md`
- add runbook promotion workflow with concrete evidence commands and pass criteria (governance, outcome reliability, backlog, safety/suppression, drill recency)
- mark `P2.6.3` and `P2.V.3` complete in the phase 2 task packet

## Validation
- documentation-only update (no runtime/script behavior changes)
