### PR TITLE
feat(horizon): add phase-1 packet runtime and telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Horizon contract files:
 - `schema/horizons.schema.json` (validation schema)
 - `docs/horizon-planning.md` (operating model)
 - `docs/examples/horizons.example.json` (sample)
+- `scripts/horizon-packet.sh` (packet lifecycle runtime for horizon dispatch tracking)
 
 Validate horizon control-plane state (when present):
 
@@ -147,6 +148,28 @@ Loop binding is optional via `horizon_ref`:
 ```
 
 This keeps waterfall tension bounded: horizons are hypotheses that evolve from run evidence.
+
+Packet runtime quick examples:
+
+```bash
+scripts/horizon-packet.sh create \
+  --repo . \
+  --packet-id pkt-001 \
+  --horizon-ref HZ-program-authn-v1 \
+  --sender planner \
+  --recipient-type local_agent \
+  --recipient-id implementer \
+  --intent "implement auth slice"
+```
+
+```bash
+scripts/horizon-packet.sh transition \
+  --repo . \
+  --packet-id pkt-001 \
+  --to-status dispatched \
+  --by dispatcher \
+  --reason "recipient selected"
+```
 
 ## Config
 

--- a/docs/horizon-planning.md
+++ b/docs/horizon-planning.md
@@ -93,6 +93,80 @@ Optional strict schema validation (requires python `jsonschema` module):
 scripts/validate-horizons.sh --repo . --strict
 ```
 
+## Packet runtime (Phase 1)
+
+Use horizon packets for atomic dispatch/work tracking above loop execution.
+
+Command:
+
+```bash
+scripts/horizon-packet.sh <create|transition|show|list> --repo .
+```
+
+Create a packet:
+
+```bash
+scripts/horizon-packet.sh create \
+  --repo . \
+  --packet-id pkt-001 \
+  --horizon-ref HZ-program-authn-v1 \
+  --sender planner \
+  --recipient-type local_agent \
+  --recipient-id implementer \
+  --intent "implement auth slice" \
+  --loop-id auth-loop \
+  --evidence-ref artifact://run-summary
+```
+
+Transition a packet:
+
+```bash
+scripts/horizon-packet.sh transition \
+  --repo . \
+  --packet-id pkt-001 \
+  --to-status dispatched \
+  --by dispatcher \
+  --reason "recipient selected"
+```
+
+List packets:
+
+```bash
+scripts/horizon-packet.sh list --repo . --horizon-ref HZ-program-authn-v1
+```
+
+Status model:
+
+1. `queued`
+2. `dispatched`
+3. `acknowledged`
+4. `in_progress`
+5. `completed`
+6. `failed`
+7. `escalated`
+8. `cancelled`
+
+Primary allowed flow:
+
+1. `queued -> dispatched -> acknowledged -> in_progress -> completed`
+
+Safety flow:
+
+1. `queued|dispatched|acknowledged|in_progress -> failed|escalated|cancelled`
+
+Artifacts:
+
+- `.superloop/horizons/packets/<packet-id>.json`
+- `.superloop/horizons/telemetry/packets.jsonl`
+
+Each packet artifact records:
+
+1. `traceId`
+2. `loopId` (optional)
+3. `horizonRef`
+4. `evidenceRefs`
+5. transition history with actor/reason/note
+
 ## Operational rules
 
 1. A loop may execute without any horizon binding.

