### PR TITLE
feat(ops-manager): add promotion rollout apply command

### DIFF
--- a/docs/ops-manager-v0.md
+++ b/docs/ops-manager-v0.md
@@ -411,6 +411,38 @@ Purpose:
 - Supports skip mode for missing evidence (`--skip-on-missing-evidence`) to avoid destructive scheduled failures in repos without live fleet telemetry.
 - Preserves strict gating behavior with `--fail-on-hold` when promotion checks should block pipeline progression.
 
+### Promotion Apply (Phase 11 / Phase 1)
+```bash
+scripts/ops-manager-promotion-apply.sh \
+  --repo /path/to/repo \
+  --intent expand \
+  --expand-step 25 \
+  --by <operator> \
+  --approval-ref <change-id> \
+  --rationale "guarded rollout expansion" \
+  --review-by <review-deadline-iso8601> \
+  --idempotency-key <key> \
+  --pretty
+```
+
+```bash
+scripts/ops-manager-promotion-apply.sh \
+  --repo /path/to/repo \
+  --intent rollback \
+  --by <operator> \
+  --approval-ref <change-id> \
+  --rationale "incident rollback" \
+  --review-by <review-deadline-iso8601> \
+  --pretty
+```
+
+Purpose:
+- Couples promotion decision artifacts to explicit rollout mutation intents.
+- Enforces decision gating (`expand` and `resume` require promotion decision `promote`; `rollback` is safety-allowed).
+- Enforces governance mutation metadata for every apply action.
+- Re-validates mutated registry through `scripts/ops-manager-fleet-registry.sh` before write.
+- Persists state and append-only telemetry for rollout posture before/after snapshots.
+
 ## Sprite Service Transport
 Service implementation entrypoint:
 - `scripts/ops-manager-sprite-service.py`
@@ -459,6 +491,8 @@ Transport mode switch:
 - `.superloop/ops-manager/fleet/telemetry/policy-governance.jsonl` - immutable fleet policy governance change history.
 - `.superloop/ops-manager/fleet/telemetry/handoff.jsonl` - fleet handoff plan/execution history.
 - `.superloop/ops-manager/fleet/telemetry/promotion.jsonl` - append-only guarded-autonomous promotion decision history.
+- `.superloop/ops-manager/fleet/promotion-apply-state.json` - latest promotion apply mutation record.
+- `.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl` - append-only promotion apply mutation history.
 - `.superloop/ops-manager/fleet/promotion-ci-result.json` - latest CI wrapper JSON decision output (`promote|hold|skipped`).
 - `.superloop/ops-manager/fleet/promotion-ci-summary.md` - latest CI wrapper markdown summary for operator workflow/step summaries.
 - `config/ops-manager-threshold-profiles.v1.json` - threshold profile catalog (repo-level, versioned).

