### PR TITLE
feat(ops-manager): add promotion CI workflow automation

### DIFF
--- a/.github/workflows/ops-manager-promotion-gates.yml
+++ b/.github/workflows/ops-manager-promotion-gates.yml
@@ -1,0 +1,115 @@
+name: Ops Manager Promotion Gates
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_path:
+        description: Repository path containing .superloop ops-manager artifacts
+        required: false
+        default: .
+      skip_on_missing_evidence:
+        description: Skip with success when evidence files are missing
+        type: boolean
+        required: false
+        default: true
+      fail_on_hold:
+        description: Fail job when promotion decision is hold
+        type: boolean
+        required: false
+        default: false
+      window_executions:
+        description: Window size for autonomous execution reliability gate
+        required: false
+        default: "20"
+      min_sample_size:
+        description: Minimum autonomous sample size required for promotion
+        required: false
+        default: "20"
+      max_ambiguity_rate:
+        description: Maximum ambiguity rate threshold
+        required: false
+        default: "0.2"
+      max_failure_rate:
+        description: Maximum failure rate threshold
+        required: false
+        default: "0.2"
+      max_manual_backlog:
+        description: Maximum manual backlog threshold
+        required: false
+        default: "5"
+      max_drill_age_hours:
+        description: Maximum drill evidence age in hours
+        required: false
+        default: "168"
+  schedule:
+    - cron: "17 5 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ops-manager-promotion-gates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  promotion-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Evaluate guarded-auto promotion gates
+        env:
+          INPUT_REPO_PATH: ${{ github.event_name == 'workflow_dispatch' && inputs.repo_path || '.' }}
+          INPUT_SKIP_MISSING: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_on_missing_evidence || 'true' }}
+          INPUT_FAIL_ON_HOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.fail_on_hold || 'false' }}
+          INPUT_WINDOW_EXECUTIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.window_executions || '20' }}
+          INPUT_MIN_SAMPLE_SIZE: ${{ github.event_name == 'workflow_dispatch' && inputs.min_sample_size || '20' }}
+          INPUT_MAX_AMBIGUITY_RATE: ${{ github.event_name == 'workflow_dispatch' && inputs.max_ambiguity_rate || '0.2' }}
+          INPUT_MAX_FAILURE_RATE: ${{ github.event_name == 'workflow_dispatch' && inputs.max_failure_rate || '0.2' }}
+          INPUT_MAX_MANUAL_BACKLOG: ${{ github.event_name == 'workflow_dispatch' && inputs.max_manual_backlog || '5' }}
+          INPUT_MAX_DRILL_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_drill_age_hours || '168' }}
+        run: |
+          set -euo pipefail
+
+          cmd=(
+            scripts/ops-manager-promotion-ci.sh
+            --repo "${INPUT_REPO_PATH}"
+            --window-executions "${INPUT_WINDOW_EXECUTIONS}"
+            --min-sample-size "${INPUT_MIN_SAMPLE_SIZE}"
+            --max-ambiguity-rate "${INPUT_MAX_AMBIGUITY_RATE}"
+            --max-failure-rate "${INPUT_MAX_FAILURE_RATE}"
+            --max-manual-backlog "${INPUT_MAX_MANUAL_BACKLOG}"
+            --max-drill-age-hours "${INPUT_MAX_DRILL_AGE_HOURS}"
+            --result-file .superloop/ops-manager/fleet/promotion-ci-result.json
+            --summary-file .superloop/ops-manager/fleet/promotion-ci-summary.md
+          )
+
+          if [ "${INPUT_SKIP_MISSING}" = "true" ]; then
+            cmd+=(--skip-on-missing-evidence)
+          fi
+          if [ "${INPUT_FAIL_ON_HOLD}" = "true" ]; then
+            cmd+=(--fail-on-hold)
+          fi
+
+          "${cmd[@]}"
+
+      - name: Show promotion CI artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f .superloop/ops-manager/fleet/promotion-ci-result.json ]; then
+            echo "--- promotion-ci-result.json ---"
+            cat .superloop/ops-manager/fleet/promotion-ci-result.json
+          else
+            echo "promotion-ci-result.json not found"
+          fi
+
+          if [ -f .superloop/ops-manager/fleet/promotion-ci-summary.md ]; then
+            echo "--- promotion-ci-summary.md ---"
+            cat .superloop/ops-manager/fleet/promotion-ci-summary.md
+          else
+            echo "promotion-ci-summary.md not found"
+          fi

