### PR TITLE
feat: phase 11 p2 promotion rollout orchestration workflow

### DIFF
--- a/.github/workflows/ops-manager-promotion-rollout.yml
+++ b/.github/workflows/ops-manager-promotion-rollout.yml
@@ -1,0 +1,193 @@
+name: Ops Manager Promotion Rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_path:
+        description: Repository path containing .superloop ops-manager artifacts
+        required: false
+        default: .
+      mode:
+        description: Orchestration mode
+        type: choice
+        required: true
+        default: dry_run
+        options:
+          - dry_run
+          - apply
+          - rollback
+      apply_intent:
+        description: Apply intent used when mode=apply
+        type: choice
+        required: false
+        default: expand
+        options:
+          - expand
+          - resume
+      expand_step:
+        description: Expand step percentage (mode=apply and apply_intent=expand)
+        required: false
+        default: "25"
+      skip_on_missing_evidence:
+        description: Skip with success when promotion evidence files are missing
+        type: boolean
+        required: false
+        default: true
+      fail_on_hold:
+        description: Fail orchestration when promotion decision is hold
+        type: boolean
+        required: false
+        default: false
+      window_executions:
+        description: Window size for autonomous execution reliability gate
+        required: false
+        default: "20"
+      min_sample_size:
+        description: Minimum autonomous sample size required for promotion
+        required: false
+        default: "20"
+      max_ambiguity_rate:
+        description: Maximum ambiguity rate threshold
+        required: false
+        default: "0.2"
+      max_failure_rate:
+        description: Maximum failure rate threshold
+        required: false
+        default: "0.2"
+      max_manual_backlog:
+        description: Maximum manual backlog threshold
+        required: false
+        default: "5"
+      max_drill_age_hours:
+        description: Maximum drill evidence age in hours
+        required: false
+        default: "168"
+      idempotency_key:
+        description: Optional idempotency key for apply/rollback mutation replay protection
+        required: false
+        default: ""
+      trace_id:
+        description: Optional trace id forwarded across promotion CI and apply
+        required: false
+        default: ""
+      by:
+        description: Governance actor identity (required for apply/rollback)
+        required: false
+        default: ""
+      approval_ref:
+        description: Governance approval/change reference (required for apply/rollback)
+        required: false
+        default: ""
+      rationale:
+        description: Governance rationale (required for apply/rollback)
+        required: false
+        default: ""
+      review_by:
+        description: Governance review deadline ISO-8601 (required for apply/rollback)
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ops-manager-promotion-rollout-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  promotion-rollout:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Orchestrate promotion rollout transition
+        env:
+          INPUT_REPO_PATH: ${{ github.event_name == 'workflow_dispatch' && inputs.repo_path || '.' }}
+          INPUT_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'dry_run' }}
+          INPUT_APPLY_INTENT: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_intent || 'expand' }}
+          INPUT_EXPAND_STEP: ${{ github.event_name == 'workflow_dispatch' && inputs.expand_step || '25' }}
+          INPUT_SKIP_MISSING: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_on_missing_evidence || 'true' }}
+          INPUT_FAIL_ON_HOLD: ${{ github.event_name == 'workflow_dispatch' && inputs.fail_on_hold || 'false' }}
+          INPUT_WINDOW_EXECUTIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.window_executions || '20' }}
+          INPUT_MIN_SAMPLE_SIZE: ${{ github.event_name == 'workflow_dispatch' && inputs.min_sample_size || '20' }}
+          INPUT_MAX_AMBIGUITY_RATE: ${{ github.event_name == 'workflow_dispatch' && inputs.max_ambiguity_rate || '0.2' }}
+          INPUT_MAX_FAILURE_RATE: ${{ github.event_name == 'workflow_dispatch' && inputs.max_failure_rate || '0.2' }}
+          INPUT_MAX_MANUAL_BACKLOG: ${{ github.event_name == 'workflow_dispatch' && inputs.max_manual_backlog || '5' }}
+          INPUT_MAX_DRILL_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_drill_age_hours || '168' }}
+          INPUT_IDEMPOTENCY_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.idempotency_key || '' }}
+          INPUT_TRACE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.trace_id || '' }}
+          INPUT_BY: ${{ github.event_name == 'workflow_dispatch' && inputs.by || '' }}
+          INPUT_APPROVAL_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.approval_ref || '' }}
+          INPUT_RATIONALE: ${{ github.event_name == 'workflow_dispatch' && inputs.rationale || '' }}
+          INPUT_REVIEW_BY: ${{ github.event_name == 'workflow_dispatch' && inputs.review_by || '' }}
+        run: |
+          set -euo pipefail
+
+          cmd=(
+            scripts/ops-manager-promotion-orchestrate.sh
+            --repo "${INPUT_REPO_PATH}"
+            --mode "${INPUT_MODE}"
+            --apply-intent "${INPUT_APPLY_INTENT}"
+            --expand-step "${INPUT_EXPAND_STEP}"
+            --window-executions "${INPUT_WINDOW_EXECUTIONS}"
+            --min-sample-size "${INPUT_MIN_SAMPLE_SIZE}"
+            --max-ambiguity-rate "${INPUT_MAX_AMBIGUITY_RATE}"
+            --max-failure-rate "${INPUT_MAX_FAILURE_RATE}"
+            --max-manual-backlog "${INPUT_MAX_MANUAL_BACKLOG}"
+            --max-drill-age-hours "${INPUT_MAX_DRILL_AGE_HOURS}"
+            --promotion-ci-result-file .superloop/ops-manager/fleet/promotion-ci-result.json
+            --promotion-ci-summary-file .superloop/ops-manager/fleet/promotion-ci-summary.md
+            --result-file .superloop/ops-manager/fleet/promotion-orchestrate-result.json
+            --summary-file .superloop/ops-manager/fleet/promotion-orchestrate-summary.md
+            --pretty
+          )
+
+          if [ "${INPUT_SKIP_MISSING}" = "true" ]; then
+            cmd+=(--skip-on-missing-evidence)
+          fi
+          if [ "${INPUT_FAIL_ON_HOLD}" = "true" ]; then
+            cmd+=(--fail-on-hold)
+          fi
+          if [ -n "${INPUT_TRACE_ID}" ]; then
+            cmd+=(--trace-id "${INPUT_TRACE_ID}")
+          fi
+          if [ -n "${INPUT_IDEMPOTENCY_KEY}" ]; then
+            cmd+=(--idempotency-key "${INPUT_IDEMPOTENCY_KEY}")
+          fi
+
+          if [ "${INPUT_MODE}" != "dry_run" ]; then
+            [ -n "${INPUT_BY}" ] || { echo "::error::input 'by' is required for mode=${INPUT_MODE}"; exit 1; }
+            [ -n "${INPUT_APPROVAL_REF}" ] || { echo "::error::input 'approval_ref' is required for mode=${INPUT_MODE}"; exit 1; }
+            [ -n "${INPUT_RATIONALE}" ] || { echo "::error::input 'rationale' is required for mode=${INPUT_MODE}"; exit 1; }
+            [ -n "${INPUT_REVIEW_BY}" ] || { echo "::error::input 'review_by' is required for mode=${INPUT_MODE}"; exit 1; }
+
+            cmd+=(
+              --by "${INPUT_BY}"
+              --approval-ref "${INPUT_APPROVAL_REF}"
+              --rationale "${INPUT_RATIONALE}"
+              --review-by "${INPUT_REVIEW_BY}"
+            )
+          fi
+
+          "${cmd[@]}"
+
+      - name: Show promotion rollout artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          for path in \
+            .superloop/ops-manager/fleet/promotion-orchestrate-result.json \
+            .superloop/ops-manager/fleet/promotion-orchestrate-summary.md \
+            .superloop/ops-manager/fleet/promotion-ci-result.json \
+            .superloop/ops-manager/fleet/promotion-ci-summary.md
+          do
+            if [ -f "$path" ]; then
+              echo "--- $path ---"
+              cat "$path"
+            else
+              echo "$path not found"
+            fi
+          done

