### PR TITLE
feat(horizon): add phase-2 orchestrator dispatch adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Horizon contract files:
 - `docs/horizon-planning.md` (operating model)
 - `docs/examples/horizons.example.json` (sample)
 - `scripts/horizon-packet.sh` (packet lifecycle runtime for horizon dispatch tracking)
+- `scripts/horizon-orchestrate.sh` (packet planning/dispatch runtime with adapters)
 
 Validate horizon control-plane state (when present):
 
@@ -169,6 +170,23 @@ scripts/horizon-packet.sh transition \
   --to-status dispatched \
   --by dispatcher \
   --reason "recipient selected"
+```
+
+```bash
+scripts/horizon-orchestrate.sh plan \
+  --repo . \
+  --horizon-ref HZ-program-authn-v1 \
+  --adapter filesystem_outbox \
+  --limit 20
+```
+
+```bash
+scripts/horizon-orchestrate.sh dispatch \
+  --repo . \
+  --horizon-ref HZ-program-authn-v1 \
+  --adapter filesystem_outbox \
+  --actor dispatcher \
+  --reason "queued packet dispatch"
 ```
 
 ## Config

--- a/feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/PLAN.MD
+++ b/feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/PLAN.MD
@@ -1,0 +1,67 @@
+# Feature: Horizon Control Plane (Phase 2 Orchestrator + Dispatch Adapters)
+
+## Goal
+Add a deterministic Horizon orchestrator runtime that plans and dispatches queued packets through explicit adapters, with stale-packet gating and auditable artifacts.
+
+## Scope
+- Add `scripts/horizon-orchestrate.sh` with `plan` and `dispatch` commands.
+- Support deterministic queued packet selection with optional filters (`horizon_ref`, recipient type, limit).
+- Add packet TTL freshness gating (expired packets are blocked from dispatch and surfaced with reason codes).
+- Add built-in dispatch adapters:
+  - `filesystem_outbox` (default)
+  - `stdout`
+- Persist orchestrator telemetry at `.superloop/horizons/telemetry/orchestrator.jsonl`.
+- Ensure dispatch transitions reuse `scripts/horizon-packet.sh` state machine (`queued -> dispatched`, fail path to `failed` on adapter write errors).
+- Add BATS coverage for plan/dispatch/dry-run/filter/limit/stale behavior.
+- Update docs (`README.md`, `docs/horizon-planning.md`).
+
+## Non-Goals (this iteration)
+- Embedding orchestrator behavior into `superloop.sh run`.
+- External SaaS transports (Slack/email/webhooks) and retry daemons.
+- Global contact directory service across repositories.
+
+## Primary References
+- `feat/horizon-control-plane/phase-1-runtime/PLAN.MD` - Phase 1 baseline and explicit Phase 2 target.
+- `scripts/horizon-packet.sh` - packet state machine and telemetry contract.
+- `tests/horizon-packet.bats` - packet contract regression baseline.
+- `docs/horizon-planning.md` - Horizon model and operating guidance.
+- `README.md` - operator quickstart guidance.
+
+## Architecture
+Phase 2 adds an explicit orchestrator plane over packet artifacts:
+
+1. Observe:
+- Read queued packet artifacts from `.superloop/horizons/packets/*.json`.
+
+2. Plan:
+- Build deterministic selection (`createdAt`, `packetId`) with optional filters and dispatch route resolution.
+- Evaluate freshness gates from `ttlSeconds` + `createdAt` and mark blocked packets with reason codes.
+
+3. Dispatch:
+- For dispatchable packets, transition packet state via `horizon-packet.sh`.
+- Deliver a dispatch envelope through the selected adapter.
+- On adapter write failure, transition packet to `failed` with deterministic reason code.
+
+4. Audit:
+- Append orchestrator run records to `.superloop/horizons/telemetry/orchestrator.jsonl`.
+
+## Decisions
+- Keep orchestrator standalone (`scripts/horizon-orchestrate.sh`) to preserve Phase 1 isolation and avoid command-router churn.
+- Default adapter is `filesystem_outbox` for zero-dependency local/agent/human handoff.
+- Use fail-closed freshness gate semantics (`packet_ttl_expired`, `packet_created_at_invalid`).
+- Keep optional seam context additive; no hard coupling to Ops Manager internals.
+
+## Risks / Constraints
+- Concurrent orchestrator writers are not lock-managed in this phase.
+- Filesystem outbox paths are local-repo artifacts, not guaranteed delivery channels.
+- `stdout` adapter requires an external consumer process for actual delivery.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: packet lifecycle runtime baseline (complete).
+- **Phase 2**: orchestrator `plan/dispatch` runtime, dispatch adapters, freshness gates, docs, tests.

--- a/feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/tasks/PHASE_1.MD
+++ b/feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/tasks/PHASE_1.MD
@@ -1,0 +1,31 @@
+# Phase 1 - Horizon Orchestrator Dispatch Baseline
+
+## P1.0 Scope Discipline
+1. [x] Keep phase scope additive and decoupled from `superloop.sh run` and Ops Manager internals.
+2. [x] Keep changes limited to Horizon orchestrator runtime + packet contract patch + docs + tests.
+
+## P1.1 Orchestrator Runtime
+1. [x] Add `scripts/horizon-orchestrate.sh` with commands: `plan`, `dispatch`.
+2. [x] Add deterministic queued packet selection with sort order and optional filters (`--horizon-ref`, `--recipient-type`, `--limit`).
+3. [x] Add freshness gating from packet TTL and created timestamp with explicit reason codes.
+4. [x] Add adapter routing with `filesystem_outbox` (default) and `stdout`.
+5. [x] Persist orchestrator run telemetry to `.superloop/horizons/telemetry/orchestrator.jsonl`.
+
+## P1.2 Packet Contract Alignment
+1. [x] Add `--loop-id` support in `scripts/horizon-packet.sh create` to align runtime behavior with documented contract.
+2. [x] Keep packet state transitions fail-closed by reusing `horizon-packet.sh` transition command from orchestrator.
+3. [x] Keep seam fields additive and nullable.
+
+## P1.3 Tests
+1. [x] Add `tests/horizon-orchestrate.bats` coverage for plan output + stale packet blocking.
+2. [x] Add dispatch coverage for filesystem outbox adapter + packet transition behavior.
+3. [x] Add dry-run, filter, and limit behavior coverage.
+4. [x] Extend packet tests for new `--loop-id` contract field.
+
+## P1.4 Documentation
+1. [x] Update `docs/horizon-planning.md` with Phase 2 orchestrator contract, commands, adapters, and artifacts.
+2. [x] Update `README.md` Horizon section with orchestrator quick examples and artifact notes.
+
+## P1.V Validation
+1. [x] `bash -n scripts/horizon-packet.sh scripts/horizon-orchestrate.sh` passes.
+2. [x] `/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats` passes.

--- a/scripts/horizon-orchestrate.sh
+++ b/scripts/horizon-orchestrate.sh
@@ -1,0 +1,625 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/horizon-orchestrate.sh <plan|dispatch> [options]
+
+Common options:
+  --repo <path>                       Repository path (default: .)
+  --state-dir <path>                  Horizon state directory (default: <repo>/.superloop/horizons)
+  --orchestrator-telemetry-file <p>   Orchestrator telemetry JSONL path (default: <state-dir>/telemetry/orchestrator.jsonl)
+  --outbox-dir <path>                 Outbox directory for filesystem adapter (default: <state-dir>/outbox)
+  --horizon-ref <id>                  Optional horizon filter
+  --recipient-type <type>             Optional recipient type filter
+  --limit <n>                         Max queued packets to select (default: 20)
+  --adapter <filesystem_outbox|stdout> Dispatch adapter (default: filesystem_outbox)
+  --actor <id>                        Actor recorded on transitions (default: horizon-orchestrator)
+  --reason <text>                     Transition reason for queued->dispatched (default: packet_dispatched_by_orchestrator)
+  --note <text>                       Optional transition note
+  --trace-id <id>                     Optional orchestrator run trace id
+  --evidence-ref <ref>                Optional evidence ref, can be repeated
+  --pretty                            Pretty-print JSON output
+
+Dispatch options:
+  --dry-run                           Build dispatch plan but do not mutate packets or emit deliveries
+
+Commands:
+  plan     Produce deterministic dispatch plan with freshness and routing annotations
+  dispatch Execute dispatch plan (or preview with --dry-run)
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "missing required command: $cmd"
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'hor-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+emit_json() {
+  local json="$1"
+  local pretty="${2:-0}"
+  if [[ "$pretty" == "1" ]]; then
+    jq '.' <<<"$json"
+  else
+    jq -c '.' <<<"$json"
+  fi
+}
+
+build_custom_evidence_refs_json() {
+  if [[ ${#EVIDENCE_REFS[@]} -eq 0 ]]; then
+    echo '[]'
+    return 0
+  fi
+  printf '%s\n' "${EVIDENCE_REFS[@]}" | jq -Rsc 'split("\n")[:-1] | map(select(length > 0))'
+}
+
+relative_or_original_path() {
+  local base="$1"
+  local path="$2"
+  if [[ "$path" == "$base"/* ]]; then
+    echo "${path#$base/}"
+  else
+    echo "$path"
+  fi
+}
+
+append_orchestrator_telemetry() {
+  local telemetry_file="$1"
+  local payload_json="$2"
+  mkdir -p "$(dirname "$telemetry_file")"
+  jq -c '.' <<<"$payload_json" >> "$telemetry_file"
+}
+
+CMD="${1:-}"
+if [[ -z "$CMD" || "$CMD" == "--help" || "$CMD" == "-h" ]]; then
+  usage
+  [[ -n "$CMD" ]] && exit 0 || exit 1
+fi
+shift
+
+REPO="."
+STATE_DIR=""
+ORCHESTRATOR_TELEMETRY_FILE=""
+OUTBOX_DIR=""
+HORIZON_REF_FILTER=""
+RECIPIENT_TYPE_FILTER=""
+LIMIT="20"
+ADAPTER="filesystem_outbox"
+ACTOR="horizon-orchestrator"
+REASON="packet_dispatched_by_orchestrator"
+NOTE=""
+TRACE_ID=""
+DRY_RUN="0"
+PRETTY="0"
+EVIDENCE_REFS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="${2:-}"
+      shift 2
+      ;;
+    --orchestrator-telemetry-file)
+      ORCHESTRATOR_TELEMETRY_FILE="${2:-}"
+      shift 2
+      ;;
+    --outbox-dir)
+      OUTBOX_DIR="${2:-}"
+      shift 2
+      ;;
+    --horizon-ref)
+      HORIZON_REF_FILTER="${2:-}"
+      shift 2
+      ;;
+    --recipient-type)
+      RECIPIENT_TYPE_FILTER="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    --adapter)
+      ADAPTER="${2:-}"
+      shift 2
+      ;;
+    --actor)
+      ACTOR="${2:-}"
+      shift 2
+      ;;
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --note)
+      NOTE="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      TRACE_ID="${2:-}"
+      shift 2
+      ;;
+    --evidence-ref)
+      EVIDENCE_REFS+=("${2:-}")
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="1"
+      shift
+      ;;
+    --pretty)
+      PRETTY="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$CMD" in
+  plan|dispatch)
+    ;;
+  *)
+    usage
+    die "unknown command: $CMD"
+    ;;
+esac
+
+need_cmd jq
+
+[[ "$LIMIT" =~ ^[0-9]+$ ]] || die "--limit must be an integer >= 0"
+(( LIMIT >= 0 )) || die "--limit must be an integer >= 0"
+
+case "$ADAPTER" in
+  filesystem_outbox|stdout)
+    ;;
+  *)
+    die "invalid --adapter: $ADAPTER"
+    ;;
+esac
+
+if [[ -z "$ACTOR" ]]; then
+  die "--actor must be non-empty"
+fi
+if [[ -z "$REASON" ]]; then
+  die "--reason must be non-empty"
+fi
+
+REPO="$(cd "$REPO" && pwd)"
+if [[ -z "$STATE_DIR" ]]; then
+  STATE_DIR="$REPO/.superloop/horizons"
+fi
+if [[ "$STATE_DIR" != /* ]]; then
+  STATE_DIR="$REPO/$STATE_DIR"
+fi
+if [[ -z "$ORCHESTRATOR_TELEMETRY_FILE" ]]; then
+  ORCHESTRATOR_TELEMETRY_FILE="$STATE_DIR/telemetry/orchestrator.jsonl"
+fi
+if [[ "$ORCHESTRATOR_TELEMETRY_FILE" != /* ]]; then
+  ORCHESTRATOR_TELEMETRY_FILE="$REPO/$ORCHESTRATOR_TELEMETRY_FILE"
+fi
+if [[ -z "$OUTBOX_DIR" ]]; then
+  OUTBOX_DIR="$STATE_DIR/outbox"
+fi
+if [[ "$OUTBOX_DIR" != /* ]]; then
+  OUTBOX_DIR="$REPO/$OUTBOX_DIR"
+fi
+
+if [[ -z "$TRACE_ID" ]]; then
+  TRACE_ID="${HORIZON_TRACE_ID:-}"
+fi
+if [[ -z "$TRACE_ID" ]]; then
+  TRACE_ID="$(generate_trace_id)"
+fi
+
+PACKETS_DIR="$STATE_DIR/packets"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HORIZON_PACKET_SCRIPT="$SCRIPT_DIR/horizon-packet.sh"
+[[ -x "$HORIZON_PACKET_SCRIPT" ]] || die "required script not executable: $HORIZON_PACKET_SCRIPT"
+
+CUSTOM_EVIDENCE_REFS_JSON="$(build_custom_evidence_refs_json)"
+NOW_EPOCH="$(date -u +%s)"
+RUN_AT="$(timestamp)"
+
+if [[ -d "$PACKETS_DIR" ]]; then
+  mapfile -t PACKET_FILES < <(find "$PACKETS_DIR" -maxdepth 1 -type f -name '*.json' | sort)
+else
+  PACKET_FILES=()
+fi
+
+if [[ ${#PACKET_FILES[@]} -eq 0 ]]; then
+  queued_packets_json='[]'
+else
+  queued_packets_json="$(jq -s \
+    --arg horizon_ref "$HORIZON_REF_FILTER" \
+    --arg recipient_type "$RECIPIENT_TYPE_FILTER" \
+    '[ .[]
+      | select((.status // "") == "queued")
+      | select(
+          if ($horizon_ref | length) > 0
+          then (.horizonRef // "") == $horizon_ref
+          else true
+          end
+        )
+      | select(
+          if ($recipient_type | length) > 0
+          then (.recipient.type // "") == $recipient_type
+          else true
+          end
+        )
+    ]
+    | sort_by((.createdAt // ""), (.packetId // ""))' "${PACKET_FILES[@]}")"
+fi
+
+selected_packets_json="$(jq -c --argjson limit "$LIMIT" '
+  if $limit == 0 then [] else .[0:$limit] end
+' <<<"$queued_packets_json")"
+
+plan_items_json="$(jq -c \
+  --arg adapter "$ADAPTER" \
+  --arg outbox_dir "$OUTBOX_DIR" \
+  --argjson now_epoch "$NOW_EPOCH" '
+  [ .[]
+    | . as $packet
+    | ((try (($packet.createdAt // "") | fromdateiso8601) catch null)) as $created_epoch
+    | (if $packet.ttlSeconds == null then null else (try ($packet.ttlSeconds | tonumber) catch null) end) as $ttl_seconds
+    | (($packet.recipient.type // "") | gsub("[^A-Za-z0-9._-]"; "_")) as $safe_type
+    | (($packet.recipient.id // "") | gsub("[^A-Za-z0-9._-]"; "_")) as $safe_id
+    | (
+        if $adapter == "filesystem_outbox"
+        then ($outbox_dir + "/" + $safe_type + "/" + $safe_id + ".jsonl")
+        elif $adapter == "stdout"
+        then "stdout://horizon-orchestrate"
+        else null
+        end
+      ) as $dispatch_target
+    | (
+        [
+          (if $created_epoch == null then "packet_created_at_invalid" else empty end),
+          (if ($ttl_seconds != null and $created_epoch != null and (($now_epoch - $created_epoch) > $ttl_seconds)) then "packet_ttl_expired" else empty end),
+          (if (($packet.recipient.type // "") | length) == 0 then "packet_recipient_type_missing" else empty end),
+          (if (($packet.recipient.id // "") | length) == 0 then "packet_recipient_id_missing" else empty end)
+        ]
+      ) as $blocked_reasons
+    | {
+        packetId: ($packet.packetId // null),
+        horizonRef: ($packet.horizonRef // null),
+        traceId: ($packet.traceId // null),
+        loopId: ($packet.loopId // null),
+        status: ($packet.status // null),
+        sender: ($packet.sender // null),
+        recipient: ($packet.recipient // {type: null, id: null}),
+        intent: ($packet.intent // null),
+        createdAt: ($packet.createdAt // null),
+        ttlSeconds: (if $ttl_seconds == null then null else $ttl_seconds end),
+        ageSeconds: (if $created_epoch == null then null else ($now_epoch - $created_epoch) end),
+        blockedReasons: $blocked_reasons,
+        dispatchable: (($blocked_reasons | length) == 0),
+        dispatchRoute: {
+          adapter: $adapter,
+          target: $dispatch_target
+        }
+      }
+  ]
+' <<<"$selected_packets_json")"
+
+plan_summary_json="$(jq -c '
+  {
+    selectedCount: length,
+    dispatchableCount: ([ .[] | select(.dispatchable == true) ] | length),
+    blockedCount: ([ .[] | select(.dispatchable == false) ] | length),
+    blockedByReason: (
+      [ .[] | .blockedReasons[] ]
+      | reduce .[] as $reason ({}; .[$reason] = ((.[$reason] // 0) + 1))
+    )
+  }
+' <<<"$plan_items_json")"
+
+plan_json="$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$RUN_AT" \
+  --arg trace_id "$TRACE_ID" \
+  --arg command "$CMD" \
+  --arg adapter "$ADAPTER" \
+  --arg horizon_ref "$HORIZON_REF_FILTER" \
+  --arg recipient_type "$RECIPIENT_TYPE_FILTER" \
+  --argjson limit "$LIMIT" \
+  --argjson dry_run "$( [[ "$DRY_RUN" == "1" ]] && echo true || echo false )" \
+  --arg state_dir "$STATE_DIR" \
+  --arg outbox_dir "$OUTBOX_DIR" \
+  --arg orchestrator_telemetry_file "$ORCHESTRATOR_TELEMETRY_FILE" \
+  --arg actor "$ACTOR" \
+  --arg reason "$REASON" \
+  --arg note "$NOTE" \
+  --argjson evidence_refs "$CUSTOM_EVIDENCE_REFS_JSON" \
+  --argjson plan_items "$plan_items_json" \
+  --argjson plan_summary "$plan_summary_json" '
+  {
+    schemaVersion: $schema_version,
+    timestamp: $timestamp,
+    category: "horizon_orchestrator_run",
+    traceId: $trace_id,
+    command: $command,
+    adapter: $adapter,
+    dryRun: $dry_run,
+    filters: {
+      horizonRef: (if ($horizon_ref | length) > 0 then $horizon_ref else null end),
+      recipientType: (if ($recipient_type | length) > 0 then $recipient_type else null end),
+      limit: $limit
+    },
+    context: {
+      stateDir: $state_dir,
+      outboxDir: $outbox_dir,
+      orchestratorTelemetryFile: $orchestrator_telemetry_file,
+      actor: $actor,
+      reason: $reason,
+      note: (if ($note | length) > 0 then $note else null end),
+      evidenceRefs: $evidence_refs
+    },
+    summary: $plan_summary,
+    items: $plan_items
+  }
+')"
+
+if [[ "$CMD" == "plan" ]]; then
+  append_orchestrator_telemetry "$ORCHESTRATOR_TELEMETRY_FILE" "$plan_json"
+  emit_json "$plan_json" "$PRETTY"
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  dispatch_json="$(jq -c '. + {
+    execution: {
+      status: "dry_run",
+      attemptedCount: 0,
+      dispatchedCount: 0,
+      failedCount: 0,
+      blockedCount: (.summary.blockedCount // 0),
+      results: []
+    }
+  }' <<<"$plan_json")"
+  append_orchestrator_telemetry "$ORCHESTRATOR_TELEMETRY_FILE" "$dispatch_json"
+  emit_json "$dispatch_json" "$PRETTY"
+  exit 0
+fi
+
+mapfile -t dispatch_items < <(jq -c '.items[] | select(.dispatchable == true)' <<<"$plan_json")
+
+dispatch_result_lines=()
+dispatched_count=0
+failed_count=0
+exit_code=0
+
+for item_json in "${dispatch_items[@]}"; do
+  packet_id="$(jq -r '.packetId // empty' <<<"$item_json")"
+  dispatch_target="$(jq -r '.dispatchRoute.target // empty' <<<"$item_json")"
+  safe_target="$(relative_or_original_path "$REPO" "$dispatch_target")"
+
+  transition_cmd=("$HORIZON_PACKET_SCRIPT" transition
+    --repo "$REPO"
+    --state-dir "$STATE_DIR"
+    --packet-id "$packet_id"
+    --to-status dispatched
+    --by "$ACTOR"
+    --reason "$REASON")
+
+  if [[ -n "$NOTE" ]]; then
+    transition_cmd+=(--note "$NOTE")
+  fi
+  if [[ ${#EVIDENCE_REFS[@]} -gt 0 ]]; then
+    for ref in "${EVIDENCE_REFS[@]}"; do
+      transition_cmd+=(--evidence-ref "$ref")
+    done
+  fi
+
+  if ! transition_output="$("${transition_cmd[@]}" 2>&1)"; then
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    dispatch_result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "failed" \
+      --arg reason_code "dispatch_transition_failed" \
+      --arg error "$transition_output" \
+      --arg adapter "$ADAPTER" \
+      --arg target "$safe_target" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reasonCode: $reason_code,
+        adapter: $adapter,
+        target: (if ($target | length) > 0 then $target else null end),
+        error: $error
+      }
+    ')")
+    continue
+  fi
+
+  envelope_json="$(jq -cn \
+    --arg schema_version "v1" \
+    --arg timestamp "$(timestamp)" \
+    --arg category "horizon_dispatch" \
+    --arg trace_id "$TRACE_ID" \
+    --arg actor "$ACTOR" \
+    --arg adapter "$ADAPTER" \
+    --arg target "$safe_target" \
+    --arg reason "$REASON" \
+    --arg note "$NOTE" \
+    --argjson packet "$item_json" \
+    --argjson evidence_refs "$CUSTOM_EVIDENCE_REFS_JSON" '
+    {
+      schemaVersion: $schema_version,
+      timestamp: $timestamp,
+      category: $category,
+      traceId: $trace_id,
+      actor: $actor,
+      adapter: $adapter,
+      target: (if ($target | length) > 0 then $target else null end),
+      reason: $reason,
+      note: (if ($note | length) > 0 then $note else null end),
+      packet: {
+        packetId: ($packet.packetId // null),
+        horizonRef: ($packet.horizonRef // null),
+        loopId: ($packet.loopId // null),
+        sender: ($packet.sender // null),
+        recipient: ($packet.recipient // {type: null, id: null}),
+        intent: ($packet.intent // null),
+        traceId: ($packet.traceId // null)
+      },
+      evidenceRefs: $evidence_refs
+    }
+  ' )"
+
+  write_ok=1
+  write_error=""
+  case "$ADAPTER" in
+    filesystem_outbox)
+      if ! mkdir -p "$(dirname "$dispatch_target")" || ! printf '%s\n' "$envelope_json" >> "$dispatch_target"; then
+        write_ok=0
+        write_error="failed to append outbox envelope: $safe_target"
+      fi
+      ;;
+    stdout)
+      :
+      ;;
+    *)
+      write_ok=0
+      write_error="unsupported adapter selected at dispatch time: $ADAPTER"
+      ;;
+  esac
+
+  if [[ "$write_ok" == "0" ]]; then
+    failed_count=$((failed_count + 1))
+    exit_code=1
+
+    "$HORIZON_PACKET_SCRIPT" transition \
+      --repo "$REPO" \
+      --state-dir "$STATE_DIR" \
+      --packet-id "$packet_id" \
+      --to-status failed \
+      --by "$ACTOR" \
+      --reason "adapter_write_failed" \
+      --note "$write_error" >/dev/null 2>&1 || true
+
+    dispatch_result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "failed" \
+      --arg reason_code "adapter_write_failed" \
+      --arg error "$write_error" \
+      --arg adapter "$ADAPTER" \
+      --arg target "$safe_target" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reasonCode: $reason_code,
+        adapter: $adapter,
+        target: (if ($target | length) > 0 then $target else null end),
+        error: $error
+      }
+    ')")
+    continue
+  fi
+
+  dispatched_count=$((dispatched_count + 1))
+
+  if [[ "$ADAPTER" == "stdout" ]]; then
+    dispatch_result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "dispatched" \
+      --arg adapter "$ADAPTER" \
+      --arg target "$safe_target" \
+      --argjson envelope "$envelope_json" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        adapter: $adapter,
+        target: (if ($target | length) > 0 then $target else null end),
+        envelope: $envelope
+      }
+    ')")
+  else
+    dispatch_result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "dispatched" \
+      --arg adapter "$ADAPTER" \
+      --arg target "$safe_target" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        adapter: $adapter,
+        target: (if ($target | length) > 0 then $target else null end)
+      }
+    ')")
+  fi
+
+done
+
+if [[ ${#dispatch_result_lines[@]} -eq 0 ]]; then
+  dispatch_results_json='[]'
+else
+  dispatch_results_json="$(printf '%s\n' "${dispatch_result_lines[@]}" | jq -s '.')"
+fi
+
+attempted_count="${#dispatch_items[@]}"
+
+execution_status="success"
+if [[ "$failed_count" -gt 0 ]]; then
+  execution_status="partial_failure"
+fi
+
+final_json="$(jq -c \
+  --arg status "$execution_status" \
+  --argjson attempted "$attempted_count" \
+  --argjson dispatched "$dispatched_count" \
+  --argjson failed "$failed_count" \
+  --argjson blocked "$(jq -r '.summary.blockedCount // 0' <<<"$plan_json")" \
+  --argjson results "$dispatch_results_json" '
+  . + {
+    execution: {
+      status: $status,
+      attemptedCount: $attempted,
+      dispatchedCount: $dispatched,
+      failedCount: $failed,
+      blockedCount: $blocked,
+      results: $results
+    }
+  }
+' <<<"$plan_json")"
+
+append_orchestrator_telemetry "$ORCHESTRATOR_TELEMETRY_FILE" "$final_json"
+emit_json "$final_json" "$PRETTY"
+exit "$exit_code"

--- a/scripts/horizon-packet.sh
+++ b/scripts/horizon-packet.sh
@@ -19,6 +19,7 @@ Create options:
   --recipient-type <type>   Recipient type (required)
   --recipient-id <id>       Recipient identifier (required)
   --intent <text>           Packet intent (required)
+  --loop-id <id>            Optional loop identifier linked to this packet
   --authority <text>        Optional authority descriptor
   --trace-id <id>           Optional trace identifier
   --ttl-seconds <n>         Optional packet freshness TTL in seconds
@@ -209,6 +210,7 @@ SENDER=""
 RECIPIENT_TYPE=""
 RECIPIENT_ID=""
 INTENT=""
+LOOP_ID=""
 AUTHORITY=""
 TRACE_ID=""
 TTL_SECONDS=""
@@ -256,6 +258,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --intent)
       INTENT="${2:-}"
+      shift 2
+      ;;
+    --loop-id)
+      LOOP_ID="${2:-}"
       shift 2
       ;;
     --authority)
@@ -360,6 +366,7 @@ case "$CMD" in
       --arg recipient_type "$RECIPIENT_TYPE" \
       --arg recipient_id "$RECIPIENT_ID" \
       --arg intent "$INTENT" \
+      --arg loop_id "$LOOP_ID" \
       --arg authority "$AUTHORITY" \
       --arg trace_id "$TRACE_ID" \
       --arg created_at "$created_at" \
@@ -375,6 +382,7 @@ case "$CMD" in
           id: $recipient_id
         },
         intent: $intent,
+        loopId: (if ($loop_id | length) > 0 then $loop_id else null end),
         authority: (if ($authority | length) > 0 then $authority else null end),
         traceId: $trace_id,
         ttlSeconds: (if ($ttl_seconds | length) > 0 then ($ttl_seconds | tonumber) else null end),

--- a/tests/horizon-orchestrate.bats
+++ b/tests/horizon-orchestrate.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  REPO_DIR="$TEMP_DIR/repo"
+  mkdir -p "$REPO_DIR/.superloop/horizons"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+create_packet() {
+  local packet_id="$1"
+  local horizon_ref="$2"
+  local recipient_type="$3"
+  local recipient_id="$4"
+  local intent="$5"
+  shift 5
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id "$packet_id" \
+    --horizon-ref "$horizon_ref" \
+    --sender planner \
+    --recipient-type "$recipient_type" \
+    --recipient-id "$recipient_id" \
+    --intent "$intent" "$@"
+  [ "$status" -eq 0 ]
+}
+
+@test "horizon orchestrate plan marks ttl-expired packet as blocked" {
+  create_packet pkt-fresh HZ-a local_agent impl-a "fresh task" --ttl-seconds 600
+  create_packet pkt-stale HZ-a local_agent impl-b "stale task" --ttl-seconds 60
+
+  local stale_file="$REPO_DIR/.superloop/horizons/packets/pkt-stale.json"
+  run bash -lc "jq -c '.createdAt=\"2020-01-01T00:00:00Z\" | .updatedAt=\"2020-01-01T00:00:00Z\"' '$stale_file' > '$stale_file.tmp' && mv '$stale_file.tmp' '$stale_file'"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" plan --repo "$REPO_DIR"
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.summary.selectedCount' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run jq -r '.summary.dispatchableCount' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.summary.blockedByReason.packet_ttl_expired' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.items[] | select(.packetId=="pkt-stale") | .dispatchable' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  run jq -r '.items[] | select(.packetId=="pkt-stale") | (.blockedReasons | index("packet_ttl_expired") != null)' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "horizon orchestrate dispatch with filesystem_outbox transitions packet" {
+  create_packet pkt-010 HZ-ops local_agent worker-a "run change"
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch \
+    --repo "$REPO_DIR" \
+    --actor dispatcher \
+    --reason "orchestrator_dispatch"
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.execution.dispatchedCount' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.execution.failedCount' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-010
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+
+  local outbox_file="$REPO_DIR/.superloop/horizons/outbox/local_agent/worker-a.jsonl"
+  [ -f "$outbox_file" ]
+
+  run jq -r '.packet.packetId' "$outbox_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkt-010" ]
+
+  local orch_telemetry="$REPO_DIR/.superloop/horizons/telemetry/orchestrator.jsonl"
+  [ -f "$orch_telemetry" ]
+
+  run jq -r '.category' "$orch_telemetry"
+  [ "$status" -eq 0 ]
+  [ "$output" = "horizon_orchestrator_run" ]
+}
+
+@test "horizon orchestrate dispatch dry-run does not mutate packets" {
+  create_packet pkt-020 HZ-ops local_agent worker-b "preview only"
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch --repo "$REPO_DIR" --dry-run
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.execution.status' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dry_run" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-020
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "queued" ]
+
+  [ ! -d "$REPO_DIR/.superloop/horizons/outbox" ]
+}
+
+@test "horizon orchestrate dispatch respects horizon filter and limit" {
+  create_packet pkt-100 HZ-a local_agent worker-1 "task 1"
+  create_packet pkt-101 HZ-a local_agent worker-2 "task 2"
+  create_packet pkt-102 HZ-b local_agent worker-3 "task 3"
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch \
+    --repo "$REPO_DIR" \
+    --horizon-ref HZ-a \
+    --limit 1
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-100
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-101
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "queued" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-102
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "queued" ]
+}
+
+@test "horizon orchestrate dispatch stdout adapter emits envelope in result" {
+  create_packet pkt-200 HZ-c human alice "request review"
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch \
+    --repo "$REPO_DIR" \
+    --adapter stdout
+  [ "$status" -eq 0 ]
+  local result_json="$output"
+
+  run jq -r '.execution.dispatchedCount' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.execution.results[0].envelope.packet.packetId' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkt-200" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-200
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+
+  [ ! -d "$REPO_DIR/.superloop/horizons/outbox" ]
+}

--- a/tests/horizon-packet.bats
+++ b/tests/horizon-packet.bats
@@ -55,6 +55,7 @@ teardown() {
     --recipient-type human \
     --recipient-id user-1 \
     --intent "request approval" \
+    --loop-id loop-approval \
     --trace-id trace-hz-001 \
     --ttl-seconds 600 \
     --evidence-ref "artifact://run-summary" \
@@ -70,6 +71,10 @@ teardown() {
   run jq -r '.ttlSeconds' <<<"$result_json"
   [ "$status" -eq 0 ]
   [ "$output" = "600" ]
+
+  run jq -r '.loopId' <<<"$result_json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "loop-approval" ]
 
   run jq -r '.evidenceRefs | index("artifact://run-summary") != null' <<<"$result_json"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Context
Phase 1 shipped Horizon packet lifecycle runtime (`scripts/horizon-packet.sh`) and explicitly left a higher-level orchestrator + dispatch adapters for Phase 2.

This PR delivers that Phase 2 slice without coupling Horizon internals into `superloop.sh run` or Ops Manager.

## Scope Delivered

### 1) New orchestrator runtime
Added `scripts/horizon-orchestrate.sh` with:
- `plan`: deterministic queued packet planning with filters + gating metadata.
- `dispatch`: executes dispatch plan through explicit adapters.

Supported options include:
- filters: `--horizon-ref`, `--recipient-type`, `--limit`
- dispatch adapters: `filesystem_outbox` (default), `stdout`
- execution controls: `--dry-run`, `--actor`, `--reason`, `--note`, repeated `--evidence-ref`

### 2) Deterministic dispatch semantics
- source set: queued packets from `.superloop/horizons/packets/*.json`
- stable ordering: `createdAt`, `packetId`
- freshness gating:
  - `packet_created_at_invalid`
  - `packet_ttl_expired`
- recipient gating:
  - `packet_recipient_type_missing`
  - `packet_recipient_id_missing`
- adapter write failure behavior:
  - packet transitions to `failed` with reason `adapter_write_failed`

### 3) Orchestrator artifacts
- new telemetry stream:
  - `.superloop/horizons/telemetry/orchestrator.jsonl`
- filesystem adapter outbox:
  - `.superloop/horizons/outbox/<recipient-type>/<recipient-id>.jsonl`

### 4) Packet contract alignment fix
Patched `scripts/horizon-packet.sh` create contract to support documented `--loop-id` and persist `loopId` in packet artifacts.

### 5) Phase packet + docs
- Added:
  - `feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/PLAN.MD`
  - `feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/tasks/PHASE_1.MD`
- Updated docs:
  - `docs/horizon-planning.md`
  - `README.md`

## Validation
Executed on branch:

```bash
bash -n scripts/horizon-packet.sh scripts/horizon-orchestrate.sh
/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats
```

Result:
- `11/11` BATS passing
- syntax checks passing

## Files
- `scripts/horizon-orchestrate.sh` (new)
- `scripts/horizon-packet.sh`
- `tests/horizon-orchestrate.bats` (new)
- `tests/horizon-packet.bats`
- `docs/horizon-planning.md`
- `README.md`
- `feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/PLAN.MD` (new)
- `feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/tasks/PHASE_1.MD` (new)

## Explicit Non-Goals
- no coupling into `superloop.sh run`
- no external SaaS transport adapters
- no cross-repo global directory service