--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -396,6 +396,21 @@ Purpose:
 - Persists latest decision state and append-only promotion telemetry artifacts.
 - Supports CI enforcement mode via `--fail-on-hold` (non-zero exit when decision is `hold`).
 
+### Promotion CI Wrapper (Phase 10 / Phase 2)
+```bash
+scripts/ops-manager-promotion-ci.sh \
+  --repo /path/to/repo \
+  --skip-on-missing-evidence \
+  --summary-file /path/to/repo/.superloop/ops-manager/fleet/promotion-ci-summary.md \
+  --result-file /path/to/repo/.superloop/ops-manager/fleet/promotion-ci-result.json
+```
+
+Purpose:
+- Wraps `scripts/ops-manager-promotion-gates.sh` for CI-friendly execution and summary generation.
+- Emits machine-readable result JSON plus markdown summary suitable for job summaries and operator handoff.
+- Supports skip mode for missing evidence (`--skip-on-missing-evidence`) to avoid destructive scheduled failures in repos without live fleet telemetry.
+- Preserves strict gating behavior with `--fail-on-hold` when promotion checks should block pipeline progression.
+
 ## Sprite Service Transport
 Service implementation entrypoint:
 - `scripts/ops-manager-sprite-service.py`
@@ -444,6 +459,8 @@ Transport mode switch:
 - `.superloop/ops-manager/fleet/telemetry/policy-governance.jsonl` - immutable fleet policy governance change history.
 - `.superloop/ops-manager/fleet/telemetry/handoff.jsonl` - fleet handoff plan/execution history.
 - `.superloop/ops-manager/fleet/telemetry/promotion.jsonl` - append-only guarded-autonomous promotion decision history.
+- `.superloop/ops-manager/fleet/promotion-ci-result.json` - latest CI wrapper JSON decision output (`promote|hold|skipped`).
+- `.superloop/ops-manager/fleet/promotion-ci-summary.md` - latest CI wrapper markdown summary for operator workflow/step summaries.
 - `config/ops-manager-threshold-profiles.v1.json` - threshold profile catalog (repo-level, versioned).
 - `config/ops-manager-alert-sinks.v1.json` - alert sink routing/catalog config (repo-level, versioned).
 - `schema/ops-manager-alert-sinks.config.schema.json` - JSON schema reference for alert sink config.