--- a/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/PLAN.MD
+++ b/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/PLAN.MD
@@ -1,0 +1,59 @@
+# Feature: Ops Manager for Superloop + Sprites (Phase 11 Promotion-to-Rollout Coupling)
+
+## Goal
+Turn promotion decisions into explicit, governed rollout policy mutations with deterministic safety behavior, idempotent apply semantics, and auditable artifacts.
+
+## Scope
+- Add a promotion apply command that consumes promotion decision artifacts and mutates fleet rollout policy in controlled steps.
+- Enforce governance metadata requirements (`actor`, `approvalRef`, `rationale`, `reviewBy`) for every mutation.
+- Support safe intents for rollout progression and rollback posture (`expand`, `resume`, `rollback`).
+- Persist promotion-apply state and append-only mutation telemetry with before/after rollout posture.
+- Add regression coverage for decision gating, idempotency, governance requirements, and rollback behavior.
+
+## Non-Goals (this iteration)
+- Fully automatic policy mutation directly inside scheduled CI workflow without explicit operator intent.
+- Multi-tenant authorization or external approval systems.
+- Arbitrary policy mutation beyond rollout + governance coupling for guarded autonomous mode.
+
+## Primary References
+- `scripts/ops-manager-promotion-gates.sh` - promotion decision source (`promote|hold`).
+- `scripts/ops-manager-fleet-registry.sh` - canonical policy contract normalization/validation.
+- `docs/ops-manager-v0.md` - fleet policy contract and artifact paths.
+- `docs/ops-manager-runbook.md` - guarded autonomous operational workflow and promotion runbook.
+- `tests/ops-manager-promotion-gates.bats` - promotion decision baseline behavior.
+
+## Architecture
+Phase 11 adds an apply layer after promotion evaluation:
+
+1. Decision intake plane:
+- Read current promotion decision artifact and validate intent compatibility (`expand` and `resume` require `promote`).
+
+2. Mutation plane:
+- Mutate only rollout/governance policy fields in registry with explicit intent semantics and deterministic limits.
+
+3. Verification plane:
+- Re-validate mutated registry via `ops-manager-fleet-registry.sh` before persistence.
+
+4. Audit plane:
+- Persist apply state and append telemetry with idempotency key, trace linkage, and before/after posture.
+
+## Decisions
+- Apply command is fail-closed for missing/invalid decision or governance metadata.
+- Rollout progression is step-based (`expand` by integer percent) for controlled blast-radius changes.
+- `rollback` is always allowed to force safe pause posture, even when latest promotion decision is not `promote`.
+- Idempotency key replay returns existing apply record without mutating registry again.
+
+## Risks / Constraints
+- Applying rollout changes against stale decision artifacts can cause operator confusion if evidence windows drift.
+- Governance metadata freshness depends on operator discipline and review cadence.
+- Invalid manual registry edits can still break apply unless registry validation remains strict.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-apply.bats tests/ops-manager-promotion-gates.bats tests/ops-manager-fleet.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Promotion apply command, audit artifacts, docs updates, and deterministic tests.
+- **Phase 2**: CI/manual orchestration workflow for guarded rollout transitions with dry-run/apply/rollback actions.