--- a/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/tasks/PHASE_2.MD
+++ b/feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/tasks/PHASE_2.MD
@@ -1,0 +1,32 @@
+# Phase 2 - Promotion Rollout Orchestration Workflow
+
+## P2.0 Feature Baseline and Scope Discipline
+1. [x] Confirm `feat/ops-manager-superloop-sprites/phase-11-promotion-rollout-coupling-initiation/PLAN.MD` phase-2 scope aligns with merged phase-1 outcomes.
+2. [x] Attach this phase file to scope authority issue (`https://github.com/Supergent/superloop/issues/103`).
+3. [x] Link this phase packet from the issue and include prior PR context (`#102`).
+
+## P2.1 Orchestration Wrapper Command
+1. [x] Add `scripts/ops-manager-promotion-orchestrate.sh` supporting `--mode dry_run|apply|rollback`.
+2. [x] Run promotion decision evaluation via `scripts/ops-manager-promotion-ci.sh` and persist orchestration result artifacts.
+3. [x] For apply/rollback modes, invoke `scripts/ops-manager-promotion-apply.sh` with deterministic argument forwarding and governance checks.
+4. [x] Support idempotency/trace forwarding and fail-closed behavior on invalid mode/intent combinations.
+
+## P2.2 Workflow Integration
+1. [x] Add `.github/workflows/ops-manager-promotion-rollout.yml` with `workflow_dispatch` inputs for dry-run/apply/rollback orchestration.
+2. [x] Wire workflow inputs to orchestration wrapper flags (mode, intent, thresholds, governance metadata).
+3. [x] Emit operator-visible result artifacts (`promotion-orchestrate-result.json`, markdown summary) in workflow logs/summary.
+
+## P2.3 Test Coverage
+1. [x] Add `tests/ops-manager-promotion-orchestrate.bats` covering dry-run preview, apply success, rollback success, and governance-failure paths.
+2. [x] Add regression coverage for decision gating propagation (`apply` blocked when decision is not `promote`).
+3. [x] Keep promotion CI/apply suites green (`tests/ops-manager-promotion-ci.bats`, `tests/ops-manager-promotion-apply.bats`).
+
+## P2.4 Docs and Runbook
+1. [x] Update `docs/ops-manager-v0.md` with orchestration command + workflow contract.
+2. [x] Update `docs/ops-manager-runbook.md` with operator runbook for dry-run/apply/rollback orchestration.
+3. [x] Document artifact paths and triage semantics for orchestration-level failures.
+
+## P2.V Validation
+1. [x] `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-orchestrate.bats tests/ops-manager-promotion-ci.bats tests/ops-manager-promotion-apply.bats` passes.
+2. [x] All new/changed scripts pass `bash -n` syntax checks.
+3. [x] Workflow YAML and docs reflect implemented orchestration behavior.

