### PR TITLE
feat(horizon): add phase-3 directory ack and retry runtime

### DIFF
--- a/docs/examples/horizon-directory.example.json
+++ b/docs/examples/horizon-directory.example.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "contacts": [
+    {
+      "recipient": {
+        "type": "local_agent",
+        "id": "implementer"
+      },
+      "dispatch": {
+        "adapter": "filesystem_outbox",
+        "target": "local_agent/implementer.jsonl"
+      },
+      "ack": {
+        "timeout_seconds": 600,
+        "max_retries": 3,
+        "retry_backoff_seconds": 120
+      },
+      "metadata": {
+        "owner": "engineering"
+      }
+    },
+    {
+      "recipient": {
+        "type": "human",
+        "id": "alice"
+      },
+      "dispatch": {
+        "adapter": "stdout"
+      },
+      "ack": {
+        "timeout_seconds": 1800,
+        "max_retries": 1,
+        "retry_backoff_seconds": 300
+      },
+      "metadata": {
+        "channel": "manual-review"
+      }
+    }
+  ]
+}

--- a/feat/horizon-control-plane/phase-3-directory-ack-retry/PLAN.MD
+++ b/feat/horizon-control-plane/phase-3-directory-ack-retry/PLAN.MD
@@ -1,0 +1,61 @@
+# Feature: Horizon Control Plane (Phase 3 Directory + Ack/Retry)
+
+## Goal
+Add Horizon-native directory, delivery acknowledgment ingest, and bounded retry/dead-letter runtime primitives while preserving strict decoupling from Ops Manager internals.
+
+## Scope
+- Add optional Horizon directory contract (`.superloop/horizon-directory.json`) and schema validation tooling.
+- Extend `scripts/horizon-orchestrate.sh` with directory-aware routing (`--directory-mode off|optional|required`, `--directory-file`).
+- Add `scripts/horizon-ack.sh` for deterministic receipt ingest and `dispatched -> acknowledged|failed|escalated|cancelled` transitions.
+- Add `scripts/horizon-retry.sh` reconcile loop for timed-out dispatched packets with retry/backoff limits and dead-letter escalation.
+- Persist ack/retry artifacts and telemetry under `.superloop/horizons/`.
+- Add BATS coverage for directory validation, directory routing, ack dedupe, and retry/escalation behavior.
+- Update Horizon docs/readme with contracts, commands, and failure semantics.
+
+## Non-Goals (this iteration)
+- Any Ops Manager bridge ingestion logic or Ops runtime coupling.
+- External transport plugins beyond `filesystem_outbox` and `stdout`.
+- Autonomous execution side-effects outside Horizon packet state and telemetry artifacts.
+
+## Primary References
+- `feat/horizon-control-plane/phase-2-orchestrator-dispatch-adapters/PLAN.MD` - prior phase baseline.
+- `scripts/horizon-orchestrate.sh` - dispatch planning/runtime surface.
+- `scripts/horizon-packet.sh` - authoritative packet transition state machine.
+- `docs/horizon-planning.md` - Horizon operating model.
+- `README.md` - top-level operator quickstart.
+
+## Architecture
+Phase 3 introduces three additive planes:
+
+1. Directory plane:
+- Optional recipient contract (`horizon-directory`) for route + retry policy overrides.
+
+2. Confirm plane:
+- Receipt ingest command (`horizon-ack`) with idempotent dedupe and transition reconciliation.
+
+3. Retry plane:
+- Reconcile command (`horizon-retry`) for dispatched packet timeout evaluation, bounded retries, and dead-letter escalation.
+
+All behavior remains repo-local and script-driven.
+
+## Decisions
+- Keep Horizon lane independent from Ops Manager bridge lane; shared integration happens only via stable dispatch envelopes.
+- Keep directory optional by default (`optional` mode), with strict `required` mode for fail-closed recipient contract enforcement.
+- Keep retry bounded and deterministic with explicit timeout, max retries, and backoff controls.
+- Keep all new controls auditable through append-only telemetry files and explicit state artifacts.
+
+## Risks / Constraints
+- Concurrent script invocations are not lock-managed in this phase.
+- Filesystem outbox remains a handoff contract, not guaranteed external delivery.
+- Ack/retry state growth requires future retention policy once production volume increases.
+
+## Gate Baseline
+- Tests mode: `N/A (repository feature work; validate via BATS + script checks)`
+- Tests commands: `/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats tests/horizon-directory.bats tests/horizon-ack.bats tests/horizon-retry.bats`
+- Validation require on completion: `N/A`
+- Validation checklist mapping file: `N/A`
+
+## Phases
+- **Phase 1**: Horizon packet lifecycle runtime.
+- **Phase 2**: Orchestrator planning/dispatch adapters.
+- **Phase 3**: Directory + ack/retry/dead-letter runtime and docs/tests.

--- a/feat/horizon-control-plane/phase-3-directory-ack-retry/tasks/PHASE_1.MD
+++ b/feat/horizon-control-plane/phase-3-directory-ack-retry/tasks/PHASE_1.MD
@@ -1,0 +1,34 @@
+# Phase 1 - Horizon Directory + Ack/Retry Baseline
+
+## P1.0 Scope Discipline
+1. [x] Keep phase scope additive and decoupled from Ops Manager runtime internals.
+2. [x] Keep changes limited to Horizon scripts/contracts/docs/tests.
+
+## P1.1 Directory Primitive
+1. [x] Add `schema/horizon-directory.schema.json`.
+2. [x] Add `docs/examples/horizon-directory.example.json`.
+3. [x] Add `scripts/validate-horizon-directory.sh` with strict + non-strict validation paths.
+
+## P1.2 Orchestrator Directory Integration
+1. [x] Extend `scripts/horizon-orchestrate.sh` with `--directory-file` and `--directory-mode`.
+2. [x] Support directory-driven adapter/target overrides with optional fallback behavior.
+3. [x] Enforce required-mode fail-closed behavior for unknown recipients.
+
+## P1.3 Ack + Retry Runtime
+1. [x] Add `scripts/horizon-ack.sh` for deterministic receipt ingest and idempotent dedupe.
+2. [x] Add `scripts/horizon-retry.sh` reconcile loop with timeout/backoff/retry budget controls.
+3. [x] Persist ack/retry/dead-letter artifacts under `.superloop/horizons/`.
+
+## P1.4 Tests
+1. [x] Add `tests/horizon-directory.bats` for directory validator behavior.
+2. [x] Add `tests/horizon-ack.bats` for ack transition + dedupe behavior.
+3. [x] Add `tests/horizon-retry.bats` for retry + escalation/dead-letter behavior.
+4. [x] Extend `tests/horizon-orchestrate.bats` for directory-mode behaviors.
+
+## P1.5 Documentation
+1. [x] Update `docs/horizon-planning.md` with Phase 3 contracts/commands/artifacts.
+2. [x] Update `README.md` Horizon section with directory + ack/retry surfaces.
+
+## P1.V Validation
+1. [x] `bash -n scripts/horizon-orchestrate.sh scripts/horizon-ack.sh scripts/horizon-retry.sh scripts/validate-horizon-directory.sh` passes.
+2. [x] `/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats tests/horizon-directory.bats tests/horizon-ack.bats tests/horizon-retry.bats` passes.

--- a/schema/horizon-directory.schema.json
+++ b/schema/horizon-directory.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Superloop Horizon Directory",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "contacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "recipient": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "id": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": ["type", "id"]
+          },
+          "dispatch": {
+            "type": "object",
+            "properties": {
+              "adapter": {
+                "type": "string",
+                "enum": ["filesystem_outbox", "stdout"]
+              },
+              "target": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": ["adapter"]
+          },
+          "ack": {
+            "type": "object",
+            "properties": {
+              "timeout_seconds": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "max_retries": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "retry_backoff_seconds": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": ["recipient", "dispatch"]
+      }
+    }
+  },
+  "required": ["version", "contacts"]
+}