--- a/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/tasks/PHASE_1.MD
+++ b/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/tasks/PHASE_1.MD
@@ -1,0 +1,28 @@
+# Phase 1 - Promotion Apply Command Baseline
+
+## P1.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/PLAN.MD` scope aligns with merged phase-10 outcomes.
+2. [x] Open/attach follow-on issue with this phase file as scope authority (`https://github.com/Supergent/superloop/issues/101`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#100`, `#98`).
+
+## P1.1 Promotion Apply Command
+1. [x] Add `scripts/ops-manager-promotion-apply.sh` with intent-based rollout mutation (`expand`, `resume`, `rollback`).
+2. [x] Enforce decision gating rules (`expand`/`resume` require promotion decision `promote`; `rollback` remains safety-allowed).
+3. [x] Enforce governance mutation metadata (`--by`, `--approval-ref`, `--rationale`, `--review-by`) and fail closed on missing values.
+4. [x] Re-validate mutated registry via `scripts/ops-manager-fleet-registry.sh` before writing.
+5. [x] Persist apply state and append telemetry artifacts with idempotency key, trace id, and before/after rollout posture.
+
+## P1.2 Test Coverage
+1. [x] Add `tests/ops-manager-promotion-apply.bats` covering successful expand/resume/rollback mutations.
+2. [x] Add regressions for decision mismatch, governance metadata missing, and invalid expand-step values.
+3. [x] Add idempotency regression proving replay with same key does not re-mutate registry or duplicate side effects.
+
+## P1.3 Docs and Runbook
+1. [x] Update `docs/ops-manager-v0.md` with promotion-apply command contract and artifact paths.
+2. [x] Update `docs/ops-manager-runbook.md` with controlled rollout apply workflow and rollback procedure.
+3. [x] Document operational semantics for idempotent replays and decision-gating failures.
+
+## P1.V Validation
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-apply.bats tests/ops-manager-promotion-gates.bats tests/ops-manager-fleet.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Updated docs/runbook match implemented apply semantics and artifact contract.

--- a/scripts/ops-manager-promotion-apply.sh
+++ b/scripts/ops-manager-promotion-apply.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-promotion-apply.sh --repo <path> --intent <expand|resume|rollback> --by <actor> --approval-ref <id> --rationale <text> --review-by <iso8601> [options]
+
+Options:
+  --registry-file <path>          Fleet registry JSON path. Default: <repo>/.superloop/ops-manager/fleet/registry.v1.json
+  --promotion-state-file <path>   Promotion decision JSON path. Default: <repo>/.superloop/ops-manager/fleet/promotion-state.json
+  --apply-state-file <path>       Apply state JSON output path. Default: <repo>/.superloop/ops-manager/fleet/promotion-apply-state.json
+  --apply-telemetry-file <path>   Apply telemetry JSONL path. Default: <repo>/.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl
+  --intent <expand|resume|rollback> Mutation intent.
+  --expand-step <n>               Expand step percentage for intent=expand (default: 25)
+  --idempotency-key <key>         Optional idempotency key. Replay returns prior result without mutation.
+  --trace-id <id>                 Apply trace id override.
+  --by <actor>                    Governance actor identity for mutation.
+  --approval-ref <id>             Governance approval/change reference.
+  --rationale <text>              Governance rationale.
+  --review-by <iso8601>           Governance review deadline (must be in future).
+  --pretty                        Pretty-print output JSON.
+  --help                          Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'trace-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+is_non_empty() {
+  local value="$1"
+  [[ -n "$value" ]]
+}
+
+repo=""
+registry_file=""
+promotion_state_file=""
+apply_state_file=""
+apply_telemetry_file=""
+intent=""
+expand_step="25"
+idempotency_key=""
+trace_id=""
+actor=""
+approval_ref=""
+rationale=""
+review_by=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --registry-file)
+      registry_file="${2:-}"
+      shift 2
+      ;;
+    --promotion-state-file)
+      promotion_state_file="${2:-}"
+      shift 2
+      ;;
+    --apply-state-file)
+      apply_state_file="${2:-}"
+      shift 2
+      ;;
+    --apply-telemetry-file)
+      apply_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --intent)
+      intent="${2:-}"
+      shift 2
+      ;;
+    --expand-step)
+      expand_step="${2:-}"
+      shift 2
+      ;;
+    --idempotency-key)
+      idempotency_key="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --by)
+      actor="${2:-}"
+      shift 2
+      ;;
+    --approval-ref)
+      approval_ref="${2:-}"
+      shift 2
+      ;;
+    --rationale)
+      rationale="${2:-}"
+      shift 2
+      ;;
+    --review-by)
+      review_by="${2:-}"
+      shift 2
+      ;;
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ "$intent" != "expand" && "$intent" != "resume" && "$intent" != "rollback" ]]; then
+  die "--intent must be one of expand, resume, rollback"
+fi
+if ! [[ "$expand_step" =~ ^[0-9]+$ ]] || (( expand_step < 1 )) || (( expand_step > 100 )); then
+  die "--expand-step must be an integer between 1 and 100"
+fi
+if ! is_non_empty "$actor"; then
+  die "--by is required"
+fi
+if ! is_non_empty "$approval_ref"; then
+  die "--approval-ref is required"
+fi
+if ! is_non_empty "$rationale"; then
+  die "--rationale is required"
+fi
+if ! is_non_empty "$review_by"; then
+  die "--review-by is required"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+registry_script="${OPS_MANAGER_FLEET_REGISTRY_SCRIPT:-$script_dir/ops-manager-fleet-registry.sh}"
+
+if [[ -z "$registry_file" ]]; then
+  registry_file="$repo/.superloop/ops-manager/fleet/registry.v1.json"
+fi
+if [[ -z "$promotion_state_file" ]]; then
+  promotion_state_file="$repo/.superloop/ops-manager/fleet/promotion-state.json"
+fi
+if [[ -z "$apply_state_file" ]]; then
+  apply_state_file="$repo/.superloop/ops-manager/fleet/promotion-apply-state.json"
+fi
+if [[ -z "$apply_telemetry_file" ]]; then
+  apply_telemetry_file="$repo/.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl"
+fi
+
+if [[ -z "$trace_id" && -n "${OPS_MANAGER_TRACE_ID:-}" ]]; then
+  trace_id="$OPS_MANAGER_TRACE_ID"
+fi
+if [[ -z "$trace_id" ]]; then
+  trace_id="$(generate_trace_id)"
+fi
+
+mkdir -p "$(dirname "$apply_state_file")"
+mkdir -p "$(dirname "$apply_telemetry_file")"
+
+[[ -f "$promotion_state_file" ]] || die "promotion state file not found: $promotion_state_file"
+promotion_state_json="$(jq -c '.' "$promotion_state_file" 2>/dev/null)" || die "invalid promotion state JSON: $promotion_state_file"
+
+promotion_decision="$(jq -r '.summary.decision // empty' <<<"$promotion_state_json")"
+if [[ -z "$promotion_decision" ]]; then
+  die "promotion state missing summary.decision"
+fi
+
+if [[ "$intent" != "rollback" && "$promotion_decision" != "promote" ]]; then
+  die "intent $intent requires promotion decision promote (found: $promotion_decision)"
+fi
+
+# validate review-by upfront for better operator feedback before mutation
+if ! jq -en --arg review_by "$review_by" '($review_by | fromdateiso8601?) != null' >/dev/null 2>&1; then
+  die "--review-by must be an ISO-8601 timestamp"
+fi
+if ! jq -en --arg review_by "$review_by" --arg now "$(timestamp)" '($review_by | fromdateiso8601) > ($now | fromdateiso8601)' >/dev/null 2>&1; then
+  die "--review-by must be in the future"
+fi
+
+if [[ -n "$idempotency_key" && -f "$apply_telemetry_file" ]]; then
+  prior_record="$(jq -cs --arg key "$idempotency_key" '[.[] | select((.idempotencyKey // "") == $key)] | last // empty' "$apply_telemetry_file" 2>/dev/null || true)"
+  if [[ -n "$prior_record" ]]; then
+    replay_json="$(jq -c '. + {replayed: true}' <<<"$prior_record")"
+    jq -c '.' <<<"$replay_json" > "$apply_state_file"
+    if [[ "$pretty" == "1" ]]; then
+      jq '.' <<<"$replay_json"
+    else
+      jq -c '.' <<<"$replay_json"
+    fi
+    exit 0
+  fi
+fi
+
+registry_json="$($registry_script --repo "$repo" --registry-file "$registry_file")" || die "failed to read/validate fleet registry"
+
+mode="$(jq -r '.policy.mode // "advisory"' <<<"$registry_json")"
+if [[ "$mode" != "guarded_auto" ]]; then
+  die "promotion apply requires policy.mode guarded_auto"
+fi
+
+changed_at="$(timestamp)"
+
+mutated_registry_json=$(jq -cn \
+  --argjson registry "$registry_json" \
+  --arg intent "$intent" \
+  --argjson expand_step "$expand_step" \
+  --arg actor "$actor" \
+  --arg approval_ref "$approval_ref" \
+  --arg rationale "$rationale" \
+  --arg changed_at "$changed_at" \
+  --arg review_by "$review_by" \
+  '
+  ($registry.policy.autonomous.rollout.canaryPercent // 100) as $canary_before
+  | ($registry.policy.autonomous.rollout.pause.manual // false) as $manual_before
+  | (
+      if $intent == "expand" then
+        ($canary_before + $expand_step | if . > 100 then 100 else . end)
+      else
+        $canary_before
+      end
+    ) as $canary_after
+  | (
+      if $intent == "rollback" then true else false end
+    ) as $manual_after
+  | ($registry
+      | .policy.autonomous.rollout.canaryPercent = $canary_after
+      | .policy.autonomous.rollout.pause.manual = $manual_after
+      | .policy.autonomous.governance.actor = $actor
+      | .policy.autonomous.governance.approvalRef = $approval_ref
+      | .policy.autonomous.governance.rationale = $rationale
+      | .policy.autonomous.governance.changedAt = $changed_at
+      | .policy.autonomous.governance.reviewBy = $review_by
+    )
+  ')
+
+# Validate mutated registry through canonical registry script, then persist normalized output.
+tmp_registry="$(mktemp)"
+trap 'rm -f "$tmp_registry"' EXIT
+jq -c '.' <<<"$mutated_registry_json" > "$tmp_registry"
+normalized_registry_json="$($registry_script --repo "$repo" --registry-file "$tmp_registry")" || die "mutated registry failed validation"
+
+before_canary="$(jq -r '.policy.autonomous.rollout.canaryPercent // 100' <<<"$registry_json")"
+after_canary="$(jq -r '.policy.autonomous.rollout.canaryPercent // 100' <<<"$normalized_registry_json")"
+before_manual="$(jq -r '.policy.autonomous.rollout.pause.manual // false' <<<"$registry_json")"
+after_manual="$(jq -r '.policy.autonomous.rollout.pause.manual // false' <<<"$normalized_registry_json")"
+fleet_id="$(jq -r '.fleetId // "default"' <<<"$normalized_registry_json")"
+
+printf '%s\n' "$normalized_registry_json" > "$registry_file"
+
+apply_record_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$changed_at" \
+  --arg fleet_id "$fleet_id" \
+  --arg trace_id "$trace_id" \
+  --arg idempotency_key "$idempotency_key" \
+  --arg intent "$intent" \
+  --arg decision "$promotion_decision" \
+  --arg actor "$actor" \
+  --arg approval_ref "$approval_ref" \
+  --arg rationale "$rationale" \
+  --arg review_by "$review_by" \
+  --arg changed_at "$changed_at" \
+  --arg registry_file "$registry_file" \
+  --arg promotion_state_file "$promotion_state_file" \
+  --arg apply_state_file "$apply_state_file" \
+  --arg apply_telemetry_file "$apply_telemetry_file" \
+  --argjson before_canary "$before_canary" \
+  --argjson after_canary "$after_canary" \
+  --argjson before_manual "$before_manual" \
+  --argjson after_manual "$after_manual" \
+  '{
+    schemaVersion: $schema_version,
+    timestamp: $timestamp,
+    category: "promotion_apply",
+    fleetId: $fleet_id,
+    traceId: $trace_id,
+    idempotencyKey: (if ($idempotency_key | length) > 0 then $idempotency_key else null end),
+    status: "applied",
+    intent: $intent,
+    decision: $decision,
+    governance: {
+      actor: $actor,
+      approvalRef: $approval_ref,
+      rationale: $rationale,
+      changedAt: $changed_at,
+      reviewBy: $review_by
+    },
+    rollout: {
+      before: {
+        canaryPercent: $before_canary,
+        manualPause: $before_manual
+      },
+      after: {
+        canaryPercent: $after_canary,
+        manualPause: $after_manual
+      },
+      changed: {
+        canaryPercent: ($before_canary != $after_canary),
+        manualPause: ($before_manual != $after_manual)
+      }
+    },
+    files: {
+      registryFile: $registry_file,
+      promotionStateFile: $promotion_state_file,
+      applyStateFile: $apply_state_file,
+      applyTelemetryFile: $apply_telemetry_file
+    },
+    reasonCodes: []
+  }')
+
+jq -c '.' <<<"$apply_record_json" > "$apply_state_file"
+jq -c '.' <<<"$apply_record_json" >> "$apply_telemetry_file"
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$apply_record_json"
+else
+  jq -c '.' <<<"$apply_record_json"
+fi

--- a/tests/ops-manager-promotion-apply.bats
+++ b/tests/ops-manager-promotion-apply.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+write_registry_guarded_auto() {
+  local repo="$1"
+  local canary_percent="$2"
+  local manual_pause="$3"
+
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  cat > "$repo/.superloop/ops-manager/fleet/registry.v1.json" <<JSON
+{
+  "schemaVersion": "v1",
+  "fleetId": "fleet-phase11",
+  "loops": [
+    {"loopId": "loop-a", "transport": "local"},
+    {"loopId": "loop-b", "transport": "local"}
+  ],
+  "policy": {
+    "mode": "guarded_auto",
+    "autonomous": {
+      "governance": {
+        "actor": "ops-initial",
+        "approvalRef": "CAB-0",
+        "rationale": "initial",
+        "changedAt": "2026-02-23T00:00:00Z",
+        "reviewBy": "2099-01-01T00:00:00Z"
+      },
+      "rollout": {
+        "canaryPercent": $canary_percent,
+        "pause": {
+          "manual": $manual_pause
+        }
+      }
+    }
+  }
+}
+JSON
+}
+
+write_promotion_state() {
+  local repo="$1"
+  local decision="$2"
+
+  mkdir -p "$repo/.superloop/ops-manager/fleet"
+
+  cat > "$repo/.superloop/ops-manager/fleet/promotion-state.json" <<JSON
+{
+  "schemaVersion": "v1",
+  "summary": {
+    "decision": "$decision",
+    "reasonCodes": []
+  }
+}
+JSON
+}
+
+@test "promotion apply expand mutates canary and clears manual pause on promote decision" {
+  local repo="$TEMP_DIR/repo-expand"
+  write_registry_guarded_auto "$repo" 25 true
+  write_promotion_state "$repo" promote
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent expand \
+    --expand-step 25 \
+    --by ops-user \
+    --approval-ref CAB-111 \
+    --rationale "phase11-expand" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.rollout.after.canaryPercent' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "50" ]
+
+  run jq -r '.rollout.after.manualPause' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.policy.autonomous.rollout.canaryPercent' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "50" ]
+
+  run jq -r '.policy.autonomous.rollout.pause.manual' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.policy.autonomous.governance.actor' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ops-user" ]
+
+  [ -f "$repo/.superloop/ops-manager/fleet/promotion-apply-state.json" ]
+  [ -f "$repo/.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl" ]
+
+  run bash -lc "wc -l < '$repo/.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "promotion apply expand fails when promotion decision is hold" {
+  local repo="$TEMP_DIR/repo-expand-hold"
+  write_registry_guarded_auto "$repo" 25 false
+  write_promotion_state "$repo" hold
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent expand \
+    --expand-step 10 \
+    --by ops-user \
+    --approval-ref CAB-112 \
+    --rationale "phase11-expand-hold" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"intent expand requires promotion decision promote"* ]]
+}
+
+@test "promotion apply rollback is safety-allowed on hold decision and sets manual pause true" {
+  local repo="$TEMP_DIR/repo-rollback"
+  write_registry_guarded_auto "$repo" 70 false
+  write_promotion_state "$repo" hold
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent rollback \
+    --by ops-user \
+    --approval-ref CAB-113 \
+    --rationale "phase11-rollback" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.rollout.after.manualPause' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.rollout.after.canaryPercent' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "70" ]
+
+  run jq -r '.policy.autonomous.rollout.pause.manual' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "promotion apply requires governance mutation metadata" {
+  local repo="$TEMP_DIR/repo-governance-required"
+  write_registry_guarded_auto "$repo" 25 false
+  write_promotion_state "$repo" promote
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent resume \
+    --approval-ref CAB-114 \
+    --rationale "phase11-resume" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--by is required"* ]]
+}
+
+@test "promotion apply idempotency replay does not re-mutate or append telemetry" {
+  local repo="$TEMP_DIR/repo-idempotency"
+  write_registry_guarded_auto "$repo" 40 true
+  write_promotion_state "$repo" promote
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent expand \
+    --expand-step 20 \
+    --idempotency-key replay-key-1 \
+    --by ops-user \
+    --approval-ref CAB-115 \
+    --rationale "phase11-idempotent-expand" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.policy.autonomous.rollout.canaryPercent' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "60" ]
+
+  run "$PROJECT_ROOT/scripts/ops-manager-promotion-apply.sh" \
+    --repo "$repo" \
+    --intent expand \
+    --expand-step 30 \
+    --idempotency-key replay-key-1 \
+    --by ops-user \
+    --approval-ref CAB-116 \
+    --rationale "phase11-idempotent-expand-retry" \
+    --review-by "2099-01-01T00:00:00Z"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.replayed' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.policy.autonomous.rollout.canaryPercent' "$repo/.superloop/ops-manager/fleet/registry.v1.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "60" ]
+
+  run bash -lc "wc -l < '$repo/.superloop/ops-manager/fleet/telemetry/promotion-apply.jsonl'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}


### PR DESCRIPTION
## Summary
- add Phase 11 initiation packet and Phase 1 checklist for promotion-to-rollout coupling
- add `scripts/ops-manager-promotion-apply.sh` with governed rollout mutation intents (`expand`, `resume`, `rollback`)
- enforce decision gating (`expand`/`resume` require `promote`; `rollback` safety-allowed), governance metadata, registry revalidation, and idempotent replay
- persist apply state and append-only apply telemetry artifacts
- add `tests/ops-manager-promotion-apply.bats` coverage for success/failure/idempotency pathways
- update `docs/ops-manager-v0.md` and `docs/ops-manager-runbook.md` with apply command + artifact workflow

## Validation
- `bash -n scripts/ops-manager-promotion-apply.sh scripts/ops-manager-promotion-gates.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-apply.bats tests/ops-manager-promotion-gates.bats`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-apply.bats tests/ops-manager-promotion-gates.bats tests/ops-manager-fleet.bats`

Refs #101