--- a/feat/horizon-control-plane/phase-1-runtime/PLAN.MD
+++ b/feat/horizon-control-plane/phase-1-runtime/PLAN.MD
@@ -1,0 +1,53 @@
+# Feature: Horizon Control Plane (Phase 1 Runtime Packet Lifecycle)
+
+## Goal
+Ship a concrete Horizon packet runtime that lets humans/agents create, transition, inspect, and audit packet state above Superloop loop execution.
+
+## Scope
+- Add `scripts/horizon-packet.sh` with `create`, `transition`, `show`, and `list` commands.
+- Persist packet state artifacts at `.superloop/horizons/packets/*.json`.
+- Persist append-only packet telemetry at `.superloop/horizons/telemetry/packets.jsonl`.
+- Enforce deterministic packet status transitions with fail-closed validation.
+- Add BATS coverage for create/transition/list/show success + failure paths.
+- Update Horizon docs/readme with executable usage and artifact contract.
+
+## Non-Goals (this iteration)
+- Embedding packet execution semantics into `superloop.sh run` role loops.
+- Transport adapters for live delivery (webhook/slack/email) and retries.
+- Cross-repo directory/discovery service for external contacts.
+
+## Primary References
+- `docs/horizon-planning.md` - horizon operating model and artifact contract.
+- `schema/horizons.schema.json` - horizon control-plane schema.
+- `scripts/validate-horizons.sh` - existing horizon schema/invariant validation path.
+- `README.md` - top-level operator guidance.
+
+## Architecture
+The runtime introduces an explicit packet state machine persisted in repo artifacts:
+
+1. command plane (`scripts/horizon-packet.sh`) validates input and transitions.
+2. state artifact per packet (`.superloop/horizons/packets/<id>.json`).
+3. append-only telemetry stream (`.superloop/horizons/telemetry/packets.jsonl`).
+
+This is additive and decoupled from ops-manager controllers and loop execution internals.
+
+## Decisions
+- Status model is fixed for Phase 1: `queued`, `dispatched`, `acknowledged`, `in_progress`, `completed`, `failed`, `escalated`, `cancelled`.
+- Transition matrix is explicit and fail-closed; illegal transitions return non-zero.
+- Packet artifacts always include `traceId`, `horizonRef`, `evidenceRefs`, and optional `loopId`.
+- CLI remains standalone script-level surface for this phase to avoid broad command-router churn.
+
+## Risks / Constraints
+- No automatic reconciliation loop yet; operators/agents must invoke commands explicitly.
+- Schema evolution requires backward compatibility for stored packet artifacts.
+- Concurrent writers to the same packet file are not lock-managed in this phase.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `/usr/bin/bats tests/horizon-packet.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: packet runtime script, deterministic transitions, telemetry artifacts, docs, tests.
+- **Phase 2**: optional integration into higher-level Horizon orchestrator commands and dispatch adapters.

--- a/feat/horizon-control-plane/phase-1-runtime/tasks/PHASE_1.MD
+++ b/feat/horizon-control-plane/phase-1-runtime/tasks/PHASE_1.MD
@@ -1,0 +1,29 @@
+# Phase 1 - Horizon Packet Runtime Baseline
+
+## P1.0 Scope Discipline
+1. [x] Keep phase scope additive and decoupled from ops-manager controllers.
+2. [x] Keep changes limited to horizon packet runtime + docs + tests.
+
+## P1.1 Runtime Script
+1. [x] Add `scripts/horizon-packet.sh` with commands: `create`, `transition`, `show`, `list`.
+2. [x] Persist packet artifacts to `.superloop/horizons/packets/<packet-id>.json`.
+3. [x] Persist append-only telemetry to `.superloop/horizons/telemetry/packets.jsonl`.
+4. [x] Enforce deterministic status transitions and fail closed on invalid transitions.
+
+## P1.2 Contract Fields
+1. [x] Include `traceId`, `horizonRef`, `evidenceRefs`, and optional `loopId` in packet artifacts.
+2. [x] Support repeated `--evidence-ref` on create/transition operations.
+3. [x] Ensure list/show surfaces preserve artifact fidelity.
+
+## P1.3 Tests
+1. [x] Add `tests/horizon-packet.bats` for create + telemetry baseline.
+2. [x] Add transition lifecycle success/failure coverage.
+3. [x] Add list filter and missing-packet error coverage.
+
+## P1.4 Documentation
+1. [x] Update `docs/horizon-planning.md` with packet runtime usage and status model.
+2. [x] Update `README.md` Horizon section with quick packet examples.
+
+## P1.V Validation
+1. [x] `bash -n scripts/horizon-packet.sh` passes.
+2. [x] `/usr/bin/bats tests/horizon-packet.bats` passes.

--- a/scripts/horizon-packet.sh
+++ b/scripts/horizon-packet.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/horizon-packet.sh <create|transition|show|list> [options]
+
+Common options:
+  --repo <path>             Repository path (default: .)
+  --state-dir <path>        Horizon state directory (default: <repo>/.superloop/horizons)
+  --telemetry-file <path>   Packet telemetry jsonl path (default: <state-dir>/telemetry/packets.jsonl)
+  --pretty                  Pretty-print JSON output
+
+Create options:
+  --packet-id <id>          Packet identifier (required)
+  --horizon-ref <id>        Horizon identifier (required)
+  --sender <id>             Sender identifier (required)
+  --recipient-type <type>   Recipient type (required)
+  --recipient-id <id>       Recipient identifier (required)
+  --intent <text>           Packet intent (required)
+  --authority <text>        Optional authority descriptor
+  --trace-id <id>           Optional trace identifier
+  --ttl-seconds <n>         Optional packet freshness TTL in seconds
+  --evidence-ref <ref>      Optional evidence ref, can be repeated
+
+Transition options:
+  --packet-id <id>          Packet identifier (required)
+  --to-status <status>      Target status (required)
+  --by <id>                 Actor applying transition (required)
+  --reason <text>           Transition reason (required)
+  --note <text>             Optional transition note
+  --evidence-ref <ref>      Optional evidence ref, can be repeated
+
+Show options:
+  --packet-id <id>          Packet identifier (required)
+
+List options:
+  --horizon-ref <id>        Filter by horizon identifier
+  --status <status>         Filter by packet status
+
+Statuses:
+  queued, dispatched, acknowledged, in_progress, completed, failed, escalated, cancelled
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "missing required command: $cmd"
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'hpk-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+emit_json() {
+  local json="$1"
+  local pretty="${2:-0}"
+  if [[ "$pretty" == "1" ]]; then
+    jq '.' <<<"$json"
+  else
+    jq -c '.' <<<"$json"
+  fi
+}
+
+is_valid_status() {
+  local status="$1"
+  case "$status" in
+    queued|dispatched|acknowledged|in_progress|completed|failed|escalated|cancelled)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_transition_allowed() {
+  local from_status="$1"
+  local to_status="$2"
+  case "$from_status" in
+    queued)
+      [[ "$to_status" == "dispatched" || "$to_status" == "cancelled" || "$to_status" == "escalated" ]]
+      ;;
+    dispatched)
+      [[ "$to_status" == "acknowledged" || "$to_status" == "failed" || "$to_status" == "escalated" || "$to_status" == "cancelled" ]]
+      ;;
+    acknowledged)
+      [[ "$to_status" == "in_progress" || "$to_status" == "failed" || "$to_status" == "escalated" || "$to_status" == "cancelled" ]]
+      ;;
+    in_progress)
+      [[ "$to_status" == "completed" || "$to_status" == "failed" || "$to_status" == "escalated" || "$to_status" == "cancelled" ]]
+      ;;
+    failed)
+      [[ "$to_status" == "escalated" || "$to_status" == "cancelled" ]]
+      ;;
+    escalated)
+      [[ "$to_status" == "in_progress" || "$to_status" == "completed" || "$to_status" == "cancelled" ]]
+      ;;
+    completed|cancelled)
+      false
+      ;;
+    *)
+      false
+      ;;
+  esac
+}
+
+build_custom_evidence_refs_json() {
+  if [[ ${#EVIDENCE_REFS[@]} -eq 0 ]]; then
+    echo '[]'
+    return 0
+  fi
+  printf '%s\n' "${EVIDENCE_REFS[@]}" | jq -Rsc 'split("\n")[:-1] | map(select(length > 0))'
+}
+
+append_telemetry() {
+  local telemetry_file="$1"
+  local packet_file="$2"
+  local packet_json="$3"
+  local action="$4"
+  local from_status="$5"
+  local to_status="$6"
+  local actor="$7"
+  local reason="$8"
+  local note="$9"
+  local evidence_refs_json="${10}"
+
+  mkdir -p "$(dirname "$telemetry_file")"
+
+  jq -cn \
+    --arg schema_version "v1" \
+    --arg timestamp "$(timestamp)" \
+    --arg category "horizon_packet" \
+    --arg action "$action" \
+    --arg packet_file "$packet_file" \
+    --arg from_status "$from_status" \
+    --arg to_status "$to_status" \
+    --arg actor "$actor" \
+    --arg reason "$reason" \
+    --arg note "$note" \
+    --argjson packet "$packet_json" \
+    --argjson evidence_refs "$evidence_refs_json" \
+    '{
+      schemaVersion: $schema_version,
+      timestamp: $timestamp,
+      category: $category,
+      action: $action,
+      packetId: ($packet.packetId // null),
+      horizonRef: ($packet.horizonRef // null),
+      status: ($packet.status // null),
+      fromStatus: (if ($from_status | length) > 0 then $from_status else null end),
+      toStatus: (if ($to_status | length) > 0 then $to_status else null end),
+      by: (if ($actor | length) > 0 then $actor else null end),
+      reason: (if ($reason | length) > 0 then $reason else null end),
+      note: (if ($note | length) > 0 then $note else null end),
+      traceId: ($packet.traceId // null),
+      evidenceRefs: $evidence_refs,
+      packetFile: $packet_file
+    }' >> "$telemetry_file"
+}
+
+packet_file_for_id() {
+  local packets_dir="$1"
+  local packet_id="$2"
+  echo "$packets_dir/$packet_id.json"
+}
+
+require_non_empty() {
+  local value="$1"
+  local name="$2"
+  [[ -n "$value" ]] || die "$name is required"
+}
+
+CMD="${1:-}"
+if [[ -z "$CMD" || "$CMD" == "--help" || "$CMD" == "-h" ]]; then
+  usage
+  [[ -n "$CMD" ]] && exit 0 || exit 1
+fi
+shift
+
+REPO="."
+STATE_DIR=""
+TELEMETRY_FILE=""
+PACKET_ID=""
+HORIZON_REF=""
+SENDER=""
+RECIPIENT_TYPE=""
+RECIPIENT_ID=""
+INTENT=""
+AUTHORITY=""
+TRACE_ID=""
+TTL_SECONDS=""
+TO_STATUS=""
+ACTOR=""
+REASON=""
+NOTE=""
+STATUS_FILTER=""
+PRETTY="0"
+EVIDENCE_REFS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="${2:-}"
+      shift 2
+      ;;
+    --telemetry-file)
+      TELEMETRY_FILE="${2:-}"
+      shift 2
+      ;;
+    --packet-id)
+      PACKET_ID="${2:-}"
+      shift 2
+      ;;
+    --horizon-ref)
+      HORIZON_REF="${2:-}"
+      shift 2
+      ;;
+    --sender)
+      SENDER="${2:-}"
+      shift 2
+      ;;
+    --recipient-type)
+      RECIPIENT_TYPE="${2:-}"
+      shift 2
+      ;;
+    --recipient-id)
+      RECIPIENT_ID="${2:-}"
+      shift 2
+      ;;
+    --intent)
+      INTENT="${2:-}"
+      shift 2
+      ;;
+    --authority)
+      AUTHORITY="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      TRACE_ID="${2:-}"
+      shift 2
+      ;;
+    --ttl-seconds)
+      TTL_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --to-status)
+      TO_STATUS="${2:-}"
+      shift 2
+      ;;
+    --by)
+      ACTOR="${2:-}"
+      shift 2
+      ;;
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --note)
+      NOTE="${2:-}"
+      shift 2
+      ;;
+    --status)
+      STATUS_FILTER="${2:-}"
+      shift 2
+      ;;
+    --evidence-ref)
+      EVIDENCE_REFS+=("${2:-}")
+      shift 2
+      ;;
+    --pretty)
+      PRETTY="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+REPO="$(cd "$REPO" && pwd)"
+if [[ -z "$STATE_DIR" ]]; then
+  STATE_DIR="$REPO/.superloop/horizons"
+fi
+if [[ "$STATE_DIR" != /* ]]; then
+  STATE_DIR="$REPO/$STATE_DIR"
+fi
+PACKETS_DIR="$STATE_DIR/packets"
+if [[ -z "$TELEMETRY_FILE" ]]; then
+  TELEMETRY_FILE="$STATE_DIR/telemetry/packets.jsonl"
+fi
+if [[ "$TELEMETRY_FILE" != /* ]]; then
+  TELEMETRY_FILE="$REPO/$TELEMETRY_FILE"
+fi
+
+CUSTOM_EVIDENCE_REFS_JSON="$(build_custom_evidence_refs_json)"
+
+case "$CMD" in
+  create)
+    require_non_empty "$PACKET_ID" "--packet-id"
+    require_non_empty "$HORIZON_REF" "--horizon-ref"
+    require_non_empty "$SENDER" "--sender"
+    require_non_empty "$RECIPIENT_TYPE" "--recipient-type"
+    require_non_empty "$RECIPIENT_ID" "--recipient-id"
+    require_non_empty "$INTENT" "--intent"
+
+    if [[ -n "$TTL_SECONDS" ]]; then
+      [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]] || die "--ttl-seconds must be an integer >= 0"
+    fi
+
+    mkdir -p "$PACKETS_DIR"
+    packet_file="$(packet_file_for_id "$PACKETS_DIR" "$PACKET_ID")"
+    [[ ! -f "$packet_file" ]] || die "packet already exists: $PACKET_ID"
+
+    if [[ -z "$TRACE_ID" ]]; then
+      TRACE_ID="${HORIZON_TRACE_ID:-}"
+    fi
+    if [[ -z "$TRACE_ID" ]]; then
+      TRACE_ID="$(generate_trace_id)"
+    fi
+
+    created_at="$(timestamp)"
+    packet_json="$(jq -cn \
+      --arg schema_version "v1" \
+      --arg packet_id "$PACKET_ID" \
+      --arg horizon_ref "$HORIZON_REF" \
+      --arg sender "$SENDER" \
+      --arg recipient_type "$RECIPIENT_TYPE" \
+      --arg recipient_id "$RECIPIENT_ID" \
+      --arg intent "$INTENT" \
+      --arg authority "$AUTHORITY" \
+      --arg trace_id "$TRACE_ID" \
+      --arg created_at "$created_at" \
+      --arg ttl_seconds "$TTL_SECONDS" \
+      --argjson evidence_refs "$CUSTOM_EVIDENCE_REFS_JSON" \
+      '{
+        schemaVersion: $schema_version,
+        packetId: $packet_id,
+        horizonRef: $horizon_ref,
+        sender: $sender,
+        recipient: {
+          type: $recipient_type,
+          id: $recipient_id
+        },
+        intent: $intent,
+        authority: (if ($authority | length) > 0 then $authority else null end),
+        traceId: $trace_id,
+        ttlSeconds: (if ($ttl_seconds | length) > 0 then ($ttl_seconds | tonumber) else null end),
+        status: "queued",
+        createdAt: $created_at,
+        updatedAt: $created_at,
+        completedAt: null,
+        evidenceRefs: $evidence_refs,
+        transitions: [
+          {
+            at: $created_at,
+            fromStatus: null,
+            toStatus: "queued",
+            by: $sender,
+            reason: "packet_created",
+            note: null,
+            evidenceRefs: $evidence_refs
+          }
+        ]
+      }')"
+
+    jq -c '.' <<<"$packet_json" > "$packet_file"
+    append_telemetry "$TELEMETRY_FILE" "$packet_file" "$packet_json" "create" "" "queued" "$SENDER" "packet_created" "" "$CUSTOM_EVIDENCE_REFS_JSON"
+    emit_json "$packet_json" "$PRETTY"
+    ;;
+
+  transition)
+    require_non_empty "$PACKET_ID" "--packet-id"
+    require_non_empty "$TO_STATUS" "--to-status"
+    require_non_empty "$ACTOR" "--by"
+    require_non_empty "$REASON" "--reason"
+
+    is_valid_status "$TO_STATUS" || die "invalid --to-status: $TO_STATUS"
+
+    packet_file="$(packet_file_for_id "$PACKETS_DIR" "$PACKET_ID")"
+    [[ -f "$packet_file" ]] || die "packet not found: $PACKET_ID"
+
+    packet_json="$(jq -c '.' "$packet_file" 2>/dev/null)" || die "invalid packet JSON: $packet_file"
+    from_status="$(jq -r '.status // empty' <<<"$packet_json")"
+    is_valid_status "$from_status" || die "packet has invalid current status: $from_status"
+    is_transition_allowed "$from_status" "$TO_STATUS" || die "transition from $from_status to $TO_STATUS is not allowed"
+
+    existing_evidence_refs_json="$(jq -c '.evidenceRefs // []' <<<"$packet_json")"
+    merged_evidence_refs_json="$(jq -cn \
+      --argjson existing "$existing_evidence_refs_json" \
+      --argjson incoming "$CUSTOM_EVIDENCE_REFS_JSON" \
+      '($existing + $incoming) | map(select(type == "string" and length > 0)) | unique')"
+
+    updated_at="$(timestamp)"
+    updated_packet_json="$(jq -cn \
+      --argjson packet "$packet_json" \
+      --arg from_status "$from_status" \
+      --arg to_status "$TO_STATUS" \
+      --arg actor "$ACTOR" \
+      --arg reason "$REASON" \
+      --arg note "$NOTE" \
+      --arg updated_at "$updated_at" \
+      --argjson merged_refs "$merged_evidence_refs_json" \
+      --argjson new_refs "$CUSTOM_EVIDENCE_REFS_JSON" \
+      '($packet
+        | .status = $to_status
+        | .updatedAt = $updated_at
+        | .completedAt = (
+            if $to_status == "completed"
+            then (.completedAt // $updated_at)
+            else .completedAt
+            end
+          )
+        | .evidenceRefs = $merged_refs
+        | .transitions += [
+            {
+              at: $updated_at,
+              fromStatus: $from_status,
+              toStatus: $to_status,
+              by: $actor,
+              reason: $reason,
+              note: (if ($note | length) > 0 then $note else null end),
+              evidenceRefs: $new_refs
+            }
+          ]
+      )')"
+
+    jq -c '.' <<<"$updated_packet_json" > "$packet_file"
+    append_telemetry "$TELEMETRY_FILE" "$packet_file" "$updated_packet_json" "transition" "$from_status" "$TO_STATUS" "$ACTOR" "$REASON" "$NOTE" "$CUSTOM_EVIDENCE_REFS_JSON"
+    emit_json "$updated_packet_json" "$PRETTY"
+    ;;
+
+  show)
+    require_non_empty "$PACKET_ID" "--packet-id"
+    packet_file="$(packet_file_for_id "$PACKETS_DIR" "$PACKET_ID")"
+    [[ -f "$packet_file" ]] || die "packet not found: $PACKET_ID"
+    packet_json="$(jq -c '.' "$packet_file" 2>/dev/null)" || die "invalid packet JSON: $packet_file"
+    emit_json "$packet_json" "$PRETTY"
+    ;;
+
+  list)
+    if [[ -n "$STATUS_FILTER" ]]; then
+      is_valid_status "$STATUS_FILTER" || die "invalid --status: $STATUS_FILTER"
+    fi
+
+    if [[ ! -d "$PACKETS_DIR" ]]; then
+      emit_json "[]" "$PRETTY"
+      exit 0
+    fi
+
+    mapfile -t packet_files < <(find "$PACKETS_DIR" -maxdepth 1 -type f -name '*.json' | sort)
+    if [[ ${#packet_files[@]} -eq 0 ]]; then
+      emit_json "[]" "$PRETTY"
+      exit 0
+    fi
+
+    list_json="$(jq -s \
+      --arg horizon_ref "$HORIZON_REF" \
+      --arg status_filter "$STATUS_FILTER" \
+      '[ .[]
+        | select(
+            if ($horizon_ref | length) > 0
+            then (.horizonRef // "") == $horizon_ref
+            else true
+            end
+          )
+        | select(
+            if ($status_filter | length) > 0
+            then (.status // "") == $status_filter
+            else true
+            end
+          )
+      ]' "${packet_files[@]}")"
+    emit_json "$list_json" "$PRETTY"
+    ;;
+
+  *)
+    usage
+    die "unknown command: $CMD"
+    ;;
+esac

--- a/tests/horizon-packet.bats
+++ b/tests/horizon-packet.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  REPO_DIR="$TEMP_DIR/repo"
+  mkdir -p "$REPO_DIR/.superloop/horizons"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+@test "horizon packet create writes queued packet and telemetry" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-001 \
+    --horizon-ref HZ-alpha \
+    --sender planner \
+    --recipient-type local_agent \
+    --recipient-id implementer \
+    --intent "implement slice" \
+    --authority "eng-manager"
+
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.status' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "queued" ]
+
+  run jq -r '.traceId | type' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "string" ]
+
+  run jq -r '.horizonRef' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "HZ-alpha" ]
+
+  [ -f "$REPO_DIR/.superloop/horizons/packets/pkt-001.json" ]
+  [ -f "$REPO_DIR/.superloop/horizons/telemetry/packets.jsonl" ]
+
+  run jq -r '.action' "$REPO_DIR/.superloop/horizons/telemetry/packets.jsonl"
+  [ "$status" -eq 0 ]
+  [ "$output" = "create" ]
+}
+
+@test "horizon packet create accepts seam fields and evidence refs" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-002 \
+    --horizon-ref HZ-beta \
+    --sender planner \
+    --recipient-type human \
+    --recipient-id user-1 \
+    --intent "request approval" \
+    --trace-id trace-hz-001 \
+    --ttl-seconds 600 \
+    --evidence-ref "artifact://run-summary" \
+    --evidence-ref "artifact://review-note"
+
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.traceId' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "trace-hz-001" ]
+
+  run jq -r '.ttlSeconds' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "600" ]
+
+  run jq -r '.evidenceRefs | index("artifact://run-summary") != null' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.evidenceRefs | index("artifact://review-note") != null' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "horizon packet transition updates state and completion timestamp" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-003 \
+    --horizon-ref HZ-gamma \
+    --sender planner \
+    --recipient-type local_agent \
+    --recipient-id implementer \
+    --intent "execute change"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-003 \
+    --to-status dispatched \
+    --by dispatcher \
+    --reason "selected recipient" \
+    --evidence-ref "artifact://dispatch-log"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-003 \
+    --to-status acknowledged \
+    --by implementer \
+    --reason "accepted"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-003 \
+    --to-status in_progress \
+    --by implementer \
+    --reason "started work"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-003 \
+    --to-status completed \
+    --by implementer \
+    --reason "delivered"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-003
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.status' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "completed" ]
+
+  run jq -r '.completedAt != null' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run jq -r '.transitions | length' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "5" ]
+
+  run jq -r '.evidenceRefs | index("artifact://dispatch-log") != null' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run bash -lc "wc -l < '$REPO_DIR/.superloop/horizons/telemetry/packets.jsonl'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "5" ]
+}
+
+@test "horizon packet transition rejects invalid state move" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-004 \
+    --horizon-ref HZ-delta \
+    --sender planner \
+    --recipient-type local_agent \
+    --recipient-id implementer \
+    --intent "invalid transition check"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-004 \
+    --to-status completed \
+    --by implementer \
+    --reason "should fail"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"transition from queued to completed is not allowed"* ]]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-004
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "queued" ]
+}
+
+@test "horizon packet list supports horizon and status filters" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-005 \
+    --horizon-ref HZ-A \
+    --sender planner \
+    --recipient-type local_agent \
+    --recipient-id impl-a \
+    --intent "task-a"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-006 \
+    --horizon-ref HZ-B \
+    --sender planner \
+    --recipient-type local_agent \
+    --recipient-id impl-b \
+    --intent "task-b"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" transition \
+    --repo "$REPO_DIR" \
+    --packet-id pkt-006 \
+    --to-status dispatched \
+    --by dispatcher \
+    --reason "routed"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" list --repo "$REPO_DIR"
+  [ "$status" -eq 0 ]
+  run jq -r 'length' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" list --repo "$REPO_DIR" --horizon-ref HZ-A
+  [ "$status" -eq 0 ]
+  run jq -r '.[0].packetId' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkt-005" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" list --repo "$REPO_DIR" --status dispatched
+  [ "$status" -eq 0 ]
+  run jq -r '.[0].packetId' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkt-006" ]
+}
+
+@test "horizon packet show fails for missing packet id" {
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id missing-pkt
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"packet not found"* ]]
+}


### PR DESCRIPTION
## Summary
Adds a concrete Phase 1 Horizon runtime slice with packet lifecycle commands, deterministic transitions, and append-only telemetry artifacts.

## What changed
- Added `scripts/horizon-packet.sh` with commands:
  - `create`
  - `transition`
  - `show`
  - `list`
- Added artifact persistence:
  - `.superloop/horizons/packets/<packet-id>.json`
  - `.superloop/horizons/telemetry/packets.jsonl`
- Added deterministic status model + transition guards:
  - `queued`, `dispatched`, `acknowledged`, `in_progress`, `completed`, `failed`, `escalated`, `cancelled`
- Added contract fields in packet artifacts:
  - `traceId`, `horizonRef`, `evidenceRefs`, optional `loopId`
- Added feature packet docs:
  - `feat/horizon-control-plane/phase-1-runtime/PLAN.MD`
  - `feat/horizon-control-plane/phase-1-runtime/tasks/PHASE_1.MD`
- Updated docs:
  - `docs/horizon-planning.md`
  - `README.md`
- Added tests:
  - `tests/horizon-packet.bats`

## Validation
- `bash -n scripts/horizon-packet.sh`
- `/usr/bin/bats tests/horizon-packet.bats`
- `/usr/bin/bats tests/ops-manager-promotion-apply.bats tests/ops-manager-promotion-orchestrate.bats`

## Scope boundaries
- No coupling to ops-manager controller internals.
- No changes to `superloop.sh` command router.
- No transport adapter execution logic in this phase.