--- a/feat/ops-manager-superloop-sprites/phase-10-promotion-gate-automation-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-10-promotion-gate-automation-initiation/tasks/PHASE_2.MD
@@ -1,0 +1,31 @@
+# Phase 2 - Promotion CI Workflow + Evidence Automation
+
+## P2.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-10-promotion-gate-automation-initiation/PLAN.MD` phase-2 scope aligns with merged phase-1 outcomes.
+2. [x] Attach this phase file to scope authority issue (`https://github.com/Supergent/superloop/issues/99`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#98`).
+
+## P2.1 CI Wrapper Command
+1. [x] Add `scripts/ops-manager-promotion-ci.sh` to run promotion-gate evaluation and emit CI-friendly JSON + markdown summaries.
+2. [x] Support explicit CI control flags (`--fail-on-hold`, `--skip-on-missing-evidence`) and deterministic evidence path configuration.
+3. [x] Publish summary output to `GITHUB_STEP_SUMMARY` when available while preserving local CLI usability.
+
+## P2.2 GitHub Actions Workflow
+1. [x] Add `.github/workflows/ops-manager-promotion-gates.yml` with `workflow_dispatch` and scheduled execution for recurring promotion checks.
+2. [x] Wire workflow inputs to threshold and behavior controls used by the CI wrapper command.
+3. [x] Ensure workflow can run non-destructively when evidence is absent (`skip` mode) while still supporting strict enforcement mode.
+
+## P2.3 Test Coverage
+1. [x] Add `tests/ops-manager-promotion-ci.bats` for promote/hold/skip pathways and markdown summary emission.
+2. [x] Add regressions for wrapper exit semantics (`0` promote/skip, `2` hold when enforced).
+3. [x] Keep existing promotion gate evaluator suite green (`tests/ops-manager-promotion-gates.bats`).
+
+## P2.4 Docs and Runbook
+1. [x] Update `docs/ops-manager-v0.md` with CI wrapper and workflow command contracts.
+2. [x] Update `docs/ops-manager-runbook.md` with recurring automation workflow (manual dispatch + schedule) and triage semantics for `hold` vs `skipped`.
+3. [x] Document artifact locations for CI summaries and promotion decision outputs.
+
+## P2.V Validation
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-gates.bats tests/ops-manager-promotion-ci.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Workflow YAML and docs reflect implemented CI behavior.

--- a/scripts/ops-manager-promotion-ci.sh
+++ b/scripts/ops-manager-promotion-ci.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-promotion-ci.sh --repo <path> [options]
+
+Options:
+  --fleet-status-file <path>       Precomputed fleet status JSON path.
+  --handoff-telemetry-file <path>  Fleet handoff telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/handoff.jsonl
+  --drill-state-file <path>        Promotion drill state JSON path. Default: <repo>/.superloop/ops-manager/fleet/drills/promotion.v1.json
+  --promotion-state-file <path>    Promotion state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/promotion-state.json
+  --promotion-telemetry-file <path> Promotion telemetry JSONL output path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/promotion.jsonl
+  --summary-file <path>            Markdown summary output path. Default: <repo>/.superloop/ops-manager/fleet/promotion-ci-summary.md
+  --result-file <path>             JSON result output path. Default: <repo>/.superloop/ops-manager/fleet/promotion-ci-result.json
+  --window-executions <n>          Promotion evaluator window size.
+  --min-sample-size <n>            Promotion evaluator min autonomous sample.
+  --max-ambiguity-rate <0..1>      Promotion evaluator ambiguity threshold.
+  --max-failure-rate <0..1>        Promotion evaluator failure threshold.
+  --max-manual-backlog <n>         Promotion evaluator manual backlog threshold.
+  --max-drill-age-hours <n>        Promotion evaluator drill staleness threshold.
+  --trace-id <id>                  Trace id forwarded to evaluator.
+  --fail-on-hold                   Exit non-zero when promotion decision is hold.
+  --skip-on-missing-evidence       Emit skipped decision and exit 0 when required evidence files are missing.
+  --pretty                         Pretty-print JSON output.
+  --help                           Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+repo=""
+fleet_status_file=""
+handoff_telemetry_file=""
+drill_state_file=""
+promotion_state_file=""
+promotion_telemetry_file=""
+summary_file=""
+result_file=""
+window_executions=""
+min_sample_size=""
+max_ambiguity_rate=""
+max_failure_rate=""
+max_manual_backlog=""
+max_drill_age_hours=""
+trace_id=""
+fail_on_hold="0"
+skip_on_missing_evidence="0"
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --fleet-status-file)
+      fleet_status_file="${2:-}"
+      shift 2
+      ;;
+    --handoff-telemetry-file)
+      handoff_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --drill-state-file)
+      drill_state_file="${2:-}"
+      shift 2
+      ;;
+    --promotion-state-file)
+      promotion_state_file="${2:-}"
+      shift 2
+      ;;
+    --promotion-telemetry-file)
+      promotion_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --summary-file)
+      summary_file="${2:-}"
+      shift 2
+      ;;
+    --result-file)
+      result_file="${2:-}"
+      shift 2
+      ;;
+    --window-executions)
+      window_executions="${2:-}"
+      shift 2
+      ;;
+    --min-sample-size)
+      min_sample_size="${2:-}"
+      shift 2
+      ;;
+    --max-ambiguity-rate)
+      max_ambiguity_rate="${2:-}"
+      shift 2
+      ;;
+    --max-failure-rate)
+      max_failure_rate="${2:-}"
+      shift 2
+      ;;
+    --max-manual-backlog)
+      max_manual_backlog="${2:-}"
+      shift 2
+      ;;
+    --max-drill-age-hours)
+      max_drill_age_hours="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --fail-on-hold)
+      fail_on_hold="1"
+      shift
+      ;;
+    --skip-on-missing-evidence)
+      skip_on_missing_evidence="1"
+      shift
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+promotion_script="${OPS_MANAGER_PROMOTION_GATES_SCRIPT:-$script_dir/ops-manager-promotion-gates.sh}"
+
+if [[ -z "$handoff_telemetry_file" ]]; then
+  handoff_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/handoff.jsonl"
+fi
+if [[ -z "$drill_state_file" ]]; then
+  drill_state_file="$repo/.superloop/ops-manager/fleet/drills/promotion.v1.json"
+fi
+if [[ -z "$promotion_state_file" ]]; then
+  promotion_state_file="$repo/.superloop/ops-manager/fleet/promotion-state.json"
+fi
+if [[ -z "$promotion_telemetry_file" ]]; then
+  promotion_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/promotion.jsonl"
+fi
+if [[ -z "$summary_file" ]]; then
+  summary_file="$repo/.superloop/ops-manager/fleet/promotion-ci-summary.md"
+fi
+if [[ -z "$result_file" ]]; then
+  result_file="$repo/.superloop/ops-manager/fleet/promotion-ci-result.json"
+fi
+
+mkdir -p "$(dirname "$summary_file")"
+mkdir -p "$(dirname "$result_file")"
+
+missing_paths=()
+if [[ -n "$fleet_status_file" && ! -f "$fleet_status_file" ]]; then
+  missing_paths+=("$fleet_status_file")
+fi
+if [[ ! -f "$handoff_telemetry_file" ]]; then
+  missing_paths+=("$handoff_telemetry_file")
+fi
+if [[ ! -f "$drill_state_file" ]]; then
+  missing_paths+=("$drill_state_file")
+fi
+
+if [[ "$skip_on_missing_evidence" == "1" && "${#missing_paths[@]}" -gt 0 ]]; then
+  skipped_json=$(jq -cn \
+    --arg schema_version "v1" \
+    --arg generated_at "$(timestamp)" \
+    --arg repo_path "$repo" \
+    --argjson missing_paths "$(printf '%s\n' "${missing_paths[@]}" | jq -R . | jq -s .)" \
+    '{
+      schemaVersion: $schema_version,
+      generatedAt: $generated_at,
+      source: {
+        repoPath: $repo_path
+      },
+      summary: {
+        decision: "skipped",
+        promote: false,
+        reasonCodes: ["promotion_ci_missing_evidence"],
+        missingEvidencePaths: $missing_paths
+      }
+    }')
+
+  jq -c '.' <<<"$skipped_json" > "$result_file"
+  {
+    echo "## Ops Manager Promotion CI"
+    echo
+    echo "Decision: \`skipped\`"
+    echo
+    echo "Reason codes: \`promotion_ci_missing_evidence\`"
+    echo
+    echo "Missing evidence paths:"
+    for path in "${missing_paths[@]}"; do
+      echo "- \\`$path\\`"
+    done
+  } > "$summary_file"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  if [[ "$pretty" == "1" ]]; then
+    jq '.' <<<"$skipped_json"
+  else
+    jq -c '.' <<<"$skipped_json"
+  fi
+  exit 0
+fi
+
+cmd=("$promotion_script" --repo "$repo" --handoff-telemetry-file "$handoff_telemetry_file" --drill-state-file "$drill_state_file" --promotion-state-file "$promotion_state_file" --promotion-telemetry-file "$promotion_telemetry_file")
+if [[ -n "$fleet_status_file" ]]; then
+  cmd+=(--fleet-status-file "$fleet_status_file")
+fi
+if [[ -n "$window_executions" ]]; then
+  cmd+=(--window-executions "$window_executions")
+fi
+if [[ -n "$min_sample_size" ]]; then
+  cmd+=(--min-sample-size "$min_sample_size")
+fi
+if [[ -n "$max_ambiguity_rate" ]]; then
+  cmd+=(--max-ambiguity-rate "$max_ambiguity_rate")
+fi
+if [[ -n "$max_failure_rate" ]]; then
+  cmd+=(--max-failure-rate "$max_failure_rate")
+fi
+if [[ -n "$max_manual_backlog" ]]; then
+  cmd+=(--max-manual-backlog "$max_manual_backlog")
+fi
+if [[ -n "$max_drill_age_hours" ]]; then
+  cmd+=(--max-drill-age-hours "$max_drill_age_hours")
+fi
+if [[ -n "$trace_id" ]]; then
+  cmd+=(--trace-id "$trace_id")
+fi
+if [[ "$pretty" == "1" ]]; then
+  cmd+=(--pretty)
+fi
+if [[ "$fail_on_hold" == "1" ]]; then
+  cmd+=(--fail-on-hold)
+fi
+
+set +e
+promotion_output="$(${cmd[@]} 2>&1)"
+promotion_status=$?
+set -e
+
+if ! promotion_json="$(jq -c '.' <<<"$promotion_output" 2>/dev/null)"; then
+  printf '%s\n' "$promotion_output" >&2
+  exit "$promotion_status"
+fi
+
+jq -c '.' <<<"$promotion_json" > "$result_file"
+
+decision="$(jq -r '.summary.decision // "unknown"' <<<"$promotion_json")"
+failed_gates_csv="$(jq -r '(.summary.failedGates // []) | join(", ")' <<<"$promotion_json")"
+reason_codes_csv="$(jq -r '(.summary.reasonCodes // []) | join(", ")' <<<"$promotion_json")"
+
+{
+  echo "## Ops Manager Promotion CI"
+  echo
+  echo "Decision: \`$decision\`"
+  echo
+  echo "Failed gates: ${failed_gates_csv:-none}"
+  echo
+  echo "Reason codes: ${reason_codes_csv:-none}"
+  echo
+  echo "Result JSON: \\`$result_file\\`"
+  echo
+  echo "Promotion state: \\`$promotion_state_file\\`"
+  echo
+  echo "Promotion telemetry: \\`$promotion_telemetry_file\\`"
+} > "$summary_file"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$promotion_json"
+else
+  jq -c '.' <<<"$promotion_json"
+fi
+
+exit "$promotion_status"