--- a/scripts/ops-manager-promotion-orchestrate.sh
+++ b/scripts/ops-manager-promotion-orchestrate.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops-manager-promotion-orchestrate.sh --repo <path> --mode <dry_run|apply|rollback> [options]
+
+Options:
+  --mode <dry_run|apply|rollback>  Orchestration mode.
+  --apply-intent <expand|resume>   Apply intent when mode=apply (default: expand).
+  --expand-step <n>                Expand step for apply intent=expand (default: 25).
+  --repo <path>                    Repository path.
+
+  --fleet-status-file <path>       Promotion CI input override.
+  --handoff-telemetry-file <path>  Promotion CI input override.
+  --drill-state-file <path>        Promotion CI input override.
+  --window-executions <n>          Promotion CI threshold override.
+  --min-sample-size <n>            Promotion CI threshold override.
+  --max-ambiguity-rate <0..1>      Promotion CI threshold override.
+  --max-failure-rate <0..1>        Promotion CI threshold override.
+  --max-manual-backlog <n>         Promotion CI threshold override.
+  --max-drill-age-hours <n>        Promotion CI threshold override.
+  --skip-on-missing-evidence       Forwarded to promotion CI evaluator.
+  --fail-on-hold                   Forwarded to promotion CI evaluator.
+
+  --promotion-ci-result-file <path>  Promotion CI JSON result path.
+  --promotion-ci-summary-file <path> Promotion CI markdown summary path.
+  --result-file <path>               Orchestration JSON result path.
+  --summary-file <path>              Orchestration markdown summary path.
+
+  --idempotency-key <key>          Forwarded to promotion apply.
+  --trace-id <id>                  Forwarded to promotion CI/apply.
+  --by <actor>                     Governance actor for apply/rollback.
+  --approval-ref <id>              Governance approval reference for apply/rollback.
+  --rationale <text>               Governance rationale for apply/rollback.
+  --review-by <iso8601>            Governance review deadline for apply/rollback.
+
+  --pretty                         Pretty-print JSON output.
+  --help                           Show this help message.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing required command: $cmd"
+  fi
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+repo=""
+mode=""
+apply_intent="expand"
+expand_step="25"
+
+fleet_status_file=""
+handoff_telemetry_file=""
+drill_state_file=""
+window_executions=""
+min_sample_size=""
+max_ambiguity_rate=""
+max_failure_rate=""
+max_manual_backlog=""
+max_drill_age_hours=""
+skip_on_missing_evidence="0"
+fail_on_hold="0"
+
+promotion_ci_result_file=""
+promotion_ci_summary_file=""
+result_file=""
+summary_file=""
+
+idempotency_key=""
+trace_id=""
+actor=""
+approval_ref=""
+rationale=""
+review_by=""
+pretty="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --apply-intent)
+      apply_intent="${2:-}"
+      shift 2
+      ;;
+    --expand-step)
+      expand_step="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+
+    --fleet-status-file)
+      fleet_status_file="${2:-}"
+      shift 2
+      ;;
+    --handoff-telemetry-file)
+      handoff_telemetry_file="${2:-}"
+      shift 2
+      ;;
+    --drill-state-file)
+      drill_state_file="${2:-}"
+      shift 2
+      ;;
+    --window-executions)
+      window_executions="${2:-}"
+      shift 2
+      ;;
+    --min-sample-size)
+      min_sample_size="${2:-}"
+      shift 2
+      ;;
+    --max-ambiguity-rate)
+      max_ambiguity_rate="${2:-}"
+      shift 2
+      ;;
+    --max-failure-rate)
+      max_failure_rate="${2:-}"
+      shift 2
+      ;;
+    --max-manual-backlog)
+      max_manual_backlog="${2:-}"
+      shift 2
+      ;;
+    --max-drill-age-hours)
+      max_drill_age_hours="${2:-}"
+      shift 2
+      ;;
+    --skip-on-missing-evidence)
+      skip_on_missing_evidence="1"
+      shift
+      ;;
+    --fail-on-hold)
+      fail_on_hold="1"
+      shift
+      ;;
+
+    --promotion-ci-result-file)
+      promotion_ci_result_file="${2:-}"
+      shift 2
+      ;;
+    --promotion-ci-summary-file)
+      promotion_ci_summary_file="${2:-}"
+      shift 2
+      ;;
+    --result-file)
+      result_file="${2:-}"
+      shift 2
+      ;;
+    --summary-file)
+      summary_file="${2:-}"
+      shift 2
+      ;;
+
+    --idempotency-key)
+      idempotency_key="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --by)
+      actor="${2:-}"
+      shift 2
+      ;;
+    --approval-ref)
+      approval_ref="${2:-}"
+      shift 2
+      ;;
+    --rationale)
+      rationale="${2:-}"
+      shift 2
+      ;;
+    --review-by)
+      review_by="${2:-}"
+      shift 2
+      ;;
+
+    --pretty)
+      pretty="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+if [[ -z "$repo" ]]; then
+  die "--repo is required"
+fi
+if [[ "$mode" != "dry_run" && "$mode" != "apply" && "$mode" != "rollback" ]]; then
+  die "--mode must be one of dry_run, apply, rollback"
+fi
+if [[ "$apply_intent" != "expand" && "$apply_intent" != "resume" ]]; then
+  die "--apply-intent must be one of expand, resume"
+fi
+if ! [[ "$expand_step" =~ ^[0-9]+$ ]] || (( expand_step < 1 )) || (( expand_step > 100 )); then
+  die "--expand-step must be an integer between 1 and 100"
+fi
+
+if [[ "$mode" == "apply" || "$mode" == "rollback" ]]; then
+  [[ -n "$actor" ]] || die "--by is required for mode $mode"
+  [[ -n "$approval_ref" ]] || die "--approval-ref is required for mode $mode"
+  [[ -n "$rationale" ]] || die "--rationale is required for mode $mode"
+  [[ -n "$review_by" ]] || die "--review-by is required for mode $mode"
+fi
+
+repo="$(cd "$repo" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+promotion_ci_script="${OPS_MANAGER_PROMOTION_CI_SCRIPT:-$script_dir/ops-manager-promotion-ci.sh}"
+promotion_apply_script="${OPS_MANAGER_PROMOTION_APPLY_SCRIPT:-$script_dir/ops-manager-promotion-apply.sh}"
+
+if [[ -z "$promotion_ci_result_file" ]]; then
+  promotion_ci_result_file="$repo/.superloop/ops-manager/fleet/promotion-ci-result.json"
+fi
+if [[ -z "$promotion_ci_summary_file" ]]; then
+  promotion_ci_summary_file="$repo/.superloop/ops-manager/fleet/promotion-ci-summary.md"
+fi
+if [[ -z "$result_file" ]]; then
+  result_file="$repo/.superloop/ops-manager/fleet/promotion-orchestrate-result.json"
+fi
+if [[ -z "$summary_file" ]]; then
+  summary_file="$repo/.superloop/ops-manager/fleet/promotion-orchestrate-summary.md"
+fi
+
+mkdir -p "$(dirname "$result_file")"
+mkdir -p "$(dirname "$summary_file")"
+
+ci_cmd=("$promotion_ci_script" --repo "$repo" --result-file "$promotion_ci_result_file" --summary-file "$promotion_ci_summary_file")
+if [[ -n "$fleet_status_file" ]]; then
+  ci_cmd+=(--fleet-status-file "$fleet_status_file")
+fi
+if [[ -n "$handoff_telemetry_file" ]]; then
+  ci_cmd+=(--handoff-telemetry-file "$handoff_telemetry_file")
+fi
+if [[ -n "$drill_state_file" ]]; then
+  ci_cmd+=(--drill-state-file "$drill_state_file")
+fi
+if [[ -n "$window_executions" ]]; then
+  ci_cmd+=(--window-executions "$window_executions")
+fi
+if [[ -n "$min_sample_size" ]]; then
+  ci_cmd+=(--min-sample-size "$min_sample_size")
+fi
+if [[ -n "$max_ambiguity_rate" ]]; then
+  ci_cmd+=(--max-ambiguity-rate "$max_ambiguity_rate")
+fi
+if [[ -n "$max_failure_rate" ]]; then
+  ci_cmd+=(--max-failure-rate "$max_failure_rate")
+fi
+if [[ -n "$max_manual_backlog" ]]; then
+  ci_cmd+=(--max-manual-backlog "$max_manual_backlog")
+fi
+if [[ -n "$max_drill_age_hours" ]]; then
+  ci_cmd+=(--max-drill-age-hours "$max_drill_age_hours")
+fi
+if [[ "$skip_on_missing_evidence" == "1" ]]; then
+  ci_cmd+=(--skip-on-missing-evidence)
+fi
+if [[ "$fail_on_hold" == "1" ]]; then
+  ci_cmd+=(--fail-on-hold)
+fi
+if [[ -n "$trace_id" ]]; then
+  ci_cmd+=(--trace-id "$trace_id")
+fi
+
+set +e
+ci_output="$(${ci_cmd[@]} 2>&1)"
+ci_status=$?
+set -e
+
+if [[ "$ci_status" -ne 0 ]]; then
+  printf '%s\n' "$ci_output" >&2
+  exit "$ci_status"
+fi
+
+[[ -f "$promotion_ci_result_file" ]] || die "promotion CI result file not found: $promotion_ci_result_file"
+ci_result_json="$(jq -c '.' "$promotion_ci_result_file" 2>/dev/null)" || die "invalid promotion CI result JSON: $promotion_ci_result_file"
+
+decision="$(jq -r '.summary.decision // "unknown"' <<<"$ci_result_json")"
+failed_gates_csv="$(jq -r '(.summary.failedGates // []) | join(", ")' <<<"$ci_result_json")"
+reason_codes_csv="$(jq -r '(.summary.reasonCodes // []) | join(", ")' <<<"$ci_result_json")"
+
+action_status="preview"
+apply_executed="false"
+apply_intent_effective="null"
+apply_record_json="null"
+
+if [[ "$mode" == "apply" || "$mode" == "rollback" ]]; then
+  apply_cmd=("$promotion_apply_script" --repo "$repo" --promotion-state-file "$promotion_ci_result_file" --intent "$([ "$mode" = "apply" ] && printf '%s' "$apply_intent" || printf 'rollback')" --by "$actor" --approval-ref "$approval_ref" --rationale "$rationale" --review-by "$review_by")
+  if [[ "$mode" == "apply" && "$apply_intent" == "expand" ]]; then
+    apply_cmd+=(--expand-step "$expand_step")
+  fi
+  if [[ -n "$idempotency_key" ]]; then
+    apply_cmd+=(--idempotency-key "$idempotency_key")
+  fi
+  if [[ -n "$trace_id" ]]; then
+    apply_cmd+=(--trace-id "$trace_id")
+  fi
+
+  set +e
+  apply_output="$(${apply_cmd[@]} 2>&1)"
+  apply_status=$?
+  set -e
+  if [[ "$apply_status" -ne 0 ]]; then
+    printf '%s\n' "$apply_output" >&2
+    exit "$apply_status"
+  fi
+
+  apply_record_json="$(jq -c '.' <<<"$apply_output" 2>/dev/null)" || die "promotion apply output was not valid JSON"
+  apply_executed="true"
+  apply_intent_effective="$(jq -r '.intent // empty' <<<"$apply_record_json")"
+  if [[ "$mode" == "rollback" ]]; then
+    action_status="rolled_back"
+  else
+    action_status="applied"
+  fi
+fi
+
+orchestrate_json=$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$(timestamp)" \
+  --arg mode "$mode" \
+  --arg status "$action_status" \
+  --arg decision "$decision" \
+  --arg result_file "$result_file" \
+  --arg summary_file "$summary_file" \
+  --arg promotion_ci_result_file "$promotion_ci_result_file" \
+  --arg promotion_ci_summary_file "$promotion_ci_summary_file" \
+  --arg failed_gates_csv "$failed_gates_csv" \
+  --arg reason_codes_csv "$reason_codes_csv" \
+  --argjson ci_result "$ci_result_json" \
+  --argjson apply_record "$apply_record_json" \
+  --argjson apply_executed "$apply_executed" \
+  --arg apply_intent_effective "$apply_intent_effective" \
+  --arg idempotency_key "$idempotency_key" \
+  '{
+    schemaVersion: $schema_version,
+    timestamp: $timestamp,
+    mode: $mode,
+    status: $status,
+    decision: $decision,
+    summary: {
+      failedGates: ($ci_result.summary.failedGates // []),
+      reasonCodes: ($ci_result.summary.reasonCodes // [])
+    },
+    apply: {
+      executed: $apply_executed,
+      intent: (if $apply_intent_effective == "" or $apply_intent_effective == "null" then null else $apply_intent_effective end),
+      idempotencyKey: (if ($idempotency_key | length) > 0 then $idempotency_key else null end),
+      record: (if $apply_executed then $apply_record else null end)
+    },
+    files: {
+      resultFile: $result_file,
+      summaryFile: $summary_file,
+      promotionCiResultFile: $promotion_ci_result_file,
+      promotionCiSummaryFile: $promotion_ci_summary_file
+    }
+  }')
+
+jq -c '.' <<<"$orchestrate_json" > "$result_file"
+
+{
+  echo "## Ops Manager Promotion Orchestration"
+  echo
+  echo "Mode: \`$mode\`"
+  echo
+  echo "Status: \`$action_status\`"
+  echo
+  echo "Promotion decision: \`$decision\`"
+  echo
+  echo "Failed gates: ${failed_gates_csv:-none}"
+  echo
+  echo "Reason codes: ${reason_codes_csv:-none}"
+  if [[ "$apply_executed" == "true" ]]; then
+    echo
+    echo "Apply intent: \`$apply_intent_effective\`"
+  fi
+  echo
+  echo "Result JSON: \`$result_file\`"
+  echo
+  echo "Promotion CI result: \`$promotion_ci_result_file\`"
+} > "$summary_file"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "$pretty" == "1" ]]; then
+  jq '.' <<<"$orchestrate_json"
+else
+  jq -c '.' <<<"$orchestrate_json"
+fi