--- a/scripts/horizon-ack.sh
+++ b/scripts/horizon-ack.sh
@@ -1,0 +1,501 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/horizon-ack.sh ingest [options]
+
+Common options:
+  --repo <path>               Repository path (default: .)
+  --state-dir <path>          Horizon state directory (default: <repo>/.superloop/horizons)
+  --file <path>               Receipt JSONL file path (default: stdin)
+  --ack-state-file <path>     Ack dedupe state file (default: <state-dir>/ack-state.json)
+  --ack-telemetry-file <path> Ack telemetry JSONL file (default: <state-dir>/telemetry/ack.jsonl)
+  --retry-state-file <path>   Retry state file (default: <state-dir>/retry-state.json)
+  --actor <id>                Default actor for transitions (default: horizon-ack)
+  --reason <text>             Default reason for acknowledged receipts (default: delivery_acknowledged)
+  --dry-run                   Validate/process receipts without mutating packet/state artifacts
+  --pretty                    Pretty-print JSON output
+
+Receipt contract (JSONL, one object per line):
+  required fields:
+    - schemaVersion: "v1"
+    - packetId: string
+    - traceId: string
+    - status: acknowledged|failed|escalated|cancelled
+  optional fields:
+    - receiptId: string (dedupe key; if absent, a hash key is derived)
+    - by: string
+    - reason: string
+    - note: string
+    - evidenceRefs: string[]
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "missing required command: $cmd"
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+emit_json() {
+  local json="$1"
+  local pretty="${2:-0}"
+  if [[ "$pretty" == "1" ]]; then
+    jq '.' <<<"$json"
+  else
+    jq -c '.' <<<"$json"
+  fi
+}
+
+hash_text() {
+  local value="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$value" | sha256sum | awk '{print $1}'
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    printf '%s' "$value" | openssl dgst -sha256 | awk '{print $2}'
+    return 0
+  fi
+  printf 'fallback-%s-%s\n' "$$" "$RANDOM"
+}
+
+append_telemetry() {
+  local telemetry_file="$1"
+  local payload_json="$2"
+  mkdir -p "$(dirname "$telemetry_file")"
+  jq -c '.' <<<"$payload_json" >> "$telemetry_file"
+}
+
+CMD="${1:-}"
+if [[ -z "$CMD" || "$CMD" == "--help" || "$CMD" == "-h" ]]; then
+  usage
+  [[ -n "$CMD" ]] && exit 0 || exit 1
+fi
+shift
+
+case "$CMD" in
+  ingest)
+    ;;
+  *)
+    usage
+    die "unknown command: $CMD"
+    ;;
+esac
+
+REPO="."
+STATE_DIR=""
+INPUT_FILE="-"
+ACK_STATE_FILE=""
+ACK_TELEMETRY_FILE=""
+RETRY_STATE_FILE=""
+ACTOR="horizon-ack"
+DEFAULT_REASON="delivery_acknowledged"
+DRY_RUN="0"
+PRETTY="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="${2:-}"
+      shift 2
+      ;;
+    --file)
+      INPUT_FILE="${2:-}"
+      shift 2
+      ;;
+    --ack-state-file)
+      ACK_STATE_FILE="${2:-}"
+      shift 2
+      ;;
+    --ack-telemetry-file)
+      ACK_TELEMETRY_FILE="${2:-}"
+      shift 2
+      ;;
+    --retry-state-file)
+      RETRY_STATE_FILE="${2:-}"
+      shift 2
+      ;;
+    --actor)
+      ACTOR="${2:-}"
+      shift 2
+      ;;
+    --reason)
+      DEFAULT_REASON="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="1"
+      shift
+      ;;
+    --pretty)
+      PRETTY="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+REPO="$(cd "$REPO" && pwd)"
+if [[ -z "$STATE_DIR" ]]; then
+  STATE_DIR="$REPO/.superloop/horizons"
+fi
+if [[ "$STATE_DIR" != /* ]]; then
+  STATE_DIR="$REPO/$STATE_DIR"
+fi
+if [[ -z "$ACK_STATE_FILE" ]]; then
+  ACK_STATE_FILE="$STATE_DIR/ack-state.json"
+fi
+if [[ "$ACK_STATE_FILE" != /* ]]; then
+  ACK_STATE_FILE="$REPO/$ACK_STATE_FILE"
+fi
+if [[ -z "$ACK_TELEMETRY_FILE" ]]; then
+  ACK_TELEMETRY_FILE="$STATE_DIR/telemetry/ack.jsonl"
+fi
+if [[ "$ACK_TELEMETRY_FILE" != /* ]]; then
+  ACK_TELEMETRY_FILE="$REPO/$ACK_TELEMETRY_FILE"
+fi
+if [[ -z "$RETRY_STATE_FILE" ]]; then
+  RETRY_STATE_FILE="$STATE_DIR/retry-state.json"
+fi
+if [[ "$RETRY_STATE_FILE" != /* ]]; then
+  RETRY_STATE_FILE="$REPO/$RETRY_STATE_FILE"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HORIZON_PACKET_SCRIPT="$SCRIPT_DIR/horizon-packet.sh"
+[[ -x "$HORIZON_PACKET_SCRIPT" ]] || die "required script not executable: $HORIZON_PACKET_SCRIPT"
+
+if [[ "$INPUT_FILE" != "-" && ! -f "$INPUT_FILE" ]]; then
+  die "receipt file not found: $INPUT_FILE"
+fi
+
+if [[ -f "$ACK_STATE_FILE" ]]; then
+  ACK_STATE_JSON="$(jq -c '.' "$ACK_STATE_FILE" 2>/dev/null)" || die "invalid ack state file: $ACK_STATE_FILE"
+else
+  ACK_STATE_JSON='{"schemaVersion":"v1","updatedAt":null,"processedKeys":{}}'
+fi
+
+ACK_STATE_JSON="$(jq -c '
+  if (.processedKeys | type) != "object" then .processedKeys = {} else . end
+  | if .schemaVersion == null then .schemaVersion = "v1" else . end
+  | if (.updatedAt // null) == null then . else . end
+' <<<"$ACK_STATE_JSON")"
+
+if [[ -f "$RETRY_STATE_FILE" ]]; then
+  RETRY_STATE_JSON="$(jq -c '.' "$RETRY_STATE_FILE" 2>/dev/null)" || die "invalid retry state file: $RETRY_STATE_FILE"
+else
+  RETRY_STATE_JSON='{"schemaVersion":"v1","updatedAt":null,"packets":{}}'
+fi
+
+RETRY_STATE_JSON="$(jq -c '
+  if (.packets | type) != "object" then .packets = {} else . end
+  | if .schemaVersion == null then .schemaVersion = "v1" else . end
+' <<<"$RETRY_STATE_JSON")"
+
+processed_count=0
+mutated_count=0
+duplicate_count=0
+rejected_count=0
+error_count=0
+result_lines=()
+
+input_stream="$INPUT_FILE"
+if [[ "$INPUT_FILE" == "-" ]]; then
+  input_stream="/dev/stdin"
+fi
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "${line//[[:space:]]/}" ]]; then
+    continue
+  fi
+
+  received_at="$(timestamp)"
+  line_hash="$(hash_text "$line")"
+
+  if ! receipt_json="$(jq -c '.' <<<"$line" 2>/dev/null)"; then
+    rejected_count=$((rejected_count + 1))
+    result_lines+=("$(jq -cn --arg status "rejected" --arg reason "invalid_json" --arg line_hash "$line_hash" --arg received_at "$received_at" '{status:$status,reason:$reason,lineHash:$line_hash,receivedAt:$received_at}')")
+    continue
+  fi
+
+  schema_version="$(jq -r '.schemaVersion // empty' <<<"$receipt_json")"
+  packet_id="$(jq -r '.packetId // empty' <<<"$receipt_json")"
+  trace_id="$(jq -r '.traceId // empty' <<<"$receipt_json")"
+  receipt_status="$(jq -r '.status // empty' <<<"$receipt_json")"
+  receipt_id="$(jq -r '.receiptId // empty' <<<"$receipt_json")"
+  receipt_actor="$(jq -r '.by // empty' <<<"$receipt_json")"
+  receipt_reason="$(jq -r '.reason // empty' <<<"$receipt_json")"
+  receipt_note="$(jq -r '.note // empty' <<<"$receipt_json")"
+
+  if [[ -z "$receipt_id" ]]; then
+    receipt_id="ack-${line_hash}"
+  fi
+
+  if [[ "$schema_version" != "v1" || -z "$packet_id" || -z "$trace_id" ]]; then
+    rejected_count=$((rejected_count + 1))
+    result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "rejected" --arg reason "missing_required_fields" --arg received_at "$received_at" '{packetId:(if ($packet_id|length)>0 then $packet_id else null end),traceId:(if ($trace_id|length)>0 then $trace_id else null end),receiptId:$receipt_id,status:$status,reason:$reason,receivedAt:$received_at}')")
+    continue
+  fi
+
+  case "$receipt_status" in
+    acknowledged|failed|escalated|cancelled)
+      ;;
+    *)
+      rejected_count=$((rejected_count + 1))
+      result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "rejected" --arg reason "invalid_status" --arg receipt_status "$receipt_status" --arg received_at "$received_at" '{packetId:$packet_id,traceId:$trace_id,receiptId:$receipt_id,status:$status,reason:$reason,receiptStatus:(if ($receipt_status|length)>0 then $receipt_status else null end),receivedAt:$received_at}')")
+      continue
+      ;;
+  esac
+
+  if jq -e --arg key "$receipt_id" '.processedKeys[$key] != null' <<<"$ACK_STATE_JSON" >/dev/null; then
+    duplicate_count=$((duplicate_count + 1))
+    result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "duplicate" --arg reason "already_processed" --arg received_at "$received_at" '{packetId:$packet_id,traceId:$trace_id,receiptId:$receipt_id,status:$status,reason:$reason,receivedAt:$received_at}')")
+    continue
+  fi
+
+  packet_file="$STATE_DIR/packets/$packet_id.json"
+  if [[ ! -f "$packet_file" ]]; then
+    rejected_count=$((rejected_count + 1))
+    result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "rejected" --arg reason "packet_not_found" --arg received_at "$received_at" '{packetId:$packet_id,traceId:$trace_id,receiptId:$receipt_id,status:$status,reason:$reason,receivedAt:$received_at}')")
+    continue
+  fi
+
+  current_status="$(jq -r '.status // empty' "$packet_file")"
+  if [[ -z "$current_status" ]]; then
+    rejected_count=$((rejected_count + 1))
+    result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "rejected" --arg reason "packet_status_missing" --arg received_at "$received_at" '{packetId:$packet_id,traceId:$trace_id,receiptId:$receipt_id,status:$status,reason:$reason,receivedAt:$received_at}')")
+    continue
+  fi
+
+  transition_required="1"
+  case "$receipt_status" in
+    acknowledged)
+      if [[ "$current_status" == "acknowledged" || "$current_status" == "in_progress" || "$current_status" == "completed" ]]; then
+        transition_required="0"
+      fi
+      ;;
+    failed)
+      if [[ "$current_status" == "failed" || "$current_status" == "escalated" || "$current_status" == "cancelled" ]]; then
+        transition_required="0"
+      fi
+      ;;
+    escalated)
+      if [[ "$current_status" == "escalated" || "$current_status" == "cancelled" ]]; then
+        transition_required="0"
+      fi
+      ;;
+    cancelled)
+      if [[ "$current_status" == "cancelled" ]]; then
+        transition_required="0"
+      fi
+      ;;
+  esac
+
+  if [[ -z "$receipt_actor" ]]; then
+    receipt_actor="$ACTOR"
+  fi
+  if [[ -z "$receipt_reason" ]]; then
+    case "$receipt_status" in
+      acknowledged)
+        receipt_reason="$DEFAULT_REASON"
+        ;;
+      failed)
+        receipt_reason="delivery_failed"
+        ;;
+      escalated)
+        receipt_reason="delivery_escalated"
+        ;;
+      cancelled)
+        receipt_reason="delivery_cancelled"
+        ;;
+    esac
+  fi
+
+  transition_error=""
+  if [[ "$transition_required" == "1" && "$DRY_RUN" != "1" ]]; then
+    transition_cmd=("$HORIZON_PACKET_SCRIPT" transition
+      --repo "$REPO"
+      --state-dir "$STATE_DIR"
+      --packet-id "$packet_id"
+      --to-status "$receipt_status"
+      --by "$receipt_actor"
+      --reason "$receipt_reason")
+
+    if [[ -n "$receipt_note" ]]; then
+      transition_cmd+=(--note "$receipt_note")
+    fi
+
+    mapfile -t receipt_refs < <(jq -r '.evidenceRefs // [] | .[]' <<<"$receipt_json")
+    if [[ ${#receipt_refs[@]} -gt 0 ]]; then
+      for ref in "${receipt_refs[@]}"; do
+        if [[ -n "$ref" ]]; then
+          transition_cmd+=(--evidence-ref "$ref")
+        fi
+      done
+    fi
+
+    if ! transition_output="$("${transition_cmd[@]}" 2>&1)"; then
+      transition_error="$transition_output"
+      error_count=$((error_count + 1))
+    fi
+  fi
+
+  if [[ -n "$transition_error" ]]; then
+    result_lines+=("$(jq -cn --arg packet_id "$packet_id" --arg trace_id "$trace_id" --arg receipt_id "$receipt_id" --arg status "error" --arg reason "transition_failed" --arg error "$transition_error" --arg received_at "$received_at" '{packetId:$packet_id,traceId:$trace_id,receiptId:$receipt_id,status:$status,reason:$reason,error:$error,receivedAt:$received_at}')")
+    continue
+  fi
+
+  processed_count=$((processed_count + 1))
+  if [[ "$transition_required" == "1" ]]; then
+    mutated_count=$((mutated_count + 1))
+  fi
+
+  if [[ "$DRY_RUN" != "1" ]]; then
+    ACK_STATE_JSON="$(jq -c \
+      --arg key "$receipt_id" \
+      --arg at "$received_at" \
+      --arg packet_id "$packet_id" \
+      --arg trace_id "$trace_id" \
+      --arg receipt_status "$receipt_status" '
+      .processedKeys[$key] = {
+        at: $at,
+        packetId: $packet_id,
+        traceId: $trace_id,
+        status: $receipt_status
+      }
+      | .updatedAt = $at
+    ' <<<"$ACK_STATE_JSON")"
+
+    if [[ "$receipt_status" == "acknowledged" ]]; then
+      RETRY_STATE_JSON="$(jq -c --arg packet_id "$packet_id" --arg at "$received_at" '
+        .packets |= (if type == "object" then . else {} end)
+        | del(.packets[$packet_id])
+        | .updatedAt = $at
+      ' <<<"$RETRY_STATE_JSON")"
+    fi
+  fi
+
+  result_status="processed"
+  if [[ "$transition_required" == "0" ]]; then
+    result_status="noop"
+  elif [[ "$DRY_RUN" == "1" ]]; then
+    result_status="dry_run"
+  fi
+
+  result_lines+=("$(jq -cn \
+    --arg packet_id "$packet_id" \
+    --arg trace_id "$trace_id" \
+    --arg receipt_id "$receipt_id" \
+    --arg receipt_status "$receipt_status" \
+    --arg result_status "$result_status" \
+    --arg current_status "$current_status" \
+    --arg actor "$receipt_actor" \
+    --arg reason "$receipt_reason" \
+    --arg received_at "$received_at" '
+    {
+      packetId: $packet_id,
+      traceId: $trace_id,
+      receiptId: $receipt_id,
+      receiptStatus: $receipt_status,
+      resultStatus: $result_status,
+      fromStatus: $current_status,
+      actor: $actor,
+      reason: $reason,
+      receivedAt: $received_at
+    }
+  ')")
+
+done < "$input_stream"
+
+if [[ ${#result_lines[@]} -eq 0 ]]; then
+  results_json='[]'
+else
+  results_json="$(printf '%s\n' "${result_lines[@]}" | jq -s '.')"
+fi
+
+run_timestamp="$(timestamp)"
+result_json="$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$run_timestamp" \
+  --arg category "horizon_ack_ingest" \
+  --arg actor "$ACTOR" \
+  --arg default_reason "$DEFAULT_REASON" \
+  --argjson dry_run "$( [[ "$DRY_RUN" == "1" ]] && echo true || echo false )" \
+  --arg file "$INPUT_FILE" \
+  --arg state_file "$ACK_STATE_FILE" \
+  --arg telemetry_file "$ACK_TELEMETRY_FILE" \
+  --arg retry_state_file "$RETRY_STATE_FILE" \
+  --argjson processed "$processed_count" \
+  --argjson mutated "$mutated_count" \
+  --argjson duplicate "$duplicate_count" \
+  --argjson rejected "$rejected_count" \
+  --argjson errors "$error_count" \
+  --argjson results "$results_json" '
+  {
+    schemaVersion: $schema_version,
+    timestamp: $timestamp,
+    category: $category,
+    actor: $actor,
+    defaultReason: $default_reason,
+    dryRun: $dry_run,
+    input: {
+      file: (if $file == "-" then "stdin" else $file end)
+    },
+    artifacts: {
+      ackStateFile: $state_file,
+      ackTelemetryFile: $telemetry_file,
+      retryStateFile: $retry_state_file
+    },
+    summary: {
+      processedCount: $processed,
+      mutatedCount: $mutated,
+      duplicateCount: $duplicate,
+      rejectedCount: $rejected,
+      errorCount: $errors
+    },
+    results: $results
+  }
+')"
+
+if [[ "$DRY_RUN" != "1" ]]; then
+  mkdir -p "$(dirname "$ACK_STATE_FILE")"
+  jq -c '.' <<<"$ACK_STATE_JSON" > "$ACK_STATE_FILE"
+
+  mkdir -p "$(dirname "$RETRY_STATE_FILE")"
+  jq -c '.' <<<"$RETRY_STATE_JSON" > "$RETRY_STATE_FILE"
+
+  append_telemetry "$ACK_TELEMETRY_FILE" "$result_json"
+fi
+
+emit_json "$result_json" "$PRETTY"
+
+if [[ "$error_count" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/horizon-retry.sh
+++ b/scripts/horizon-retry.sh
@@ -1,0 +1,908 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/horizon-retry.sh reconcile [options]
+
+Common options:
+  --repo <path>                 Repository path (default: .)
+  --state-dir <path>            Horizon state directory (default: <repo>/.superloop/horizons)
+  --outbox-dir <path>           Outbox directory for filesystem adapter (default: <state-dir>/outbox)
+  --directory-file <path>       Horizon directory file path (default: <repo>/.superloop/horizon-directory.json)
+  --directory-mode <mode>       Directory mode: off|optional|required (default: optional)
+  --horizon-ref <id>            Optional horizon filter
+  --recipient-type <type>       Optional recipient type filter
+  --limit <n>                   Max dispatched packets to evaluate (default: 50)
+  --adapter <filesystem_outbox|stdout>
+                                Adapter fallback when directory does not override (default: filesystem_outbox)
+  --retry-state-file <path>     Retry state file (default: <state-dir>/retry-state.json)
+  --retry-telemetry-file <path> Retry telemetry jsonl (default: <state-dir>/telemetry/retry.jsonl)
+  --dead-letter-file <path>     Dead-letter jsonl (default: <state-dir>/telemetry/dead-letter.jsonl)
+  --ack-timeout-seconds <n>     Ack timeout before retry/escalation (default: 600)
+  --max-retries <n>             Max retries before escalation (default: 3)
+  --retry-backoff-seconds <n>   Backoff between retries (default: 120)
+  --actor <id>                  Actor used for escalations/failure transitions (default: horizon-retry)
+  --reason <text>               Reason used for retry dispatch envelopes (default: packet_retry_dispatch)
+  --trace-id <id>               Optional run trace id
+  --evidence-ref <ref>          Optional evidence ref, can be repeated
+  --dry-run                     Evaluate and plan actions without mutating files
+  --pretty                      Pretty-print output JSON
+
+Behavior:
+  - Evaluates packets currently in `dispatched` state.
+  - If ack timeout has not elapsed: no retry action.
+  - If timeout elapsed and retries remain: re-dispatch via adapter.
+  - If timeout elapsed and retries exhausted: transition packet to `escalated` and append dead-letter record.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "missing required command: $cmd"
+}
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+generate_trace_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+  printf 'hrr-%s-%s-%04d\n' "$(date -u +%Y%m%d%H%M%S)" "$$" "$RANDOM"
+}
+
+emit_json() {
+  local json="$1"
+  local pretty="${2:-0}"
+  if [[ "$pretty" == "1" ]]; then
+    jq '.' <<<"$json"
+  else
+    jq -c '.' <<<"$json"
+  fi
+}
+
+relative_or_original_path() {
+  local base="$1"
+  local path="$2"
+  if [[ "$path" == "$base"/* ]]; then
+    echo "${path#$base/}"
+  else
+    echo "$path"
+  fi
+}
+
+build_custom_evidence_refs_json() {
+  if [[ ${#EVIDENCE_REFS[@]} -eq 0 ]]; then
+    echo '[]'
+    return 0
+  fi
+  printf '%s\n' "${EVIDENCE_REFS[@]}" | jq -Rsc 'split("\n")[:-1] | map(select(length > 0))'
+}
+
+append_jsonl() {
+  local file="$1"
+  local payload="$2"
+  mkdir -p "$(dirname "$file")"
+  jq -c '.' <<<"$payload" >> "$file"
+}
+
+load_directory_contacts() {
+  local mode="$1"
+  local file="$2"
+
+  DIRECTORY_ENABLED="0"
+  DIRECTORY_CONTACTS_JSON='{}'
+
+  if [[ "$mode" == "off" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "$file" ]]; then
+    if [[ "$mode" == "required" ]]; then
+      die "directory mode is required but file is missing: $file"
+    fi
+    return 0
+  fi
+
+  jq -e '
+    .version == 1 and
+    (.contacts | type == "array") and
+    ([.contacts[] | .recipient.type + "|" + .recipient.id] | length == (unique | length))
+  ' "$file" >/dev/null || die "invalid horizon directory file: $file"
+
+  DIRECTORY_CONTACTS_JSON="$(jq -c '
+    .contacts
+    | map({
+        key: ((.recipient.type // "") + "|" + (.recipient.id // "")),
+        value: {
+          dispatchAdapter: (.dispatch.adapter // null),
+          dispatchTarget: (.dispatch.target // null),
+          ackTimeoutSeconds: (.ack.timeout_seconds // null),
+          maxRetries: (.ack.max_retries // null),
+          retryBackoffSeconds: (.ack.retry_backoff_seconds // null)
+        }
+      })
+    | from_entries
+  ' "$file")"
+
+  DIRECTORY_ENABLED="1"
+}
+
+resolve_route_and_policy() {
+  local packet_json="$1"
+
+  jq -cn \
+    --arg default_adapter "$ADAPTER" \
+    --arg outbox_dir "$OUTBOX_DIR" \
+    --arg directory_mode "$DIRECTORY_MODE" \
+    --arg directory_file "$DIRECTORY_FILE" \
+    --argjson directory_enabled "$( [[ "$DIRECTORY_ENABLED" == "1" ]] && echo true || echo false )" \
+    --argjson directory_contacts "$DIRECTORY_CONTACTS_JSON" \
+    --argjson default_ack_timeout "$ACK_TIMEOUT_SECONDS" \
+    --argjson default_max_retries "$MAX_RETRIES" \
+    --argjson default_backoff "$RETRY_BACKOFF_SECONDS" '
+    $packet_json as $packet
+    | (($packet.recipient.type // "") | gsub("[^A-Za-z0-9._-]"; "_")) as $safe_type
+    | (($packet.recipient.id // "") | gsub("[^A-Za-z0-9._-]"; "_")) as $safe_id
+    | (($packet.recipient.type // "") + "|" + ($packet.recipient.id // "")) as $contact_key
+    | ($directory_contacts[$contact_key] // null) as $contact
+    | (
+        if ($directory_enabled and $contact != null and (($contact.dispatchAdapter // "") | length) > 0)
+        then $contact.dispatchAdapter
+        else $default_adapter
+        end
+      ) as $adapter
+    | (
+        if $adapter == "filesystem_outbox"
+        then (
+          if ($directory_enabled and $contact != null and (($contact.dispatchTarget // "") | length) > 0)
+          then (
+            if ($contact.dispatchTarget | startswith("/"))
+            then $contact.dispatchTarget
+            else ($outbox_dir + "/" + $contact.dispatchTarget)
+            end
+          )
+          else ($outbox_dir + "/" + $safe_type + "/" + $safe_id + ".jsonl")
+          end
+        )
+        elif $adapter == "stdout"
+        then "stdout://horizon-retry"
+        else null
+        end
+      ) as $target
+    | {
+        directory: {
+          enabled: $directory_enabled,
+          mode: $directory_mode,
+          file: (if $directory_enabled then $directory_file else null end),
+          contactKey: $contact_key,
+          matched: ($contact != null)
+        },
+        route: {
+          adapter: $adapter,
+          target: $target
+        },
+        policy: {
+          ackTimeoutSeconds: (
+            if ($contact != null and ($contact.ackTimeoutSeconds // null) != null and (($contact.ackTimeoutSeconds | type) == "number") and ($contact.ackTimeoutSeconds >= 0) and ($contact.ackTimeoutSeconds == ($contact.ackTimeoutSeconds | floor)))
+            then ($contact.ackTimeoutSeconds | floor)
+            else $default_ack_timeout
+            end
+          ),
+          maxRetries: (
+            if ($contact != null and ($contact.maxRetries // null) != null and (($contact.maxRetries | type) == "number") and ($contact.maxRetries >= 0) and ($contact.maxRetries == ($contact.maxRetries | floor)))
+            then ($contact.maxRetries | floor)
+            else $default_max_retries
+            end
+          ),
+          retryBackoffSeconds: (
+            if ($contact != null and ($contact.retryBackoffSeconds // null) != null and (($contact.retryBackoffSeconds | type) == "number") and ($contact.retryBackoffSeconds >= 0) and ($contact.retryBackoffSeconds == ($contact.retryBackoffSeconds | floor)))
+            then ($contact.retryBackoffSeconds | floor)
+            else $default_backoff
+            end
+          )
+        }
+      }
+  ' --argjson packet_json "$packet_json"
+}
+
+build_retry_envelope() {
+  local packet_json="$1"
+  local adapter="$2"
+  local target="$3"
+  local attempt="$4"
+
+  jq -cn \
+    --arg schema_version "v1" \
+    --arg timestamp "$(timestamp)" \
+    --arg category "horizon_dispatch_retry" \
+    --arg trace_id "$TRACE_ID" \
+    --arg actor "$ACTOR" \
+    --arg adapter "$adapter" \
+    --arg target "$target" \
+    --arg reason "$REASON" \
+    --argjson attempt "$attempt" \
+    --argjson packet "$packet_json" \
+    --argjson evidence_refs "$CUSTOM_EVIDENCE_REFS_JSON" '
+    {
+      schemaVersion: $schema_version,
+      timestamp: $timestamp,
+      category: $category,
+      traceId: $trace_id,
+      actor: $actor,
+      adapter: $adapter,
+      target: (if ($target | length) > 0 then $target else null end),
+      reason: $reason,
+      retryAttempt: $attempt,
+      packet: {
+        packetId: ($packet.packetId // null),
+        horizonRef: ($packet.horizonRef // null),
+        loopId: ($packet.loopId // null),
+        sender: ($packet.sender // null),
+        recipient: ($packet.recipient // {type: null, id: null}),
+        intent: ($packet.intent // null),
+        traceId: ($packet.traceId // null)
+      },
+      evidenceRefs: $evidence_refs
+    }
+  '
+}
+
+CMD="${1:-}"
+if [[ -z "$CMD" || "$CMD" == "--help" || "$CMD" == "-h" ]]; then
+  usage
+  [[ -n "$CMD" ]] && exit 0 || exit 1
+fi
+shift
+
+case "$CMD" in
+  reconcile)
+    ;;
+  *)
+    usage
+    die "unknown command: $CMD"
+    ;;
+esac
+
+REPO="."
+STATE_DIR=""
+OUTBOX_DIR=""
+DIRECTORY_FILE=""
+DIRECTORY_MODE="optional"
+HORIZON_REF_FILTER=""
+RECIPIENT_TYPE_FILTER=""
+LIMIT="50"
+ADAPTER="filesystem_outbox"
+RETRY_STATE_FILE=""
+RETRY_TELEMETRY_FILE=""
+DEAD_LETTER_FILE=""
+ACK_TIMEOUT_SECONDS="600"
+MAX_RETRIES="3"
+RETRY_BACKOFF_SECONDS="120"
+ACTOR="horizon-retry"
+REASON="packet_retry_dispatch"
+TRACE_ID=""
+DRY_RUN="0"
+PRETTY="0"
+EVIDENCE_REFS=()
+DIRECTORY_ENABLED="0"
+DIRECTORY_CONTACTS_JSON='{}'
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="${2:-}"
+      shift 2
+      ;;
+    --outbox-dir)
+      OUTBOX_DIR="${2:-}"
+      shift 2
+      ;;
+    --directory-file)
+      DIRECTORY_FILE="${2:-}"
+      shift 2
+      ;;
+    --directory-mode)
+      DIRECTORY_MODE="${2:-}"
+      shift 2
+      ;;
+    --horizon-ref)
+      HORIZON_REF_FILTER="${2:-}"
+      shift 2
+      ;;
+    --recipient-type)
+      RECIPIENT_TYPE_FILTER="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    --adapter)
+      ADAPTER="${2:-}"
+      shift 2
+      ;;
+    --retry-state-file)
+      RETRY_STATE_FILE="${2:-}"
+      shift 2
+      ;;
+    --retry-telemetry-file)
+      RETRY_TELEMETRY_FILE="${2:-}"
+      shift 2
+      ;;
+    --dead-letter-file)
+      DEAD_LETTER_FILE="${2:-}"
+      shift 2
+      ;;
+    --ack-timeout-seconds)
+      ACK_TIMEOUT_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --max-retries)
+      MAX_RETRIES="${2:-}"
+      shift 2
+      ;;
+    --retry-backoff-seconds)
+      RETRY_BACKOFF_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --actor)
+      ACTOR="${2:-}"
+      shift 2
+      ;;
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --trace-id)
+      TRACE_ID="${2:-}"
+      shift 2
+      ;;
+    --evidence-ref)
+      EVIDENCE_REFS+=("${2:-}")
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="1"
+      shift
+      ;;
+    --pretty)
+      PRETTY="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+[[ "$LIMIT" =~ ^[0-9]+$ ]] || die "--limit must be an integer >= 0"
+[[ "$ACK_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || die "--ack-timeout-seconds must be an integer >= 0"
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || die "--max-retries must be an integer >= 0"
+[[ "$RETRY_BACKOFF_SECONDS" =~ ^[0-9]+$ ]] || die "--retry-backoff-seconds must be an integer >= 0"
+
+case "$ADAPTER" in
+  filesystem_outbox|stdout)
+    ;;
+  *)
+    die "invalid --adapter: $ADAPTER"
+    ;;
+esac
+
+case "$DIRECTORY_MODE" in
+  off|optional|required)
+    ;;
+  *)
+    die "invalid --directory-mode: $DIRECTORY_MODE"
+    ;;
+esac
+
+REPO="$(cd "$REPO" && pwd)"
+if [[ -z "$STATE_DIR" ]]; then
+  STATE_DIR="$REPO/.superloop/horizons"
+fi
+if [[ "$STATE_DIR" != /* ]]; then
+  STATE_DIR="$REPO/$STATE_DIR"
+fi
+if [[ -z "$OUTBOX_DIR" ]]; then
+  OUTBOX_DIR="$STATE_DIR/outbox"
+fi
+if [[ "$OUTBOX_DIR" != /* ]]; then
+  OUTBOX_DIR="$REPO/$OUTBOX_DIR"
+fi
+if [[ -z "$DIRECTORY_FILE" ]]; then
+  DIRECTORY_FILE="$REPO/.superloop/horizon-directory.json"
+fi
+if [[ "$DIRECTORY_FILE" != /* ]]; then
+  DIRECTORY_FILE="$REPO/$DIRECTORY_FILE"
+fi
+if [[ -z "$RETRY_STATE_FILE" ]]; then
+  RETRY_STATE_FILE="$STATE_DIR/retry-state.json"
+fi
+if [[ "$RETRY_STATE_FILE" != /* ]]; then
+  RETRY_STATE_FILE="$REPO/$RETRY_STATE_FILE"
+fi
+if [[ -z "$RETRY_TELEMETRY_FILE" ]]; then
+  RETRY_TELEMETRY_FILE="$STATE_DIR/telemetry/retry.jsonl"
+fi
+if [[ "$RETRY_TELEMETRY_FILE" != /* ]]; then
+  RETRY_TELEMETRY_FILE="$REPO/$RETRY_TELEMETRY_FILE"
+fi
+if [[ -z "$DEAD_LETTER_FILE" ]]; then
+  DEAD_LETTER_FILE="$STATE_DIR/telemetry/dead-letter.jsonl"
+fi
+if [[ "$DEAD_LETTER_FILE" != /* ]]; then
+  DEAD_LETTER_FILE="$REPO/$DEAD_LETTER_FILE"
+fi
+
+load_directory_contacts "$DIRECTORY_MODE" "$DIRECTORY_FILE"
+
+if [[ -z "$TRACE_ID" ]]; then
+  TRACE_ID="${HORIZON_TRACE_ID:-}"
+fi
+if [[ -z "$TRACE_ID" ]]; then
+  TRACE_ID="$(generate_trace_id)"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HORIZON_PACKET_SCRIPT="$SCRIPT_DIR/horizon-packet.sh"
+[[ -x "$HORIZON_PACKET_SCRIPT" ]] || die "required script not executable: $HORIZON_PACKET_SCRIPT"
+
+PACKETS_DIR="$STATE_DIR/packets"
+if [[ -d "$PACKETS_DIR" ]]; then
+  mapfile -t PACKET_FILES < <(find "$PACKETS_DIR" -maxdepth 1 -type f -name '*.json' | sort)
+else
+  PACKET_FILES=()
+fi
+
+if [[ ${#PACKET_FILES[@]} -eq 0 ]]; then
+  dispatched_packets_json='[]'
+else
+  dispatched_packets_json="$(jq -s \
+    --arg horizon_ref "$HORIZON_REF_FILTER" \
+    --arg recipient_type "$RECIPIENT_TYPE_FILTER" \
+    '[ .[]
+      | select((.status // "") == "dispatched")
+      | select(
+          if ($horizon_ref | length) > 0
+          then (.horizonRef // "") == $horizon_ref
+          else true
+          end
+        )
+      | select(
+          if ($recipient_type | length) > 0
+          then (.recipient.type // "") == $recipient_type
+          else true
+          end
+        )
+    ]
+    | sort_by((.updatedAt // ""), (.packetId // ""))' "${PACKET_FILES[@]}")"
+fi
+
+selected_packets_json="$(jq -c --argjson limit "$LIMIT" '
+  if $limit == 0 then [] else .[0:$limit] end
+' <<<"$dispatched_packets_json")"
+
+if [[ -f "$RETRY_STATE_FILE" ]]; then
+  RETRY_STATE_JSON="$(jq -c '.' "$RETRY_STATE_FILE" 2>/dev/null)" || die "invalid retry state file: $RETRY_STATE_FILE"
+else
+  RETRY_STATE_JSON='{"schemaVersion":"v1","updatedAt":null,"packets":{}}'
+fi
+RETRY_STATE_JSON="$(jq -c 'if (.packets|type)!="object" then .packets={} else . end | if .schemaVersion==null then .schemaVersion="v1" else . end' <<<"$RETRY_STATE_JSON")"
+
+CUSTOM_EVIDENCE_REFS_JSON="$(build_custom_evidence_refs_json)"
+NOW_EPOCH="$(date -u +%s)"
+RUN_AT="$(timestamp)"
+
+considered_count=0
+retry_due_count=0
+retried_count=0
+escalated_count=0
+blocked_count=0
+error_count=0
+result_lines=()
+dead_letter_lines=()
+
+mapfile -t packet_items < <(jq -c '.[]' <<<"$selected_packets_json")
+
+for packet_json in "${packet_items[@]}"; do
+  considered_count=$((considered_count + 1))
+
+  packet_id="$(jq -r '.packetId // empty' <<<"$packet_json")"
+  packet_trace_id="$(jq -r '.traceId // empty' <<<"$packet_json")"
+  updated_at="$(jq -r '.updatedAt // empty' <<<"$packet_json")"
+
+  resolved_json="$(resolve_route_and_policy "$packet_json")"
+  directory_matched="$(jq -r '.directory.matched' <<<"$resolved_json")"
+  route_adapter="$(jq -r '.route.adapter // empty' <<<"$resolved_json")"
+  route_target="$(jq -r '.route.target // empty' <<<"$resolved_json")"
+  safe_target="$(relative_or_original_path "$REPO" "$route_target")"
+  ack_timeout="$(jq -r '.policy.ackTimeoutSeconds' <<<"$resolved_json")"
+  max_retries="$(jq -r '.policy.maxRetries' <<<"$resolved_json")"
+  retry_backoff="$(jq -r '.policy.retryBackoffSeconds' <<<"$resolved_json")"
+
+  blocked_reason=""
+
+  if [[ "$DIRECTORY_MODE" == "required" && "$DIRECTORY_ENABLED" == "1" && "$directory_matched" != "true" ]]; then
+    blocked_reason="directory_contact_not_found"
+  fi
+
+  if [[ -z "$blocked_reason" ]]; then
+    case "$route_adapter" in
+      filesystem_outbox|stdout)
+        ;;
+      *)
+        blocked_reason="dispatch_adapter_invalid"
+        ;;
+    esac
+  fi
+
+  if [[ -z "$blocked_reason" && "$route_adapter" == "filesystem_outbox" && -z "$route_target" ]]; then
+    blocked_reason="dispatch_target_missing"
+  fi
+
+  updated_epoch="$(jq -nr --arg ts "$updated_at" 'try ($ts | fromdateiso8601) catch ""')"
+  if [[ -z "$blocked_reason" && -z "$updated_epoch" ]]; then
+    blocked_reason="packet_updated_at_invalid"
+  fi
+
+  retry_count="$(jq -r --arg packet_id "$packet_id" '.packets[$packet_id].retryCount // 0' <<<"$RETRY_STATE_JSON")"
+  last_retry_at="$(jq -r --arg packet_id "$packet_id" '.packets[$packet_id].lastRetryAt // empty' <<<"$RETRY_STATE_JSON")"
+
+  if [[ -n "$blocked_reason" ]]; then
+    blocked_count=$((blocked_count + 1))
+    result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "blocked" \
+      --arg reason "$blocked_reason" \
+      --arg adapter "$route_adapter" \
+      --arg target "$safe_target" \
+      --arg updated_at "$updated_at" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reason: $reason,
+        adapter: (if ($adapter|length)>0 then $adapter else null end),
+        target: (if ($target|length)>0 then $target else null end),
+        updatedAt: (if ($updated_at|length)>0 then $updated_at else null end)
+      }
+    ')")
+    continue
+  fi
+
+  age_seconds=$((NOW_EPOCH - updated_epoch))
+
+  if (( age_seconds < ack_timeout )); then
+    result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "waiting" \
+      --arg reason "ack_timeout_not_reached" \
+      --argjson age "$age_seconds" \
+      --argjson timeout "$ack_timeout" \
+      --argjson retries "$retry_count" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reason: $reason,
+        ageSeconds: $age,
+        ackTimeoutSeconds: $timeout,
+        retryCount: $retries
+      }
+    ')")
+    continue
+  fi
+
+  retry_due_count=$((retry_due_count + 1))
+
+  if (( retry_count >= max_retries )); then
+    if [[ "$DRY_RUN" != "1" ]]; then
+      transition_cmd=("$HORIZON_PACKET_SCRIPT" transition
+        --repo "$REPO"
+        --state-dir "$STATE_DIR"
+        --packet-id "$packet_id"
+        --to-status escalated
+        --by "$ACTOR"
+        --reason "ack_timeout_max_retries_exceeded"
+        --note "retry budget exhausted")
+      if [[ ${#EVIDENCE_REFS[@]} -gt 0 ]]; then
+        for ref in "${EVIDENCE_REFS[@]}"; do
+          transition_cmd+=(--evidence-ref "$ref")
+        done
+      fi
+
+      if ! transition_error="$("${transition_cmd[@]}" 2>&1)"; then
+        error_count=$((error_count + 1))
+        result_lines+=("$(jq -cn \
+          --arg packet_id "$packet_id" \
+          --arg status "error" \
+          --arg reason "escalation_transition_failed" \
+          --arg error "$transition_error" '
+          {
+            packetId: $packet_id,
+            status: $status,
+            reason: $reason,
+            error: $error
+          }
+        ')")
+        continue
+      fi
+
+      RETRY_STATE_JSON="$(jq -c --arg packet_id "$packet_id" --arg at "$RUN_AT" '
+        .packets |= (if type == "object" then . else {} end)
+        | del(.packets[$packet_id])
+        | .updatedAt = $at
+      ' <<<"$RETRY_STATE_JSON")"
+    fi
+
+    escalated_count=$((escalated_count + 1))
+
+    dead_letter_lines+=("$(jq -cn \
+      --arg schema_version "v1" \
+      --arg timestamp "$RUN_AT" \
+      --arg category "horizon_dead_letter" \
+      --arg trace_id "$TRACE_ID" \
+      --arg packet_id "$packet_id" \
+      --arg horizon_ref "$(jq -r '.horizonRef // empty' <<<"$packet_json")" \
+      --arg packet_trace_id "$packet_trace_id" \
+      --arg actor "$ACTOR" \
+      --arg reason "ack_timeout_max_retries_exceeded" \
+      --argjson retries "$retry_count" \
+      --argjson max_retries "$max_retries" \
+      --argjson age "$age_seconds" '
+      {
+        schemaVersion: $schema_version,
+        timestamp: $timestamp,
+        category: $category,
+        traceId: $trace_id,
+        packetId: $packet_id,
+        horizonRef: (if ($horizon_ref|length)>0 then $horizon_ref else null end),
+        packetTraceId: (if ($packet_trace_id|length)>0 then $packet_trace_id else null end),
+        actor: $actor,
+        reason: $reason,
+        retryCount: $retries,
+        maxRetries: $max_retries,
+        ageSeconds: $age
+      }
+    ')")
+
+    result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "escalated" \
+      --arg reason "ack_timeout_max_retries_exceeded" \
+      --argjson retries "$retry_count" \
+      --argjson max_retries "$max_retries" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reason: $reason,
+        retryCount: $retries,
+        maxRetries: $max_retries
+      }
+    ')")
+    continue
+  fi
+
+  if [[ -n "$last_retry_at" ]]; then
+    last_retry_epoch="$(jq -nr --arg ts "$last_retry_at" 'try ($ts | fromdateiso8601) catch ""')"
+    if [[ -n "$last_retry_epoch" ]]; then
+      elapsed_since_retry=$((NOW_EPOCH - last_retry_epoch))
+      if (( elapsed_since_retry < retry_backoff )); then
+        blocked_count=$((blocked_count + 1))
+        result_lines+=("$(jq -cn \
+          --arg packet_id "$packet_id" \
+          --arg status "blocked" \
+          --arg reason "retry_backoff_active" \
+          --argjson elapsed "$elapsed_since_retry" \
+          --argjson backoff "$retry_backoff" '
+          {
+            packetId: $packet_id,
+            status: $status,
+            reason: $reason,
+            elapsedSinceRetrySeconds: $elapsed,
+            retryBackoffSeconds: $backoff
+          }
+        ')")
+        continue
+      fi
+    fi
+  fi
+
+  next_retry=$((retry_count + 1))
+  envelope_json="$(build_retry_envelope "$packet_json" "$route_adapter" "$safe_target" "$next_retry")"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    retried_count=$((retried_count + 1))
+    result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "dry_run_retry" \
+      --arg adapter "$route_adapter" \
+      --arg target "$safe_target" \
+      --argjson attempt "$next_retry" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        adapter: $adapter,
+        target: (if ($target|length)>0 then $target else null end),
+        retryAttempt: $attempt
+      }
+    ')")
+    continue
+  fi
+
+  write_ok=1
+  write_error=""
+  case "$route_adapter" in
+    filesystem_outbox)
+      if ! mkdir -p "$(dirname "$route_target")" || ! printf '%s\n' "$envelope_json" >> "$route_target"; then
+        write_ok=0
+        write_error="failed to append retry envelope: $safe_target"
+      fi
+      ;;
+    stdout)
+      :
+      ;;
+    *)
+      write_ok=0
+      write_error="unsupported adapter: $route_adapter"
+      ;;
+  esac
+
+  if [[ "$write_ok" == "0" ]]; then
+    error_count=$((error_count + 1))
+
+    "$HORIZON_PACKET_SCRIPT" transition \
+      --repo "$REPO" \
+      --state-dir "$STATE_DIR" \
+      --packet-id "$packet_id" \
+      --to-status failed \
+      --by "$ACTOR" \
+      --reason "adapter_write_failed" \
+      --note "$write_error" >/dev/null 2>&1 || true
+
+    result_lines+=("$(jq -cn \
+      --arg packet_id "$packet_id" \
+      --arg status "error" \
+      --arg reason "adapter_write_failed" \
+      --arg error "$write_error" '
+      {
+        packetId: $packet_id,
+        status: $status,
+        reason: $reason,
+        error: $error
+      }
+    ')")
+    continue
+  fi
+
+  retried_count=$((retried_count + 1))
+
+  RETRY_STATE_JSON="$(jq -c \
+    --arg packet_id "$packet_id" \
+    --arg at "$RUN_AT" \
+    --argjson retry_count "$next_retry" '
+    .packets |= (if type == "object" then . else {} end)
+    | .packets[$packet_id] = {
+        retryCount: $retry_count,
+        lastRetryAt: $at
+      }
+    | .updatedAt = $at
+  ' <<<"$RETRY_STATE_JSON")"
+
+  result_lines+=("$(jq -cn \
+    --arg packet_id "$packet_id" \
+    --arg status "retried" \
+    --arg adapter "$route_adapter" \
+    --arg target "$safe_target" \
+    --argjson attempt "$next_retry" '
+    {
+      packetId: $packet_id,
+      status: $status,
+      adapter: $adapter,
+      target: (if ($target|length)>0 then $target else null end),
+      retryAttempt: $attempt
+    }
+  ')")
+
+done
+
+if [[ ${#result_lines[@]} -eq 0 ]]; then
+  results_json='[]'
+else
+  results_json="$(printf '%s\n' "${result_lines[@]}" | jq -s '.')"
+fi
+
+result_json="$(jq -cn \
+  --arg schema_version "v1" \
+  --arg timestamp "$RUN_AT" \
+  --arg category "horizon_retry_reconcile" \
+  --arg trace_id "$TRACE_ID" \
+  --arg actor "$ACTOR" \
+  --arg reason "$REASON" \
+  --argjson dry_run "$( [[ "$DRY_RUN" == "1" ]] && echo true || echo false )" \
+  --arg directory_mode "$DIRECTORY_MODE" \
+  --arg directory_file "$DIRECTORY_FILE" \
+  --argjson directory_enabled "$( [[ "$DIRECTORY_ENABLED" == "1" ]] && echo true || echo false )" \
+  --arg state_file "$RETRY_STATE_FILE" \
+  --arg telemetry_file "$RETRY_TELEMETRY_FILE" \
+  --arg dead_letter_file "$DEAD_LETTER_FILE" \
+  --argjson considered "$considered_count" \
+  --argjson due "$retry_due_count" \
+  --argjson retried "$retried_count" \
+  --argjson escalated "$escalated_count" \
+  --argjson blocked "$blocked_count" \
+  --argjson errors "$error_count" \
+  --argjson results "$results_json" '
+  {
+    schemaVersion: $schema_version,
+    timestamp: $timestamp,
+    category: $category,
+    traceId: $trace_id,
+    actor: $actor,
+    reason: $reason,
+    dryRun: $dry_run,
+    directory: {
+      mode: $directory_mode,
+      enabled: $directory_enabled,
+      file: (if $directory_enabled then $directory_file else null end)
+    },
+    artifacts: {
+      retryStateFile: $state_file,
+      retryTelemetryFile: $telemetry_file,
+      deadLetterFile: $dead_letter_file
+    },
+    summary: {
+      consideredCount: $considered,
+      dueCount: $due,
+      retriedCount: $retried,
+      escalatedCount: $escalated,
+      blockedCount: $blocked,
+      errorCount: $errors
+    },
+    results: $results
+  }
+')"
+
+if [[ "$DRY_RUN" != "1" ]]; then
+  mkdir -p "$(dirname "$RETRY_STATE_FILE")"
+  jq -c '.' <<<"$RETRY_STATE_JSON" > "$RETRY_STATE_FILE"
+
+  append_jsonl "$RETRY_TELEMETRY_FILE" "$result_json"
+
+  if [[ ${#dead_letter_lines[@]} -gt 0 ]]; then
+    mkdir -p "$(dirname "$DEAD_LETTER_FILE")"
+    printf '%s\n' "${dead_letter_lines[@]}" | jq -c '.' >> "$DEAD_LETTER_FILE"
+  fi
+fi
+
+emit_json "$result_json" "$PRETTY"
+
+if [[ "$error_count" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/validate-horizon-directory.sh
+++ b/scripts/validate-horizon-directory.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/validate-horizon-directory.sh [--repo DIR] [--file PATH] [--schema PATH] [--strict]
+
+Options:
+  --repo DIR      Repository root (default: .)
+  --file PATH     Directory file path (default: .superloop/horizon-directory.json)
+  --schema PATH   Schema path (default: schema/horizon-directory.schema.json)
+  --strict        Run full JSON Schema validation via python jsonschema module
+  -h, --help      Show this help
+
+Notes:
+  - Non-strict mode uses Superloop's built-in schema validator plus additional
+    jq checks for recipient uniqueness and policy invariants.
+  - Strict mode requires python3/python with the `jsonschema` module installed.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+repo="."
+directory_path=".superloop/horizon-directory.json"
+schema_path="schema/horizon-directory.schema.json"
+strict="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --file)
+      [[ $# -ge 2 ]] || die "--file requires a value"
+      directory_path="$2"
+      shift 2
+      ;;
+    --schema)
+      [[ $# -ge 2 ]] || die "--schema requires a value"
+      schema_path="$2"
+      shift 2
+      ;;
+    --strict)
+      strict="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd jq
+
+repo=$(cd "$repo" && pwd)
+[[ -x "$repo/superloop.sh" ]] || die "missing executable: $repo/superloop.sh"
+
+if [[ "$directory_path" != /* ]]; then
+  directory_path="$repo/$directory_path"
+fi
+if [[ "$schema_path" != /* ]]; then
+  schema_path="$repo/$schema_path"
+fi
+
+[[ -f "$directory_path" ]] || die "directory file not found: $directory_path"
+[[ -f "$schema_path" ]] || die "schema file not found: $schema_path"
+
+jq -e '.' "$directory_path" >/dev/null
+"$repo/superloop.sh" validate --repo "$repo" --config "$directory_path" --schema "$schema_path" >/dev/null
+
+jq -e '
+  .version == 1 and
+  (.contacts | type == "array" and length > 0) and
+  ([.contacts[] | .recipient.type + "|" + .recipient.id] | length == (unique | length)) and
+  ([.contacts[].dispatch.adapter] | all(. == "filesystem_outbox" or . == "stdout")) and
+  ([.contacts[] | .dispatch.target? | select(. != null)] | all(type == "string" and length > 0)) and
+  ([.contacts[] | .ack.timeout_seconds? | select(. != null)] | all(type == "number" and . >= 0 and . == floor)) and
+  ([.contacts[] | .ack.max_retries? | select(. != null)] | all(type == "number" and . >= 0 and . == floor)) and
+  ([.contacts[] | .ack.retry_backoff_seconds? | select(. != null)] | all(type == "number" and . >= 0 and . == floor))
+' "$directory_path" >/dev/null
+
+if [[ "$strict" == "1" ]]; then
+  py_bin=""
+  if command -v python3 >/dev/null 2>&1; then
+    py_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    py_bin="python"
+  else
+    die "strict mode requires python3/python with jsonschema module"
+  fi
+
+  "$py_bin" - "$schema_path" "$directory_path" <<'PY'
+import json
+import sys
+
+schema_path = sys.argv[1]
+directory_path = sys.argv[2]
+
+try:
+    import jsonschema  # type: ignore
+except Exception as exc:
+    sys.stderr.write(f"error: strict mode requires python jsonschema module ({exc.__class__.__name__})\n")
+    sys.exit(1)
+
+with open(schema_path, "r", encoding="utf-8") as f:
+    schema = json.load(f)
+with open(directory_path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+jsonschema.validate(instance=data, schema=schema)
+PY
+fi
+
+echo "ok: horizon directory file is valid"

--- a/tests/horizon-ack.bats
+++ b/tests/horizon-ack.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  REPO_DIR="$TEMP_DIR/repo"
+  mkdir -p "$REPO_DIR/.superloop/horizons"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+create_dispatched_packet() {
+  local packet_id="$1"
+  local recipient_type="$2"
+  local recipient_id="$3"
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id "$packet_id" \
+    --horizon-ref HZ-ack \
+    --sender planner \
+    --recipient-type "$recipient_type" \
+    --recipient-id "$recipient_id" \
+    --intent "ack test"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch \
+    --repo "$REPO_DIR" \
+    --actor dispatcher \
+    --reason "initial dispatch"
+  [ "$status" -eq 0 ]
+}
+
+@test "horizon ack ingest transitions dispatched packet to acknowledged and dedupes" {
+  create_dispatched_packet pkt-ack-001 local_agent worker-ack
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-ack-001
+  [ "$status" -eq 0 ]
+  local packet_trace_id
+  packet_trace_id="$(jq -r '.traceId' <<<"$output")"
+
+  local receipt_file="$TEMP_DIR/receipts.jsonl"
+  jq -cn \
+    --arg packet_id "pkt-ack-001" \
+    --arg trace_id "$packet_trace_id" \
+    '{schemaVersion:"v1",packetId:$packet_id,traceId:$trace_id,status:"acknowledged",by:"delivery-gateway",reason:"delivered"}' > "$receipt_file"
+
+  run "$PROJECT_ROOT/scripts/horizon-ack.sh" ingest --repo "$REPO_DIR" --file "$receipt_file"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-ack-001
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "acknowledged" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-ack.sh" ingest --repo "$REPO_DIR" --file "$receipt_file"
+  [ "$status" -eq 0 ]
+  run jq -r '.summary.duplicateCount' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run jq -r '.processedKeys | length' "$REPO_DIR/.superloop/horizons/ack-state.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "horizon ack ingest rejects missing required fields" {
+  create_dispatched_packet pkt-ack-002 local_agent worker-ack-2
+
+  local receipt_file="$TEMP_DIR/receipts-invalid.jsonl"
+  jq -cn '{schemaVersion:"v1",packetId:"pkt-ack-002",status:"acknowledged"}' > "$receipt_file"
+
+  run "$PROJECT_ROOT/scripts/horizon-ack.sh" ingest --repo "$REPO_DIR" --file "$receipt_file"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.summary.rejectedCount' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-ack-002
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+}

--- a/tests/horizon-directory.bats
+++ b/tests/horizon-directory.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+@test "validate horizon directory accepts valid contract" {
+  local directory_file="$TEMP_DIR/horizon-directory.json"
+  cat > "$directory_file" <<'JSON'
+{
+  "version": 1,
+  "contacts": [
+    {
+      "recipient": {"type": "local_agent", "id": "implementer"},
+      "dispatch": {"adapter": "filesystem_outbox", "target": "local_agent/implementer.jsonl"},
+      "ack": {"timeout_seconds": 300, "max_retries": 2, "retry_backoff_seconds": 60}
+    },
+    {
+      "recipient": {"type": "human", "id": "alice"},
+      "dispatch": {"adapter": "stdout"}
+    }
+  ]
+}
+JSON
+
+  run "$PROJECT_ROOT/scripts/validate-horizon-directory.sh" --repo "$PROJECT_ROOT" --file "$directory_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok: horizon directory file is valid"* ]]
+}
+
+@test "validate horizon directory fails on duplicate recipients" {
+  local directory_file="$TEMP_DIR/horizon-directory-invalid.json"
+  cat > "$directory_file" <<'JSON'
+{
+  "version": 1,
+  "contacts": [
+    {
+      "recipient": {"type": "local_agent", "id": "implementer"},
+      "dispatch": {"adapter": "filesystem_outbox", "target": "local_agent/implementer.jsonl"}
+    },
+    {
+      "recipient": {"type": "local_agent", "id": "implementer"},
+      "dispatch": {"adapter": "stdout"}
+    }
+  ]
+}
+JSON
+
+  run "$PROJECT_ROOT/scripts/validate-horizon-directory.sh" --repo "$PROJECT_ROOT" --file "$directory_file"
+  [ "$status" -ne 0 ]
+}

--- a/tests/horizon-retry.bats
+++ b/tests/horizon-retry.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  PROJECT_ROOT="$(dirname "$TEST_DIR")"
+  TEMP_DIR="$(mktemp -d)"
+  REPO_DIR="$TEMP_DIR/repo"
+  mkdir -p "$REPO_DIR/.superloop/horizons"
+}
+
+teardown() {
+  rm -rf "$TEMP_DIR"
+}
+
+create_dispatched_packet() {
+  local packet_id="$1"
+  local recipient_type="$2"
+  local recipient_id="$3"
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" create \
+    --repo "$REPO_DIR" \
+    --packet-id "$packet_id" \
+    --horizon-ref HZ-retry \
+    --sender planner \
+    --recipient-type "$recipient_type" \
+    --recipient-id "$recipient_id" \
+    --intent "retry test"
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-orchestrate.sh" dispatch \
+    --repo "$REPO_DIR" \
+    --actor dispatcher \
+    --reason "initial dispatch"
+  [ "$status" -eq 0 ]
+}
+
+mark_packet_stale() {
+  local packet_id="$1"
+  local packet_file="$REPO_DIR/.superloop/horizons/packets/$packet_id.json"
+  run bash -lc "jq -c '.updatedAt=\"2020-01-01T00:00:00Z\"' '$packet_file' > '$packet_file.tmp' && mv '$packet_file.tmp' '$packet_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "horizon retry reconcile redispatches timed-out packet and updates retry state" {
+  create_dispatched_packet pkt-retry-001 local_agent worker-retry
+  mark_packet_stale pkt-retry-001
+
+  run "$PROJECT_ROOT/scripts/horizon-retry.sh" reconcile \
+    --repo "$REPO_DIR" \
+    --ack-timeout-seconds 1 \
+    --max-retries 2 \
+    --retry-backoff-seconds 0
+  [ "$status" -eq 0 ]
+
+  run jq -r '.summary.retriedCount' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  local outbox_file="$REPO_DIR/.superloop/horizons/outbox/local_agent/worker-retry.jsonl"
+  run bash -lc "wc -l < '$outbox_file'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run jq -r '.packets["pkt-retry-001"].retryCount' "$REPO_DIR/.superloop/horizons/retry-state.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-retry-001
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+}
+
+@test "horizon retry reconcile escalates to dead letter after retry budget exhausted" {
+  create_dispatched_packet pkt-retry-002 local_agent worker-retry-2
+  mark_packet_stale pkt-retry-002
+
+  run "$PROJECT_ROOT/scripts/horizon-retry.sh" reconcile \
+    --repo "$REPO_DIR" \
+    --ack-timeout-seconds 1 \
+    --max-retries 1 \
+    --retry-backoff-seconds 0
+  [ "$status" -eq 0 ]
+
+  run "$PROJECT_ROOT/scripts/horizon-retry.sh" reconcile \
+    --repo "$REPO_DIR" \
+    --ack-timeout-seconds 1 \
+    --max-retries 1 \
+    --retry-backoff-seconds 0
+  [ "$status" -eq 0 ]
+
+  run jq -r '.summary.escalatedCount' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+
+  run "$PROJECT_ROOT/scripts/horizon-packet.sh" show --repo "$REPO_DIR" --packet-id pkt-retry-002
+  [ "$status" -eq 0 ]
+  run jq -r '.status' <<<"$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "escalated" ]
+
+  local dead_letter_file="$REPO_DIR/.superloop/horizons/telemetry/dead-letter.jsonl"
+  [ -f "$dead_letter_file" ]
+
+  run jq -r '.packetId' "$dead_letter_file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkt-retry-002" ]
+}


### PR DESCRIPTION
## Context
This is Horizon Phase 3, continuing the Horizon lane without crossing into Ops Manager bridge internals.

Boundary respected:
- Horizon-only runtime/contracts/tests/docs
- no Ops Manager bridge ingestion logic
- shared envelope contract remains additive and stable

## Scope Delivered

### 1) Directory primitive
- Added optional directory contract schema:
  - `schema/horizon-directory.schema.json`
- Added example directory:
  - `docs/examples/horizon-directory.example.json`
- Added validator:
  - `scripts/validate-horizon-directory.sh`

Directory supports contact-level overrides for:
- dispatch adapter/target
- ack timeout
- max retries
- retry backoff

### 2) Orchestrator directory integration
Updated `scripts/horizon-orchestrate.sh`:
- new options:
  - `--directory-file`
  - `--directory-mode off|optional|required`
- behavior:
  - optional mode: directory overrides when present, fallback routing otherwise
  - required mode: fail-closed on unknown recipients (`directory_contact_not_found`)
- plan items now include:
  - `ackPolicy`
  - `directory` metadata

### 3) Delivery confirmation primitive
Added `scripts/horizon-ack.sh`:
- ingests JSONL delivery receipts
- required receipt fields: `schemaVersion`, `packetId`, `traceId`, `status`
- idempotent dedupe via `receiptId` (or deterministic hash fallback)
- applies deterministic transitions via `horizon-packet.sh`
- updates artifacts:
  - `.superloop/horizons/ack-state.json`
  - `.superloop/horizons/telemetry/ack.jsonl`
- removes acknowledged packets from retry-state tracking

### 4) Retry/dead-letter primitive
Added `scripts/horizon-retry.sh` (`reconcile`):
- scans `dispatched` packets
- evaluates timeout/backoff/retry budget
- retries dispatch when eligible (`horizon_dispatch_retry` envelope)
- escalates exhausted packets and appends dead-letter records
- updates artifacts:
  - `.superloop/horizons/retry-state.json`
  - `.superloop/horizons/telemetry/retry.jsonl`
  - `.superloop/horizons/telemetry/dead-letter.jsonl`

### 5) Phase packet + docs sync
- Added Phase 3 packet:
  - `feat/horizon-control-plane/phase-3-directory-ack-retry/PLAN.MD`
  - `feat/horizon-control-plane/phase-3-directory-ack-retry/tasks/PHASE_1.MD`
- Updated docs:
  - `docs/horizon-planning.md`
  - `README.md`

## Validation
Executed on this branch:

```bash
bash -n scripts/horizon-orchestrate.sh scripts/horizon-ack.sh scripts/horizon-retry.sh scripts/validate-horizon-directory.sh
/usr/bin/bats tests/horizon-packet.bats tests/horizon-orchestrate.bats tests/horizon-directory.bats tests/horizon-ack.bats tests/horizon-retry.bats
```

Result:
- syntax checks pass
- BATS: `19/19` passing

## Files
- `scripts/horizon-orchestrate.sh`
- `scripts/horizon-ack.sh` (new)
- `scripts/horizon-retry.sh` (new)
- `scripts/validate-horizon-directory.sh` (new)
- `schema/horizon-directory.schema.json` (new)
- `docs/examples/horizon-directory.example.json` (new)
- `tests/horizon-orchestrate.bats`
- `tests/horizon-directory.bats` (new)
- `tests/horizon-ack.bats` (new)
- `tests/horizon-retry.bats` (new)
- `docs/horizon-planning.md`
- `README.md`
- `feat/horizon-control-plane/phase-3-directory-ack-retry/PLAN.MD` (new)
- `feat/horizon-control-plane/phase-3-directory-ack-retry/tasks/PHASE_1.MD` (new)