--- a/tests/ops-manager-promotion-ci.bats
+++ b/tests/ops-manager-promotion-ci.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+iso_hours_ago() {
+  local hours="$1"
+
+  python3 - "$hours" <<'PY'
+import datetime
+import sys
+
+hours = int(sys.argv[1])
+value = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=hours)
+print(value.replace(microsecond=0).isoformat().replace("+00:00", "Z"))
+PY
+}
+
+write_status_fixture() {
+  local file="$1"
+  local posture="$2"
+  local blocks_autonomous="$3"
+  local manual_backlog="$4"
+  local autopause_active="$5"
+
+  cat > "$file" <<JSON
+{
+  "schemaVersion": "v1",
+  "autonomous": {
+    "enabled": true,
+    "governance": {
+      "posture": "$posture",
+      "blocksAutonomous": $blocks_autonomous,
+      "reasonCodes": []
+    },
+    "outcomeRollup": {
+      "manual_backlog": $manual_backlog
+    },
+    "rollout": {
+      "autopause": {
+        "active": $autopause_active
+      }
+    },
+    "safetyGateDecisions": {
+      "byPath": {
+        "policyGated": {"blockedCount": 0, "byReason": {}},
+        "rolloutGated": {"blockedCount": 0, "byReason": {}},
+        "governanceGated": {"blockedCount": 0, "reasonCodes": []},
+        "transportGated": {"blockedCount": 0, "byReason": {}}
+      }
+    }
+  }
+}
+JSON
+}
+
+write_handoff_telemetry() {
+  local file="$1"
+  local runs="$2"
+  local attempted="$3"
+  local executed="$4"
+  local ambiguous="$5"
+  local failed="$6"
+
+  : > "$file"
+  for _ in $(seq 1 "$runs"); do
+    printf '{"timestamp":"%s","category":"fleet_handoff_execute","execution":{"mode":"autonomous","requestedIntentCount":%s,"executedCount":%s,"ambiguousCount":%s,"failedCount":%s}}\n' \
+      "$(now_iso)" "$attempted" "$executed" "$ambiguous" "$failed" >> "$file"
+  done
+}
+
+write_drill_state() {
+  local file="$1"
+  local completed_at="$2"
+
+  cat > "$file" <<JSON
+{
+  "schemaVersion": "v1",
+  "updatedAt": "$(now_iso)",
+  "drills": [
+    {"id": "kill_switch", "status": "pass", "completedAt": "$completed_at"},
+    {"id": "sprite_service_outage", "status": "pass", "completedAt": "$completed_at"},
+    {"id": "ambiguous_retry_guard", "status": "pass", "completedAt": "$completed_at"}
+  ]
+}
+JSON
+}
+
+@test "promotion CI skips with success when evidence is missing and skip mode is enabled" {
+  local repo="$TEMP_DIR/repo-skip"
+  local result_file="$TEMP_DIR/result-skip.json"
+  local summary_file="$TEMP_DIR/summary-skip.md"
+
+  mkdir -p "$repo"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-ci.sh" \
+    --repo "$repo" \
+    --skip-on-missing-evidence \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.summary.decision' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "skipped" ]
+
+  run jq -e '.summary.reasonCodes | index("promotion_ci_missing_evidence") != null' "$result_file"
+  [ "$status" -eq 0 ]
+
+  run grep -q 'Decision: `skipped`' "$summary_file"
+  [ "$status" -eq 0 ]
+}
+
+@test "promotion CI emits promote decision and markdown summary" {
+  local repo="$TEMP_DIR/repo-promote"
+  local status_file="$TEMP_DIR/status-promote.json"
+  local handoff_file="$TEMP_DIR/handoff-promote.jsonl"
+  local drill_file="$TEMP_DIR/drills-promote.json"
+  local result_file="$TEMP_DIR/result-promote.json"
+  local summary_file="$TEMP_DIR/summary-promote.md"
+
+  mkdir -p "$repo/.superloop/ops-manager/fleet/telemetry" "$repo/.superloop/ops-manager/fleet/drills"
+
+  write_status_fixture "$status_file" "active" "false" "1" "false"
+  write_handoff_telemetry "$handoff_file" 20 1 1 0 0
+  write_drill_state "$drill_file" "$(iso_hours_ago 1)"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-ci.sh" \
+    --repo "$repo" \
+    --fleet-status-file "$status_file" \
+    --handoff-telemetry-file "$handoff_file" \
+    --drill-state-file "$drill_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.summary.decision' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "promote" ]
+
+  run grep -q 'Decision: `promote`' "$summary_file"
+  [ "$status" -eq 0 ]
+}
+
+@test "promotion CI propagates hold exit code when fail-on-hold is enabled" {
+  local repo="$TEMP_DIR/repo-hold"
+  local status_file="$TEMP_DIR/status-hold.json"
+  local handoff_file="$TEMP_DIR/handoff-hold.jsonl"
+  local drill_file="$TEMP_DIR/drills-hold.json"
+  local result_file="$TEMP_DIR/result-hold.json"
+  local summary_file="$TEMP_DIR/summary-hold.md"
+
+  mkdir -p "$repo/.superloop/ops-manager/fleet/telemetry" "$repo/.superloop/ops-manager/fleet/drills"
+
+  write_status_fixture "$status_file" "active" "false" "99" "false"
+  write_handoff_telemetry "$handoff_file" 20 1 1 0 0
+  write_drill_state "$drill_file" "$(iso_hours_ago 1)"
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-ci.sh" \
+    --repo "$repo" \
+    --fleet-status-file "$status_file" \
+    --handoff-telemetry-file "$handoff_file" \
+    --drill-state-file "$drill_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file" \
+    --fail-on-hold
+
+  [ "$status" -eq 2 ]
+
+  run jq -r '.summary.decision' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hold" ]
+
+  run jq -e '.summary.reasonCodes | index("promotion_manual_backlog_exceeded") != null' "$result_file"
+  [ "$status" -eq 0 ]
+
+  run grep -q 'Decision: `hold`' "$summary_file"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add Phase 10 / Phase 2 packet (`tasks/PHASE_2.MD`) for promotion CI workflow automation
- add `scripts/ops-manager-promotion-ci.sh` wrapper to execute promotion gates in CI, emit markdown/json summaries, support skip-on-missing-evidence, and optional fail-on-hold enforcement
- add `.github/workflows/ops-manager-promotion-gates.yml` for scheduled + manual promotion checks
- add `tests/ops-manager-promotion-ci.bats` coverage for `promote`, `hold`, and `skipped` decision pathways
- update `docs/ops-manager-v0.md` and `docs/ops-manager-runbook.md` with CI wrapper/workflow contracts and artifact paths

## Validation
- `bash -n scripts/ops-manager-promotion-ci.sh scripts/ops-manager-promotion-gates.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-ci.bats tests/ops-manager-promotion-gates.bats`
- workflow YAML parse check via `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ops-manager-promotion-gates.yml"))'`

Refs #99