--- a/tests/ops-manager-promotion-orchestrate.bats
+++ b/tests/ops-manager-promotion-orchestrate.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+
+  PROMOTION_CI_STUB="$TEMP_DIR/promotion-ci-stub.sh"
+  PROMOTION_APPLY_STUB="$TEMP_DIR/promotion-apply-stub.sh"
+  APPLY_LOG="$TEMP_DIR/apply-log.jsonl"
+
+  cat > "$PROMOTION_CI_STUB" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=""
+result_file=""
+summary_file=""
+fail_on_hold="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --result-file)
+      result_file="${2:-}"
+      shift 2
+      ;;
+    --summary-file)
+      summary_file="${2:-}"
+      shift 2
+      ;;
+    --fail-on-hold)
+      fail_on_hold="1"
+      shift
+      ;;
+    --skip-on-missing-evidence)
+      shift
+      ;;
+    --fleet-status-file|--handoff-telemetry-file|--drill-state-file|--window-executions|--min-sample-size|--max-ambiguity-rate|--max-failure-rate|--max-manual-backlog|--max-drill-age-hours|--trace-id)
+      shift 2
+      ;;
+    --pretty)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$repo" ]]
+[[ -n "$result_file" ]]
+[[ -n "$summary_file" ]]
+
+mkdir -p "$(dirname "$result_file")"
+mkdir -p "$(dirname "$summary_file")"
+
+decision="${PROMOTION_STUB_DECISION:-promote}"
+
+cat > "$result_file" <<JSON
+{"schemaVersion":"v1","summary":{"decision":"$decision","failedGates":[],"reasonCodes":[]}}
+JSON
+
+echo "stub summary decision=$decision" > "$summary_file"
+
+echo "{\"summary\":{\"decision\":\"$decision\"}}"
+
+if [[ "$fail_on_hold" == "1" && "$decision" == "hold" ]]; then
+  exit 2
+fi
+
+exit 0
+STUB
+  chmod +x "$PROMOTION_CI_STUB"
+
+  cat > "$PROMOTION_APPLY_STUB" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+intent=""
+promotion_state_file=""
+expand_step=""
+idempotency_key=""
+trace_id=""
+actor=""
+approval_ref=""
+rationale=""
+review_by=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --intent)
+      intent="${2:-}"
+      shift 2
+      ;;
+    --promotion-state-file)
+      promotion_state_file="${2:-}"
+      shift 2
+      ;;
+    --expand-step)
+      expand_step="${2:-}"
+      shift 2
+      ;;
+    --idempotency-key)
+      idempotency_key="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      trace_id="${2:-}"
+      shift 2
+      ;;
+    --by)
+      actor="${2:-}"
+      shift 2
+      ;;
+    --approval-ref)
+      approval_ref="${2:-}"
+      shift 2
+      ;;
+    --rationale)
+      rationale="${2:-}"
+      shift 2
+      ;;
+    --review-by)
+      review_by="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$intent" ]]
+[[ -n "$promotion_state_file" ]]
+
+decision="$(jq -r '.summary.decision // "unknown"' "$promotion_state_file")"
+if [[ "$intent" != "rollback" && "$decision" != "promote" ]]; then
+  echo "intent $intent requires promotion decision promote (found: $decision)" >&2
+  exit 7
+fi
+
+if [[ -n "${APPLY_STUB_LOG:-}" ]]; then
+  jq -cn --arg intent "$intent" --arg decision "$decision" --arg expand_step "$expand_step" --arg idempotency_key "$idempotency_key" --arg trace_id "$trace_id" --arg promotion_state_file "$promotion_state_file" --arg actor "$actor" --arg approval_ref "$approval_ref" --arg rationale "$rationale" --arg review_by "$review_by" '{intent:$intent,decision:$decision,expandStep:$expand_step,idempotencyKey:$idempotency_key,traceId:$trace_id,promotionStateFile:$promotion_state_file,actor:$actor,approvalRef:$approval_ref,rationale:$rationale,reviewBy:$review_by}' >> "$APPLY_STUB_LOG"
+fi
+
+jq -cn --arg intent "$intent" --arg decision "$decision" '{schemaVersion:"v1",status:"applied",intent:$intent,promotionDecision:$decision}'
+STUB
+  chmod +x "$PROMOTION_APPLY_STUB"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+@test "orchestrate dry_run returns preview without executing apply" {
+  local repo="$TEMP_DIR/repo-dry"
+  local result_file="$TEMP_DIR/orchestrate-dry.json"
+  local summary_file="$TEMP_DIR/orchestrate-dry.md"
+  local ci_result_file="$TEMP_DIR/ci-dry.json"
+  local ci_summary_file="$TEMP_DIR/ci-dry.md"
+
+  mkdir -p "$repo"
+
+  run env OPS_MANAGER_PROMOTION_CI_SCRIPT="$PROMOTION_CI_STUB" OPS_MANAGER_PROMOTION_APPLY_SCRIPT="$PROMOTION_APPLY_STUB" APPLY_STUB_LOG="$APPLY_LOG" PROMOTION_STUB_DECISION="hold" \
+    "$PROJECT_ROOT/scripts/ops-manager-promotion-orchestrate.sh" \
+    --repo "$repo" \
+    --mode dry_run \
+    --promotion-ci-result-file "$ci_result_file" \
+    --promotion-ci-summary-file "$ci_summary_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.mode' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dry_run" ]
+
+  run jq -r '.status' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "preview" ]
+
+  run jq -r '.decision' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hold" ]
+
+  run jq -r '.apply.executed' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  [ ! -f "$APPLY_LOG" ]
+}
+
+@test "orchestrate apply executes apply intent and forwards idempotency and trace" {
+  local repo="$TEMP_DIR/repo-apply"
+  local result_file="$TEMP_DIR/orchestrate-apply.json"
+  local summary_file="$TEMP_DIR/orchestrate-apply.md"
+  local ci_result_file="$TEMP_DIR/ci-apply.json"
+  local ci_summary_file="$TEMP_DIR/ci-apply.md"
+
+  mkdir -p "$repo"
+
+  run env OPS_MANAGER_PROMOTION_CI_SCRIPT="$PROMOTION_CI_STUB" OPS_MANAGER_PROMOTION_APPLY_SCRIPT="$PROMOTION_APPLY_STUB" APPLY_STUB_LOG="$APPLY_LOG" PROMOTION_STUB_DECISION="promote" \
+    "$PROJECT_ROOT/scripts/ops-manager-promotion-orchestrate.sh" \
+    --repo "$repo" \
+    --mode apply \
+    --apply-intent expand \
+    --expand-step 30 \
+    --idempotency-key idmp-01 \
+    --trace-id trace-01 \
+    --by ops-user \
+    --approval-ref CAB-201 \
+    --rationale "phase11p2-apply" \
+    --review-by "2099-01-01T00:00:00Z" \
+    --promotion-ci-result-file "$ci_result_file" \
+    --promotion-ci-summary-file "$ci_summary_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.status' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "applied" ]
+
+  run jq -r '.apply.executed' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.apply.intent' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "expand" ]
+
+  run bash -lc "wc -l < '$APPLY_LOG'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.expandStep' "$APPLY_LOG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "30" ]
+
+  run jq -r '.idempotencyKey' "$APPLY_LOG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "idmp-01" ]
+
+  run jq -r '.traceId' "$APPLY_LOG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-01" ]
+}
+
+@test "orchestrate apply propagates decision gating failure when decision is hold" {
+  local repo="$TEMP_DIR/repo-apply-hold"
+  local result_file="$TEMP_DIR/orchestrate-apply-hold.json"
+  local summary_file="$TEMP_DIR/orchestrate-apply-hold.md"
+  local ci_result_file="$TEMP_DIR/ci-apply-hold.json"
+  local ci_summary_file="$TEMP_DIR/ci-apply-hold.md"
+
+  mkdir -p "$repo"
+
+  run env OPS_MANAGER_PROMOTION_CI_SCRIPT="$PROMOTION_CI_STUB" OPS_MANAGER_PROMOTION_APPLY_SCRIPT="$PROMOTION_APPLY_STUB" APPLY_STUB_LOG="$APPLY_LOG" PROMOTION_STUB_DECISION="hold" \
+    "$PROJECT_ROOT/scripts/ops-manager-promotion-orchestrate.sh" \
+    --repo "$repo" \
+    --mode apply \
+    --apply-intent resume \
+    --by ops-user \
+    --approval-ref CAB-202 \
+    --rationale "phase11p2-apply-hold" \
+    --review-by "2099-01-01T00:00:00Z" \
+    --promotion-ci-result-file "$ci_result_file" \
+    --promotion-ci-summary-file "$ci_summary_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires promotion decision promote"* ]]
+}
+
+@test "orchestrate rollback executes rollback intent on hold decision" {
+  local repo="$TEMP_DIR/repo-rollback"
+  local result_file="$TEMP_DIR/orchestrate-rollback.json"
+  local summary_file="$TEMP_DIR/orchestrate-rollback.md"
+  local ci_result_file="$TEMP_DIR/ci-rollback.json"
+  local ci_summary_file="$TEMP_DIR/ci-rollback.md"
+
+  mkdir -p "$repo"
+
+  run env OPS_MANAGER_PROMOTION_CI_SCRIPT="$PROMOTION_CI_STUB" OPS_MANAGER_PROMOTION_APPLY_SCRIPT="$PROMOTION_APPLY_STUB" APPLY_STUB_LOG="$APPLY_LOG" PROMOTION_STUB_DECISION="hold" \
+    "$PROJECT_ROOT/scripts/ops-manager-promotion-orchestrate.sh" \
+    --repo "$repo" \
+    --mode rollback \
+    --by ops-user \
+    --approval-ref CAB-203 \
+    --rationale "phase11p2-rollback" \
+    --review-by "2099-01-01T00:00:00Z" \
+    --promotion-ci-result-file "$ci_result_file" \
+    --promotion-ci-summary-file "$ci_summary_file" \
+    --result-file "$result_file" \
+    --summary-file "$summary_file"
+
+  [ "$status" -eq 0 ]
+
+  run jq -r '.status' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "rolled_back" ]
+
+  run jq -r '.apply.intent' "$result_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "rollback" ]
+
+  run jq -r '.intent' "$APPLY_LOG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "rollback" ]
+}
+
+@test "orchestrate requires governance metadata for apply and rollback modes" {
+  local repo="$TEMP_DIR/repo-governance"
+
+  mkdir -p "$repo"
+
+  run env OPS_MANAGER_PROMOTION_CI_SCRIPT="$PROMOTION_CI_STUB" OPS_MANAGER_PROMOTION_APPLY_SCRIPT="$PROMOTION_APPLY_STUB" \
+    "$PROJECT_ROOT/scripts/ops-manager-promotion-orchestrate.sh" \
+    --repo "$repo" \
+    --mode apply
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--by is required for mode apply"* ]]
+}


### PR DESCRIPTION
## Summary
- add `scripts/ops-manager-promotion-orchestrate.sh` to unify promotion CI evaluation with dry-run/apply/rollback rollout mutations
- add `tests/ops-manager-promotion-orchestrate.bats` covering preview/apply/rollback and governance + decision-gating behavior
- add `.github/workflows/ops-manager-promotion-rollout.yml` dispatch workflow for operator-controlled orchestration with surfaced artifacts
- update contract/runbook docs and complete the Phase 11 P2 task checklist

## Validation
- `bash -n scripts/ops-manager-promotion-orchestrate.sh scripts/ops-manager-promotion-ci.sh scripts/ops-manager-promotion-apply.sh`
- `~/.local/bats-runtime/node_modules/.bin/bats tests/ops-manager-promotion-orchestrate.bats tests/ops-manager-promotion-ci.bats tests/ops-manager-promotion-apply.bats`

Closes #103
